### PR TITLE
KIALI-1754 Updating installation examples to v0.9.0 version

### DIFF
--- a/content/gettingstarted/index.adoc
+++ b/content/gettingstarted/index.adoc
@@ -23,7 +23,7 @@ Kiali currently requires Istio version 1.0 (see below if you have not yet instal
 
 Kiali is still in development. Snapshots releases are pushed on Dockerhub from the CI pipeline.
 
-To deploy Kiali to your Istio-enabled OpenShift cluster you can run the following. Kiali currently requires Istio version 1.0.0 (see below if you have not yet installed Istio).
+To deploy Kiali to your Istio-enabled OpenShift cluster you can run the following. Kiali currently requires Istio version 1.0 (see below if you have not yet installed Istio).
 
 === Preparation
 
@@ -41,12 +41,12 @@ You can now install Istio if needed. See https://istio.io/docs/setup/ for detail
 
 === Install Kiali
 
-Then install Kiali (note: this assumes you are installing v0.7.2 - set your VERSION_LABEL to the appropriate version you want to install):
+Then install Kiali (note: this assumes you are installing v0.9.0 - set your VERSION_LABEL to the appropriate version you want to install):
 
 ```
 JAEGER_URL="http://jaeger-query-istio-system.127.0.0.1.nip.io"
 GRAFANA_URL="http://grafana-istio-system.127.0.0.1.nip.io"
-VERSION_LABEL="v0.7.2"
+VERSION_LABEL="v0.9.0"
 
 curl https://raw.githubusercontent.com/kiali/kiali/${VERSION_LABEL}/deploy/openshift/kiali-configmap.yaml | \
   VERSION_LABEL=${VERSION_LABEL} \
@@ -86,14 +86,14 @@ oc get route -n istio-system -l app=kiali
 
 Kiali currently requires Istio version 1.0 (see below if you have not yet installed Istio).
 
-To deploy Kiali to your Istio-enabled Kubernetes cluster you can run the following (note: this assumes you are installing v0.7.2 - set your VERSION_LABEL to the appropriate version you want to install):
+To deploy Kiali to your Istio-enabled Kubernetes cluster you can run the following (note: this assumes you are installing v0.9.0 - set your VERSION_LABEL to the appropriate version you want to install):
 
 icon:bullhorn[size=2x] {nbsp}{nbsp}{nbsp}{nbsp} If you wish to install in Minikube, ensure that you enable the Ingress add-on by executing `minikube addons enable ingress`.
 
 ```
 JAEGER_URL="http://jaeger-query-istio-system.127.0.0.1.nip.io"
 GRAFANA_URL="http://grafana-istio-system.127.0.0.1.nip.io"
-VERSION_LABEL="v0.7.2"
+VERSION_LABEL="v0.9.0"
 
 curl https://raw.githubusercontent.com/kiali/kiali/${VERSION_LABEL}/deploy/kubernetes/kiali-configmap.yaml | \
   VERSION_LABEL=${VERSION_LABEL} \


### PR DESCRIPTION
Preparing kiali.io for v0.9.0 release. I have updated version on the installation examples, just to be updated.

This PR also is meant to update the API documentation. I am waiting now for https://github.com/kiali/kiali/pull/569.