### PR TITLE
More visibility to posts in Kiali website

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,7 @@ theme = "canvas"
       "/css/kiali_style.css",
       "https://use.fontawesome.com/releases/v5.3.1/css/all.css"
     ]
+    maxBlogPosts   = 10
 
 [menu]
   [[menu.main]]

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,87 +1,16 @@
-{{ partial "header.html" . }}
+{{ block "main" .   }}
+    {{- $maxBlogPosts := .Site.Params.maxBlogPosts }}
+    {{- $json         := getJSON "https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/kialiproject" }}
+    {{- $posts        := first $maxBlogPosts $json.items }}
 
-<section id="slider" class="slider-element bg-angle">
-  <div class="vertical-middle ignore-header dark">
-    <div class="container">
-      <div class="row justify-content-between align-items-center">
-        <div class="col-md-5">
-          <div class="slider-title">
-            <h1 class="text-rotater mb-3" data-separator="," data-rotate="fadeIn" data-speed="3500">
-              Service mesh observability and configuration
-            </h1>
-            <p><i>Kiali</i> is originated from the greek word κιάλι meaning <i>monocular</i> or <i>spyglass</i>.</p>
-            <p>
-              Kiali project provides answers to the questions:<br />What microservices are part of my Istio service
-              mesh? How are they connected? How are they performing?
-            </p>
-            <p>
-              <span
-                ><i
-                  ><a style="color:white" href="https://youtu.be/9CQ0PMiOGhg?t=371"
-                    >"This is the kind of tool that you really need"</a
-                  ></i
-                ></span
-              ><br /><span style="float:right">-- David Gageot, Google</span>
-            </p>
-          </div>
-          <a href="/documentation/getting-started" class="button"
-            >Get started <i class="icon-line-arrow-right t600"></i
-          ></a>
-        </div>
-        <div class="col_half topmargin-sm col_last" style="vertical-align: center">
-          <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-            <iframe
-              src="//www.youtube.com/embed/mbS0UReSWyY"
-              style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;"
-              allowfullscreen
-              title="Kiali Overview">
-            </iframe>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
 
-<section id="content">
-  <div class="content-wrap nopadding">
-    <div class="container clearfix">
-      <div class="features-bottom-box">
-        <div id="features-list">
-          <div id="features-title">
-            <h2>Features</h2>
-            <p>A growing set of features</p>
-          </div>
-          <div id="graph-feature" class="imgContainer" onclick="location.href='/documentation/features/#_graph'">
-            <img src="images/documentation/features/graph.svg" />
-            <p>Topology</p>
-          </div>
-          <div
-            id="health-feature"
-            class="imgContainer"
-            onclick="location.href='/documentation/features/#_graph_health'"
-          >
-            <img src="images/documentation/features/services.svg" />
-            <p>Health <br />computation</p>
-          </div>
-          <div class="imgContainer" onclick="location.href='/documentation/features/#_detail_metrics'">
-            <img src="images/documentation/features/metrics.svg" />
-            <p>Metrics</p>
-          </div>
-          <div class="imgContainer" onclick="location.href='/documentation/features/#_istio_configuration'">
-            <img src="images/documentation/features/info.svg" />
-            <p>Configuration <br />validation</p>
-          </div>
-          <div class="imgContainer" onclick="location.href='/documentation/features/#_distributed_tracing'">
-            <img src="images/documentation/features/tracing.svg" />
-            <p>Distributed <br />tracing</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-<!-- #content end -->
+    {{ partial "header.html" . }}
 
-{{ partial "footer.html" . }}
+    <!-- # content start home -->
+    {{ partial "home/introduction.html" . }}
+    {{ partial "home/features.html" . }}
+    {{ partial "home/articles.html" (dict "posts" $posts) }}
+    <!-- #content end -->
 
+    {{ partial "footer.html" . }}
+{{end}}

