### PR TITLE
KIALI-1574 Note which browsers are supported

### DIFF
--- a/content/documentation/known_issues/index.adoc
+++ b/content/documentation/known_issues/index.adoc
@@ -1,5 +1,5 @@
 ---
-title: "Known_Issues"
+title: "Known Issues"
 date: 2018-09-04T15:55:00+02:00
 draft: false
 type: "documentation"
@@ -21,6 +21,12 @@ If you are hitting a limitation, regardless if it's listed here or not, do not h
 The whole list of JIRA tickets can be found https://issues.jboss.org/projects/KIALI/issues/[here].
 
 icon:lightbulb[size=2x] {nbsp}{nbsp}{nbsp}{nbsp} In general, we use the GitHub tracker for issues raised by the community, and JIRA for issues raised by the core engineering team. Both are publicly accessible.
+
+== Accessing Kiali with Internet Explorer
+
+No version of Internet Explorer is supported with Kiali. Users may experience some https://github.com/kiali/kiali/issues/507[issues] when using Kiali through this browser.
+
+In order to have the best experience with Kiali you will need to update to use a link:../prerequisites/#_browser_requirements[supported browser].
 
 == Non Deployment-based workloads
 

--- a/content/documentation/prerequisites/index.adoc
+++ b/content/documentation/prerequisites/index.adoc
@@ -14,6 +14,12 @@ toc::[]
 :icons: font
 :imagesdir: /images/documentation/prerequisites/
 
+== Browser Requirements
+
+Kiali requires a modern web browser to be able to function properly.
+
+Users accessing Kiali should be doing so using the last two versions of Chrome, Edge, Firefox or Safari.
+
 == Software Requirements
 
 To run Kiali, you're going to need two things:


### PR DESCRIPTION
Adds a note about what browsers we support.

Our UI is using patternfly and this is where I am getting the recommended browser list from: https://www.patternfly.org/get-started/frequently-asked-questions/#support

It also adds a note into our 'known issues' section that IE11 is not supported and to see the docs for a list of supported browsers.