### PR TITLE
support users who do not have hugo+asciidoc installed on their box.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+HUGO_VERSION ?= 0.53
 
 install: checkDep
 	@echo Installing AsciiDoctor
@@ -22,4 +23,12 @@ deploy: build
 	aws configure set preview.cloudfront true
 	aws cloudfront create-invalidation --distribution-id E3RFW0PBPFCVRO --paths '/*'
 
+# Targets used to build and use the Hugo+Asciidoctor docker image
 
+hugo-docker:
+	docker build --build-arg HUGO_VERSION=${HUGO_VERSION} -t kiali/hugo:${HUGO_VERSION} hugo
+
+hugo-serve:
+	@mkdir -p ./resources/_gen/images && mkdir -p ./resources/_gen/assets
+	@docker run -t -i --sig-proxy=true --rm --mount type=bind,src=$(shell pwd),dst=/site -w /site -p 1313:1313 kiali/hugo:${HUGO_VERSION} /hugo serve --baseURL "http://localhost:1313/" --bind 0.0.0.0 --disableFastRender
+	@rm -rf ./resources

--- a/README.adoc
+++ b/README.adoc
@@ -9,17 +9,23 @@ The website is written in link:https://asciidoctor.org/docs/asciidoc-syntax-quic
 
 == Requirements
 
-Kiali.io runs on top of Hugo. You will need to have link://https://gohugo.io/[Hugo] installed and the `hugo` command available on your path in order to locally run a kiali.io instance.
+Kiali.io runs on top of Hugo. In order to locally run a kiali.io instance you will need to either install Hugo and AsciiDoctor locally or run a docker image that contains Hugo and AsciiDoctor.
 
-It is likely you can easily install `hugo` using your system's package manager. For more information about how to install Hugo please see its link:https://gohugo.io/getting-started/installing/[installation documentation]. 
+=== Install and Run Hugo and AsciiDoctor Locally
 
-It is recommended to run **Hugo 0.48**
+If you want to locally install the required tools, you first must have link://https://gohugo.io/[Hugo] installed and the `hugo` command available on your PATH. It is likely you can easily install `hugo` using your system's package manager. For more information about how to install Hugo please see its link:https://gohugo.io/getting-started/installing/[installation documentation].
 
-Asciidoctor is also required to run Kiali.io. The `make install` command will install Asciidoctor using link:https://rubygems.org[Ruby Gem] and Bundler. You will need to have the `gem` command on your path. Please see the link:https://rubygems.org/pages/download[Ruby Gem installation docs] for more information.
+Asciidoctor is also required to run kiali.io. The `make install` command will install Asciidoctor using link:https://rubygems.org[Ruby Gem] and Bundler. You will need to have the `gem` command on your path. Please see the link:https://rubygems.org/pages/download[Ruby Gem installation docs] for more information.
+
+It is recommended to install and run at least **Hugo 0.48**
+
+=== Install and Run Hugo and AsciiDoctor via Docker
+
+If you do not want to install a local copy of Hugo and AsciiDoctor, you can run a Hugo+AsciiDoctor docker image instead. You need to first create the docker image via `make hugo-docker`. Once you have a docker image, you can run the Hugo server via `make hugo-serve`.
 
 == Installing
 
-The following command needs to be run in order to install a few dependencies:
+If you want to install and run Hugo and AsciiDoctor locally, the following command needs to be run in order to install a few dependencies:
 
 [source, bash]
 ----
@@ -33,6 +39,13 @@ Hugo has a live `serve` command that runs a small, lightweight web server on you
 [source,bash]
 ----
 make serve
+----
+
+If you did not install Hugo and AsciiDoctor locally, but you instead want to run with the docker image, you can use the hugo-serve make target instead:
+
+[source,bash]
+----
+make hugo-serve
 ----
 
 If everything is working as expected you should see something like the following being outputted:
@@ -61,7 +74,7 @@ You should now be able to access hugo running kiali.io at link:http://localhost:
 
 This running instance should support live reload. Changes you make to files should be automatically updated in your running instance.
 
-Some files may not be supported for live reload. If you are not automatically seeing your changes live you may need to restart the server. You can restart the server by pressing 'ctrl-c' and running `make serve` again.
+Some files may not be supported for live reload. If you are not automatically seeing your changes live you may need to restart the server. You can restart the server by pressing 'ctrl-c' and running `make serve` again (or `make hugo-serve` if you are running the docker image).
 
 ==  Project directory structure
 
@@ -79,6 +92,7 @@ Some files may not be supported for live reload. If you are not automatically se
 ├── [static] - Directory for any static files to be compiled into the web site (style sheets, JavaScript, images, robots.txt, fav icons, etc.).
 ├── [themes] - Directory that contains the site theme.  Themes override layouts.
 ├── Makefile
+├── hugo/Dockerfile - the Dockerfile used to build the Hugo+AsciiDoctor image
 ├── config.toml - Main configuration file, where you define the web site title, URL, language, etc.
 ├── README.adoc (This file)
 ```

--- a/hugo/Dockerfile
+++ b/hugo/Dockerfile
@@ -1,0 +1,11 @@
+FROM asciidoctor/docker-asciidoctor:latest
+
+ARG HUGO_VERSION
+
+ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz /hugo.tar.gz
+RUN tar -zxvf /hugo.tar.gz -C /
+
+RUN addgroup -g 777 hugo && adduser -u 777 -G hugo -D hugo
+USER hugo
+RUN ["/hugo", "version"]
+


### PR DESCRIPTION
Now people have the option to just run "make hugo-serve" rather than install hugo/asciidoc.
For now, you have to build the docker container first "make hugo-docker" but if this PR is good, we can publish our hugo+asciidoc image to doc hub and people won't even need to build it.

NOTE: This does NOT affect the previous way things work. The Makefile still has the targets it had before and you can still install hugo/asciidoctor locally. So it still works the way it did originally. This only adds the optional feature of letting someone run the docker image if they don't want to install those tools locally.