### PR TITLE
KIALI-2178 Submenu documentation is white when we hide the header

### DIFF
--- a/static/css/kiali_style.css
+++ b/static/css/kiali_style.css
@@ -39,6 +39,10 @@ h2 {
   color: #FFFFFF;
 }
 
+#primary-menu ul ul li > a {
+  color: black;
+}
+
 #content .features-bottom-box li > a {
   font-size: 16px;
   font-weight: 500


### PR DESCRIPTION
### Before

![peek 2018-12-20 11-25](https://user-images.githubusercontent.com/3019213/50281644-78acdc00-0450-11e9-9526-1a9988ac270e.gif)


### After

![peek 2018-12-20 12-14](https://user-images.githubusercontent.com/3019213/50281784-da6d4600-0450-11e9-9716-be28dff536db.gif)

