### PR TITLE
KIALI-2358 Update doc to include updated service account name

### DIFF
--- a/content/gettingstarted/index.adoc
+++ b/content/gettingstarted/index.adoc
@@ -185,6 +185,6 @@ Then you will need to grant the `kiali` role in the namespace of your choosing:
 
 [source,bash]
 ----
-oc adm policy add-role-to-user kiali system:serviceaccount:istio-system:kiali -n ${NAMESPACE}
+oc adm policy add-role-to-user kiali system:serviceaccount:istio-system:kiali-service-account -n ${NAMESPACE}
 ----
 {nbsp} +


### PR DESCRIPTION
The service account name was updated a while ago to match what is being used in upstream Istio. But the docs for running with reduced permissions was not updated at that time.