### PR TITLE
Adding documentation for MeshPolicy validation in KIALI-2093

### DIFF
--- a/content/documentation/overview/index.adoc
+++ b/content/documentation/overview/index.adoc
@@ -220,6 +220,17 @@ This section lists all the validations that Kiali performs on all Istio configur
 |link:/files/validation_examples/201.yaml[201.yaml, window="_blank"]
 |===
 
+.List of MeshPolicy validations
+[cols="2,1,2,1,1", options="header"]
+|===
+|Validation message |Severity |Description |Source |Example
+|Mesh-wide Destination Rule enabling mTLS missing
+|error
+|When there is a MeshPolicy enabling mTLS but there isn't any mesh-wide Destination Rule enabling mTLS
+|https://github.com/kiali/kiali/tree/master/business/checkers/mesh_policies_checker.go[source code, window="_blank"]
+|link:/files/validation_examples/401.yaml[401.yaml, window="_blank"]
+|===
+
 === Distributed Tracing
 
 Clicking on Distributed Tracing menu item will open a new tab with the https://www.jaegertracing.io/[Jaeger] UI for tracing services.

--- a/content/documentation/overview/index.adoc
+++ b/content/documentation/overview/index.adoc
@@ -224,9 +224,9 @@ This section lists all the validations that Kiali performs on all Istio configur
 [cols="2,1,2,1,1", options="header"]
 |===
 |Validation message |Severity |Description |Source |Example
-|Mesh-wide Destination Rule enabling mTLS missing
+|Mesh-wide Destination Rule enabling mTLS is missing
 |error
-|When there is a MeshPolicy enabling mTLS but there isn't any mesh-wide Destination Rule enabling mTLS
+|When there is a MeshPolicy enabling mTLS, but there isn't any mesh-wide Destination Rule enabling mTLS
 |https://github.com/kiali/kiali/tree/master/business/checkers/mesh_policies_checker.go[source code, window="_blank"]
 |link:/files/validation_examples/401.yaml[401.yaml, window="_blank"]
 |===

--- a/static/files/validation_examples/401.yaml
+++ b/static/files/validation_examples/401.yaml
@@ -1,0 +1,8 @@
+# Make sure there isn't any DestinationRule enabling meshwide mTLS
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "MeshPolicy"
+metadata:
+  name: "default"
+spec:
+  peers:
+  - mtls: {}


### PR DESCRIPTION
Adding documentation of the validation introduced into kiali/kiali-2093.

This PR is in DNM until  kiali/kiali-2093 is merged.