--- a/layouts/partials/home/articles.html
+++ b/layouts/partials/home/articles.html
@@ -1,0 +1,80 @@
+<div class="section nomargin">
+        <div class="container clearfix">
+    <div class="blog" id="blog">
+        <h1 class="blog-section-last-posts-title">LATEST IN OUR BLOG</h1>
+        <div class="title-line"></div>
+
+        <div class="blog__container">
+            <i class='fas fa-chevron-circle-left arrows prev arrow_disabled' id="posts_scrollleft" style='font-size:40px'></i>
+            <ul id="blog_posts_kiali" class="blog__slider">
+                {{- range .posts | first 10}}
+                {{- $link    := .link }}
+                {{- $img     := .thumbnail }}
+                {{- $title   := .title }}
+                {{- $author  := .author  | truncate 10 }}
+                {{- $dateRaw := .pubDate }}
+                {{- $date    := dateFormat "January 2, 2006" $dateRaw }}
+
+                {{- $summary := .content | plainify | truncate 150 }}
+
+
+                <li class="blog__post">
+                    <div>
+                        <img src="{{ $img }}" class="blog__topImg"></img>
+                        <h2 class="blog__title">{{ $title }}</h2>
+                        <div class="blog__content">
+                            <div class="blog__preview">
+
+                                <p class="blog__intro">
+                                    {{ $summary }}
+                                </p>
+                            </div>
+                            <hr>
+                            <div class="blog__info">
+                                <span class="blog__author">
+                                  {{ $author }}
+                                </span>
+                                <br />
+                                <span class="blog__date">
+                                  {{ $date }}
+                                </span>
+                            </div>
+                            <Button onclick="window.open('{{ $link }}','_blank')" class="button blog__readMore">
+                                Read More
+                            </Button>
+                        </div>
+                    </div>
+                </li>
+                {{- end }}
+            </ul>
+            <i class='fas fa-chevron-circle-right arrows next' id="posts_scrollright" style='font-size:40px'></i>
+        </div>
+    </div>
+        </div>
+</div>
+
+<script type="text/javascript">
+    window.onload = function() {
+
+        $('#posts_scrollleft').click(function () {
+            $('#blog_posts_kiali').scrollLeft($('#blog_posts_kiali').scrollLeft() - 370);
+            if($('#blog_posts_kiali').scrollLeft() < 200) {
+                $('#posts_scrollleft').addClass('arrow_disabled');
+            }
+
+            if($('#blog_posts_kiali').scrollLeft() < 2450) {
+                $('#posts_scrollright').removeClass('arrow_disabled');
+            }
+        });
+        $('#posts_scrollright').click(function () {
+            $('#blog_posts_kiali').scrollLeft($('#blog_posts_kiali').scrollLeft() + 370);
+            if($('#blog_posts_kiali').scrollLeft() > 150) {
+                $('#posts_scrollleft').removeClass('arrow_disabled');
+            }
+
+            if($('#blog_posts_kiali').scrollLeft() > 2450) {
+                $('#posts_scrollright').addClass('arrow_disabled');
+            }
+        });
+    };
+</script>

--- a/layouts/partials/home/features.html
+++ b/layouts/partials/home/features.html
@@ -1,0 +1,38 @@
+<section id="content">
+    <div class="content-wrap nopadding">
+        <div class="container clearfix">
+            <div class="features-bottom-box">
+                <div id="features-list">
+                    <div id="features-title">
+                        <h2>Features</h2>
+                        <p>A growing set of features</p>
+                    </div>
+                    <div id="graph-feature" class="imgContainer" onclick="location.href='/documentation/features/#_graph'">
+                        <img src="images/documentation/features/graph.svg" />
+                        <p>Topology</p>
+                    </div>
+                    <div
+                            id="health-feature"
+                            class="imgContainer"
+                            onclick="location.href='/documentation/features/#_graph_health'"
+                    >
+                        <img src="images/documentation/features/services.svg" />
+                        <p>Health <br />computation</p>
+                    </div>
+                    <div class="imgContainer" onclick="location.href='/documentation/features/#_detail_metrics'">
+                        <img src="images/documentation/features/metrics.svg" />
+                        <p>Metrics</p>
+                    </div>
+                    <div class="imgContainer" onclick="location.href='/documentation/features/#_istio_configuration'">
+                        <img src="images/documentation/features/info.svg" />
+                        <p>Configuration <br />validation</p>
+                    </div>
+                    <div class="imgContainer" onclick="location.href='/documentation/features/#_distributed_tracing'">
+                        <img src="images/documentation/features/tracing.svg" />
+                        <p>Distributed <br />tracing</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/layouts/partials/home/introduction.html
+++ b/layouts/partials/home/introduction.html
@@ -1,0 +1,42 @@
+<section id="slider" class="slider-element bg-angle">
+    <div class="vertical-middle ignore-header dark">
+        <div class="container">
+            <div class="row justify-content-between align-items-center">
+                <div class="col-md-5">
+                    <div class="slider-title">
+                        <h1 class="text-rotater mb-3" data-separator="," data-rotate="fadeIn" data-speed="3500">
+                            Service mesh observability and configuration
+                        </h1>
+                        <p><i>Kiali</i> is originated from the greek word κιάλι meaning <i>monocular</i> or <i>spyglass</i>.</p>
+                        <p>
+                            Kiali project provides answers to the questions:<br />What microservices are part of my Istio service
+                            mesh? How are they connected? How are they performing?
+                        </p>
+                        <p>
+              <span
+              ><i
+              ><a style="color:white" href="https://youtu.be/9CQ0PMiOGhg?t=371"
+              >"This is the kind of tool that you really need"</a
+              ></i
+              ></span
+              ><br /><span style="float:right">-- David Gageot, Google</span>
+                        </p>
+                    </div>
+                    <a href="/documentation/getting-started" class="button"
+                    >Get started <i class="icon-line-arrow-right t600"></i
+                    ></a>
+                </div>
+                <div class="col_half topmargin-sm col_last" style="vertical-align: center">
+                    <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+                        <iframe
+                                src="//www.youtube.com/embed/mbS0UReSWyY"
+                                style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;"
+                                allowfullscreen
+                                title="Kiali Overview">
+                        </iframe>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/static/css/kiali_style.css
+++ b/static/css/kiali_style.css
@@ -398,3 +398,148 @@ div.kiali-video {
   margin-left: auto;
   margin-right: auto;
 }
