### PR TITLE
KIALI-1965 Use a docker image to start Hugo instead of building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,17 @@
 
 HUGO_VERSION ?= 0.48
+# The port and ip that the Hugo server will bind to
+BOUND_IP ?= 127.0.0.1
+PORT ?= 1313
 
 install:
-	@echo Installing Hugo version ${HUGO_VERSION}
-	@mkdir -p ${GOPATH}/src/github.com/gohugoio/
-	@wget -qO- https://github.com/gohugoio/hugo/archive/v${HUGO_VERSION}.tar.gz | tar xvz -C ${GOPATH}/src/github.com/gohugoio/
-	@mv ${GOPATH}/src/github.com/gohugoio/hugo-${HUGO_VERSION} ${GOPATH}/src/github.com/gohugoio/hugo; cd ${GOPATH}/src/github.com/gohugoio/hugo; go build -o ${GOPATH}/bin/hugo
-	@export PATH=${PATH}:${GOPATH}/bin
 	@echo Installing AsciiDoctor
 	@gem install bundler
 	@bundle install
 
 serve:
-	@hugo serve
+	@echo Starting the Hugo Docker image
+	@docker run --rm --name kialiio -v `pwd`:/src -p ${BOUND_IP}:${PORT}:1313 cibuilds/hugo:${HUGO_VERSION} hugo serve -v -s src/ --bind 0.0.0.0
 
 build:
 	rm -rf public
@@ -23,5 +22,3 @@ deploy: build
 	aws s3 sync public/ s3://kiali.io --acl public-read --delete
 	aws configure set preview.cloudfront true
 	aws cloudfront create-invalidation --distribution-id E3RFW0PBPFCVRO --paths '/*'
-
-

--- a/README.adoc
+++ b/README.adoc
@@ -9,23 +9,11 @@ The website is written in link:https://asciidoctor.org/docs/asciidoc-syntax-quic
 
 == Requirements
 
-- You need Go & Bundler (Ruby)
+- You need Docker & Gem (Ruby)
 
-== Building
+== Install Requirements
 
-- Clone this repository inside a GOPATH.  These instructions will use the example GOPATH of "/source/kiali/kiali" but you can use whatever you want. Just change the first line of the below instructions to use your GOPATH.
-
-[source, bash]
-----
-export GOPATH=/source/kiali/kiali
-mkdir -p $GOPATH
-cd $GOPATH
-mkdir -p src/github.com/kiali/kiali.io
-git clone git@github.com:kiali/kiali.io
-export PATH=${PATH}:${GOPATH}/bin
-----
-
-- Install Requirements
+Kiali.io needs Asciidoctor installed before it can be served. The following command will install Asciidoctor using Gem and Bundler:
 
 [source, bash]
 ----
@@ -40,6 +28,8 @@ Hugo has a live `serve` command that runs a small, lightweight web server on you
 ----
 make serve
 ----
+
+If everything is working as expected you should see something like the following being outputted:
 
 ```
                    | EN
@@ -61,7 +51,11 @@ Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
 Press Ctrl+C to stop
 ```
 
-It should live reload. If not, you may have to restart the server.
+You should now be able to access hugo running kiali.io at link:http://localhost:1313/[http://localhost:1313]
+
+This running instance should support live reload. Changes you make to files should be automatically updated in your running instance.
+
+Some files may not be supportted for live reload. If you are not automatically seeing your changes live you may need to restart the server. You can restart the server by pressing 'ctrl-c' and running `make serve` again.
 
 ==  Project directory structure
 


### PR DESCRIPTION
This will use a Hugo docker image to run Hugo instead of having us download and build a version of Hugo.

This simplifies the build process a lot and makes it easier to get things up and running.

Other than requiring docker to be installed, this should behave the same as before.