### PR TITLE
Update outdated demo video on homepage

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -69,7 +69,7 @@
               </div>
               <div class="col_half topmargin-sm col_last" style="vertical-align: center">
                 <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-                  <iframe src="//www.youtube.com/embed/8HZlDGURzLc" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" allowfullscreen title="Kiali Overview"></iframe>
+                  <iframe src="//www.youtube.com/embed/6NWPi8lm2Y0" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" allowfullscreen title="Kiali Overview"></iframe>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Homepage video is from version 0.3. We are at 0.14. I guess it would be great to replace it for a fresher one. I just found this vid from @pilhuhn (from mid october).
This is a wdyt PR, so wdyt? 