### PR TITLE
Use always https for font import

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,7 @@
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="author" content="SemiColonWeb" />
 
-	<link href="http://fonts.googleapis.com/css?family=Roboto:300,400,400i,700|Istok+Web:400,700" rel="stylesheet" type="text/css" />
+	<link href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700|Istok+Web:400,700" rel="stylesheet" type="text/css" />
 	<link rel="stylesheet" href="/css/bootstrap.css" type="text/css" />
 	<link rel="stylesheet" href="/style.css" type="text/css" />
 	<link rel="stylesheet" href="/css/dark.css" type="text/css" />


### PR DESCRIPTION
Accessing to kiali.io in https triggers an error of insecure request because of the font import.
Changing this import to https makes kiali works for both http and https since it is not a problem (the opposite) to make request to https from a non-secure webpages.