### PR TITLE
Simplify hugo install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,8 @@ HUGO_VERSION ?= 0.48
 
 install:
 	@echo Installing Hugo version ${HUGO_VERSION}
-	@mkdir -p ${GOPATH}/src/github.com/gohugoio/
-	@wget -qO- https://github.com/gohugoio/hugo/archive/v${HUGO_VERSION}.tar.gz | tar xvz -C ${GOPATH}/src/github.com/gohugoio/
-	@mv ${GOPATH}/src/github.com/gohugoio/hugo-${HUGO_VERSION} ${GOPATH}/src/github.com/gohugoio/hugo; cd ${GOPATH}/src/github.com/gohugoio/hugo; go build -o ${GOPATH}/bin/hugo
-	@export PATH=${PATH}:${GOPATH}/bin
+	@HUGO_VERSION=${HUGO_VERSION} sh scripts/get-hugo.sh
+	@export PATH="${PATH}:${GOPATH}/bin"
 	@echo Installing AsciiDoctor
 	@gem install bundler
 	@bundle install
@@ -23,5 +21,3 @@ deploy: build
 	aws s3 sync public/ s3://kiali.io --acl public-read --delete
 	aws configure set preview.cloudfront true
 	aws cloudfront create-invalidation --distribution-id E3RFW0PBPFCVRO --paths '/*'
-
-

--- a/README.adoc
+++ b/README.adoc
@@ -32,6 +32,19 @@ export PATH=${PATH}:${GOPATH}/bin
 make install
 ----
 
+This will attempt to determine the binary of Hugo needed and download it. If it can't it will proceed to download the source code and compile.
+You can force the compile by setting `BUILD_HUGO=TRUE`
+
+[source, bash]
+----
+BUILD_HUGO=TRUE make install
+----
+
+You can always download the required dependencies yourself if the above fails:
+
+ - Hugo at least v0.48 ([github releases](https://github.com/gohugoio/hugo/releases/tag/v0.48) or brew if you are on mac)
+ - AsciiDoctor (by running `bundle install`)
+
 ==  Start local server
 
 Hugo has a live `serve` command that runs a small, lightweight web server on your computer so you can test your site locally without needing to upload it anywhere.  As you make changes to files in your project, it will rebuild your project and reload the browser for you.

--- a/scripts/get-hugo.sh
+++ b/scripts/get-hugo.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+function arq {
+    if [ `uname -m` == 'x86_64' ]; then
+      echo "64"
+    else
+      echo "32"
+    fi
+}
+
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     PLATFORM=Linux-`arq`;;
+    Darwin*)    PLATFORM=macOS-`arq`;;
+    CYGWIN*)    PLATFORM=Windows-`arq`;;
+    MINGW*)     PLATFORM=Windows-`arq`;;
+    *)          PLATFORM="UNKNOWN"
+esac
+
+if [ "${PLATFORM}" == 'UNKNOWN' ] || [ "${BUILD_HUGO}" == 'TRUE' ]; then
+  echo "Downloading hugo source code and compiling"
+  mkdir -p ${GOPATH}/src/github.com/gohugoio/
+  wget -qO- https://github.com/gohugoio/hugo/archive/v${HUGO_VERSION}.tar.gz | tar xvz -C ${GOPATH}/src/github.com/gohugoio/
+  mv ${GOPATH}/src/github.com/gohugoio/hugo-${HUGO_VERSION} ${GOPATH}/src/github.com/gohugoio/hugo; cd ${GOPATH}/src/github.com/gohugoio/hugo; go build -o ${GOPATH}/bin/hugo
+else
+  echo "Downloading hugo binary from https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_${PLATFORM}bit.tar.gz"
+  mkdir -p ${GOPATH}/bin
+  wget -qO- https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_${PLATFORM}bit.tar.gz | tar xvz -C ${GOPATH}/bin hugo
+fi


### PR DESCRIPTION
  Instead of downloading the code and compiling, download the binary
  and put it on ${GOPATH}/bin

I did this because I was getting dependencies error when trying to build that specific hugo version, probably related to my env, but this seems safer.