+
+.title-line {
+  margin-top: 46px;
+  background-color: #0094DE;
+  width: 40px;
+  height: 2px;
+}
+
+/* Last articles in medium */
+
+.blog {
+  width: 1120px;
+}
+
+.blog-section-last-posts-title {
+  font-family: Varela Round;
+  font-weight: lighter;
+  color: #0094DE;
+  font-size: 28px;
+  text-transform: capitalize;
+}
+.title {
+  color: #363636;
+  font-size: 2rem;
+  font-weight: 600;
+  line-height: 1.125;
+  word-break: break-word;
+}
+
+.blog__container {
+  position: relative;
+  margin-top:20px;
+  width: 100%;
+  height: 100%;
+}
+
+.blog__slider {
+  width: 100%;
+  list-style: none;
+  height: 700px;
+  padding: 0;
+  overflow: hidden;
+  margin: 0 10px 0 10px;
+  display: inline-flex; }
+
+.blog__post {
+  background-color: #fff;
+  shadow: 3px,5px, 6, rgba(0,0,0,.3);
+  padding: 14px;
+  width: 350px;
+  height: 480px;
+  display: flex;
+  flex-shrink: 0;
+  flex-grow: 1;
+  margin: 0 10px 0 10px;
+  justify-content: center;
+}
+
+.blog__topImg {
+  width: 380px;
+  height: 270px;
+  display: block;
+  margin: 0 auto;
+  object-fit: cover; }
+
+.blog__content {
+  margin: 0;
+  color: black;
+  padding: .8rem; }
+
+.blog__preview {
+  height: 200px;
+  font-size: .95rem;
+  margin-top: 20px;
+  font-weight: 300;
+}
+
+.blog__title {
+  background-color:rgba(0, 148, 222, .9);
+  color: #ffffff;
+  margin-top: -160px;
+  height:100px;
+  position: relative;
+  opacity: 0.9;
+  font-family:Varela round;
+  font-size:24px;
+}
+
+.blog__intro {
+  color: #555555;
+  font-family: Lato;
+  font-size: 16px;
+}
+
+.blog__info {
+  font-family: Lato;
+  display: inline-block;
+  float: left;
+}
+
+.blog__author {
+  font-size: 18px;
+  color: #555555;
+}
+
+.blog__author:hover .tooltip__author {
+  visibility: visible;
+}
+
+.blog__date {
+  font-size: 16px;
+  color: #6C757D;
+}
+
+.blog__readMore {
+  font-family: Lato;
+  float: right;
+  margin-top: 20px;
+  display: inline-block;
+  font-size: 16px;
+  font-weight: bold;
+  color: #0094DE;
+  border-color: #0094DE;
+  border-radius: 3px;
+  border: 2px solid;
+  background-color: #FFFFFF;
+  text-shadow: none;
+}
+.arrows {
+  position: absolute;
+  top: 50%;
+  margin-top: -31px;
+  color:#39B7F9;
+  display: inline-flex;
+}
+.prev {
+  left: -30px;
+}
+.next{
+  right: -40px;
+}
+
+.arrow_disabled{
+  opacity: 0.3;
+}


### PR DESCRIPTION
I saw how in jaeger they show the last posts of their blog in their website. They have a link in the main menu to the blog and we only have the "medium" icon, What do you think about to show the lasts posts like them in the website @abonas @theute ? Here is the PoC

![peek 2019-01-12 12-26](https://user-images.githubusercontent.com/3019213/51072731-96431f00-1665-11e9-84fd-d73c0099653a.gif)

- Configuration of the lasts posts in the config.toml
- Structure the partials