### PR TITLE
Update menu-content height

### DIFF
--- a/scripts/template.hbs
+++ b/scripts/template.hbs
@@ -6,6 +6,7 @@ type = "api"
 <style>
     .menu-content {
         top: 60px !important;
+        height: calc(100vh - 60px);
     }
 </style>
 


### PR DESCRIPTION
Take into account the top offset introduced

I just noticed this, when the screen becomes small (or the menu bigger due the number of elements) 60px of the bottom will hide and we won't be able to see them because of the offset introduced.

Without fix:
![without](https://user-images.githubusercontent.com/3845764/47182277-a491d100-d2ea-11e8-9f82-c45fa7b1893a.png)

With fix:
![with](https://user-images.githubusercontent.com/3845764/47182275-a491d100-d2ea-11e8-9efc-e615a3e10462.png)