### PR TITLE
KIALI-2142 Update styling on website drop down menu of Documentation section

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -57,7 +57,7 @@
 		</div>
 		<!-- Header
 ============================================= -->
-		<header id="header" class="full-header transparent-header dark" data-sticky-class="not-dark">
+		<header id="header" class="full-header transparent-header" data-sticky-class="not-dark">
 
 			<div id="header-wrap">
 

--- a/static/css/kiali_style.css
+++ b/static/css/kiali_style.css
@@ -207,7 +207,7 @@ h2 {
   color: #FFFFFF;
 }
 
-
+/*
 .dark #header-wrap:not(.not-dark) #primary-menu>ul>li>a {
   color: #fff !important
 }
@@ -215,7 +215,7 @@ h2 {
 .dark #header-wrap:not(.not-dark) #primary-menu>ul>li>ul>li>a {
   color: #fff !important
 }
-
+*/
 #primary-menu ul li>a {
   letter-spacing: 0
 }


### PR DESCRIPTION
Remove the dark class we keep the background style of the dropdown in white.
![peek 2019-01-08 12-38](https://user-images.githubusercontent.com/3019213/50828700-62ed5100-1342-11e9-9aac-e02a8576e392.gif)

I am worried about this. 

The javascript file [themes/canvas/static/js/functions.js](https://github.com/kiali/kiali.io/blob/master/themes/canvas/static/js/functions.js) of the canvas theme applied the style [dark.css](https://github.com/kiali/kiali.io/blob/master/themes/canvas/static/css/dark.css) when the user scroll down, this file make all the magic adding and removing classes. 

Right now we are overwriting the css rules in the [kiali_style.css](https://github.com/kiali/kiali.io/blob/master/static/css/kiali_style.css) file in some cases with **!important**

We are changing  practically the canvas theme and I think that we should create a new theme for Kiali (Jaeger website has their own theme) with the UX comments, It does not make sense to have huge files of the canvas theme if we are not using them and will be easier to maintain in the future.

What do you think @abonas ?
