### PR TITLE
fix the known issues link found on the documentation page

### DIFF
--- a/content/documentation/known_issues/index.adoc
+++ b/content/documentation/known_issues/index.adoc
@@ -1,5 +1,5 @@
 ---
-title: "Known Issues"
+title: "Known_Issues"
 date: 2018-09-04T15:55:00+02:00
 draft: false
 type: "documentation"


### PR DESCRIPTION
the documentation page (https://www.kiali.io/documentation/) has a bad link to known issues (the URL has "known issues" - missing the underscore "known_issues").

This fixes it.

I do not know how to get the link text to show a space but the actual link to use underscore, so this fix shows underscore in the link text as well as in the URL.