### PR TITLE
KIALI-2451 Create new page for validation documentations

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -22,6 +22,12 @@ theme = "canvas"
       url = "/documentation/features"
       weight = 1
       parent="documentation"
+      [[menu.main]]
+         identifier = "doc_validation"
+         name = "Validation"
+         url = "/documentation/overview/validation"
+         weight = 1
+         parent="doc_overview"
   [[menu.main]]
       identifier = "doc_prerequisites"
       name = "Prerequisites"

--- a/config.toml
+++ b/config.toml
@@ -25,9 +25,9 @@ theme = "canvas"
       [[menu.main]]
          identifier = "doc_validation"
          name = "Validation"
-         url = "/documentation/overview/validation"
+         url = "/documentation/features/validation"
          weight = 1
-         parent="doc_overview"
+         parent="doc_features"
   [[menu.main]]
       identifier = "doc_prerequisites"
       name = "Prerequisites"

--- a/content/documentation/features/_index.adoc
+++ b/content/documentation/features/_index.adoc
@@ -1,0 +1,6 @@
+---
+title: "Features"
+date: 2018-06-20T19:04:38+02:00
+draft: false
+type: "features"
+---

--- a/content/documentation/features/index.adoc
+++ b/content/documentation/features/index.adoc
@@ -210,7 +210,6 @@ Kiali is more than observability, it also helps you to configure, update and val
 
 === Istio Configuration
 The Istio configuration view provides advanced filtering and navigation for Istio configuration objects such as Virtual Services and Gateways.
-
 Kiali provides inline config edition and powerful **semantic validation** for Istio resources.
 ++++
 <a class="video-popup" href="/images/documentation/features/istio_configuration.mp4" title="Istio Configurations">
@@ -218,129 +217,12 @@ Kiali provides inline config edition and powerful **semantic validation** for Is
 </a>
 ++++
 
-{empty} +
+=== Validations
+Kiali performs a set of validations to the most common Istio Objects (Destination Rules, Service Entries, Virtual Services, and so on). Those validations are done in addition to/on top of the existing ones performed by Istio's Galley component. Most validations are done inside a single namespace only, any exceptions (such as gateways) are properly documented.
 
-=== Validations Performed
+Galley validation are mostly syntactic validations based on the object syntax analysis of Istio Objects while Kiali validations are mostly semantic validations between different Istio Objects. Kiali validations are based on the runtime status of your service mesh, Galley validations are static ones and doesn't take into account what is configured in the mesh.
 
-This section lists all the validations that Kiali performs on all Istio configurations. Most of these validations are done in addition to/on top of the existing ones performed by Istio's Galley component (except those marked as deprecated). Most validations are done inside a single namespace only, any exceptions (such as gateways) are marked below.
-
-[cols="2,1,2,1,1", options="header"]
-.List of destination rule validations
-|===
-|Validation message |Severity |Description |Source |Example
-|More than one Destination Rule for the same host subset combination
-|warning
-|Warning shown when two Destination Rules point to the same host and share one or more subsets. If non-local mTLS is enabled this check is ignored.
-|https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/multi_match_checker.go[source code, window=_blank]
-|link:/files/validation_examples/001.yaml[001.yaml, window=_blank]
-
-|This host has no matching workloads
-|error
-|When one destination rule has a host that doesn't exist. This checks against any workload, service names as well as service entries
-|https://github.com/kiali/kiali/blob/master/business/checkers/destinationrules/no_dest_checker.go#L28[source code, window=_blank]
-|link:/files/validation_examples/002.yaml[002.yaml, window=_blank]
-
-|This subset's labels are not found in any matching host
-|error
-|There isn't any workload for this host matching its labels with the ones from that subset
-|https://github.com/kiali/kiali/blob/master/business/checkers/destinationrules/no_dest_checker.go#L46[source code, window=_blank]
-|link:/files/validation_examples/003.yaml[003.yaml, window=_blank]
-
-|MeshPolicy enabling mTLS is missing
-|error
-|When there is a DestinationRule enabling mTLS mesh-wide, but there isn't any MeshPolicy enabling mTLS
-|https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/meshwide_mtls_checker.go[source code, window=_blank]
-|link:/files/validation_examples/004.yaml[004.yaml, window=_blank]
-
-|===
-
-.List of virtual service validations
-[cols="2,1,2,1,1", options="header"]
-|===
-|Validation message |Severity |Description |Source |Example
-|VirtualService is pointing to a non-existent gateway
-|error
-|When the virtual service has a specified a gateway that doesn't exist
-|https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/no_gateway_checker.go[source code, window=_blank]
-|link:/files/validation_examples/101.yaml[101.yaml, window=_blank]
-
-|DestinationWeight on route doesn't have a valid service (host not found)
-|error
-|When a destination weight has a host that doesn't exist. This checks against service names as well as service entries
-|https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/no_host_checker.go[source code, window=_blank]
-|link:/files/validation_examples/102.yaml[102.yaml, window=_blank]
-
-|VirtualService doesn't define any route protocol
-|error
-|When a Virtual Service doesn't define any tcp, http or tls routes
-|https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/no_host_checker.go[source code, window=_blank]
-|link:/files/validation_examples/103.yaml[103.yaml, window=_blank]
-
-|More than one Virtual Service for same host
-|warning
-|When two virtual services point to the same host. This includes hosts with wildcards also.
-|https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/single_host_checker.go[source code, window=_blank]
-|link:/files/validation_examples/104.yaml[104.yaml, window=_blank]
-
-|Subset not found
-|warning
-|When there is no subset defined in any destination rule
-|https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/subset_presence_checker.go[source code, window=_blank]
-|link:/files/validation_examples/105.yaml[105.yaml, window=_blank]
-
-|Destination field is mandatory
-|error
-|When a Destination field within a DestinationWeight is empty
-|https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/subset_presence_checker.go[source code, window=_blank]
-|link:/files/validation_examples/106.yaml[106.yaml, window=_blank]
-
-|(Deprecated) Weight must be a number
-|error
-|When a destination weight is not a number
-|https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/route_checker.go[source code, window=_blank]
-|link:/files/validation_examples/107.yaml[107.yaml, window=_blank]
-
-|(Deprecated) Weight should be between 0 and 100
-|error
-|When a destination weight is > 100 or < 0
-|https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/route_checker.go[source code, window=_blank]
-|link:/files/validation_examples/108.yaml[108.yaml, window=_blank]
-
-|(Deprecated) Weight sum should be 100
-|error
-|When the sum of all the weights for a protocol doesn't sum up to 100
-|https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/route_checker.go[source code, window=_blank]
-|link:/files/validation_examples/109.yaml[109.yaml, window=_blank]
-
-|(Deprecated) All routes should have weight
-|warning
-|When weight sum is different from 100 and one or more destination weights have no weight, but the rest have.
-|https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/route_checker.go[source code, window=_blank]
-|link:/files/validation_examples/110.yaml[110.yaml, window=_blank]
-|===
-
-.List of Gateway validations
-[cols="2,1,2,1,1", options="header"]
-|===
-|Validation message |Severity |Description |Source |Example
-|More than one Gateway for the same host port combination
-|warning
-|When two or more gateways (from same or different namespace) point to the same host-port combination
-|https://github.com/kiali/kiali/tree/master/business/checkers/gateways/multi_match_checker.go[source code, window=_blank]
-|link:/files/validation_examples/201.yaml[201.yaml, window=_blank]
-|===
-
-.List of MeshPolicy validations
-[cols="2,1,2,1,1", options="header"]
-|===
-|Validation message |Severity |Description |Source |Example
-|Mesh-wide Destination Rule enabling mTLS is missing
-|error
-|When there is a MeshPolicy enabling mTLS, but there isn't any mesh-wide Destination Rule enabling mTLS
-|https://github.com/kiali/kiali/tree/master/business/checkers/mesh_policies_checker.go[source code, window=_blank]
-|link:/files/validation_examples/401.yaml[401.yaml, window=_blank]
-|===
-
+Check the complete link:/documentation/features/validation[list of validations] for further information.
 
 === Istio Wizards
 Kiali provides different actions to create, update and delete Istio configuration driven by Wizards. These are located in the *Actions* menu on the Service Details page.

--- a/content/documentation/features/validation/index.adoc
+++ b/content/documentation/features/validation/index.adoc
@@ -25,7 +25,7 @@ More than one Gateway for the same host port combination
 
 === Description
 
-Gateway creates a proxy that will forward the inbound traffic for the exposed ports. If two different gateways expose the same ports for the same host, this creates ambiquity inside Istio as either of these gateways could handle the traffic. This is most likely a configuration error. This check is done across all namespaces the user has access to.
+Gateway creates a proxy that will forward the inbound traffic for the exposed ports. If two different gateways expose the same ports for the same host, this creates ambiguity inside Istio as either of these gateways could handle the traffic. This is most likely a configuration error. This check is done across all namespaces the user has access to.
 
 === Resolution
 
@@ -254,7 +254,7 @@ https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/tr
 Policy enabling namespace-wide mTLS is missing
 
 === Description
-Istio has the ability to define mTLS communications at namespace level. In order to do that, Istio needs both a DestinationRule and a Policy targetting all the clients/workloads of the specific namespace. The Policy will allow mTLS authentication method for all the workloads within a namespace. The DestinationRule will define all the clients within the namespace to start communications in mTLS mode.
+Istio has the ability to define mTLS communications at namespace level. In order to do that, Istio needs both a DestinationRule and a Policy targeting all the clients/workloads of the specific namespace. The Policy will allow mTLS authentication method for all the workloads within a namespace. The DestinationRule will define all the clients within the namespace to start communications in mTLS mode.
 If the Policy is not found and the DestinationRule is on STRICT mode in that namespace, all the communications within that namespace will return 500 errors.
 
 === Resolution
@@ -407,10 +407,12 @@ https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/no
 Subset not found
 
 === Description
+VirtualService will route matching requests to a service inside your mesh. Routing can also match a subset of traffic to a certain version of it for example. The subsets referred in a VirtualService have to be defined in one DestinationRule.
 
+If one route in the VirtualService points to a subset that doesn't exist Istio won't be able to send traffic to a service.
 
 === Resolution
-
+Fix the routes that points to a non existing subsets. It might be fixing a typo in the subset's name or defining the missing subset in a DestinationRule.
 
 === Severity
 
@@ -464,42 +466,15 @@ More than one Virtual Service for same host
 
 === Description
 
-
+A VirtualService defines a set of traffic routing rules to apply when a host is addressed. Each routing rule defines matching criteria for traffic of a specific protocol. If the traffic is matched, then it is sent to a named destination service (or subset/version of it) defined in the registry.
 
 === Resolution
 
-This is valid configuration only if VirtualService is bound to a gateway, sidecars do not accept this behavior. There are several caveats when using this method and defining the same parts in multiple Virtual Service definitions is not recommended. While Istio will merge the configuration, it does not guarantee any ordering for cross-resource merging and only the first seen configuration is applied (rest ignored). As recommended, each VS definition shold have a 'catch-all' situation, but this can only be defined in a definition affecting the same host.
+This is valid configuration only if VirtualService is bound to a gateway, sidecars do not accept this behavior. There are several caveats when using this method and defining the same parts in multiple Virtual Service definitions is not recommended. While Istio will merge the configuration, it does not guarantee any ordering for cross-resource merging and only the first seen configuration is applied (rest ignored). As recommended, each VS definition should have a 'catch-all' situation, but this can only be defined in a definition affecting the same host.
 
 === Severity
 
 Warning
-
-=== Example
-
-[source, yaml]
-----
-include::/data/files/validation_examples/104.yaml[]
-----
-
-=== See Also
-
-https://istio.io/help/ops/traffic-management/deploy-guidelines/#multiple-virtual-services-and-destination-rules-for-the-same-host[Istio documention Multiple virtual services for the same host, window="_blank"]
-
-'''
-
-=== Error message
-
-Destination field is mandatory
-
-=== Description
-
-
-
-=== Resolution
-
-=== Severity
-
-Error
 
 === Example
 

--- a/content/documentation/features/validation/index.adoc
+++ b/content/documentation/features/validation/index.adoc
@@ -23,6 +23,7 @@ toc::[]
 
 Gateway creates a proxy that will forward the inbound traffic for the exposed ports. If two different gateways expose the same ports for the same host, this creates ambiguity inside Istio as either of these gateways could handle the traffic. This is most likely a configuration error. This check is done across all namespaces the user has access to.
 
+:numbered!:
 ==== Resolution
 
 Remove the duplicate gateway entries or merge the two gateway definitions into a single one.
@@ -40,13 +41,14 @@ include::/data/files/validation_examples/201.yaml[]
 
 ==== See Also
 
-https://github.com/kiali/kiali/tree/master/business/checkers/gateways/multi_match_checker.go[Validator source code, window=_blank]
--
+https://github.com/kiali/kiali/tree/master/business/checkers/gateways/multi_match_checker.go[Validator source code, window=_blank] +
 https://istio.io/docs/reference/config/istio.networking.v1alpha3/#Gateway[Istio Gateway documentation, window=_blank]
 
 '''
 
+:numbered:
 === No matching workload found for gateway selector in this namespace
+:numbered!:
 
 A label selector to match the workload to which this gateway should be applied to. This validation will only check the current namespace for matching workloads as this is recommended (and potentially in the future required) by the Istio. Excluded from this check are the default "istio-ingressgateway" and "istio-egressgateway" workloads which Istio ships with.
 
@@ -69,14 +71,15 @@ include::/data/files/validation_examples/202.yaml[]
 
 ==== See Also
 
-https://github.com/kiali/kiali/blob/master/business/checkers/gateways/selector_checker.go[Validator source code, window="_blank"]
--
+https://github.com/kiali/kiali/blob/master/business/checkers/gateways/selector_checker.go[Validator source code, window="_blank"] +
 https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Gateway[Istio documentation for gateways, window="_blank"]
 
 [#destinationrules]
+:numbered:
 == Destination rules
 
 === More than one Destination Rule for the same host subset combination
+:numbered!:
 
 Istio applies traffic rules for services after the routing has happened. These can include different settings such as connection pooling, circuit breakers, load balancing, detection, etc. Istio can define the same rules for all services under a host or different rules for different versions of the service. 
 
@@ -101,17 +104,16 @@ include::/data/files/validation_examples/001.yaml[]
 
 ==== See Also
 
-https://github.com/kiali/kiali/tree/master/business/checkers/destination_rules/multi_match_checker.go[Validator source code, window="_blank"]
--
-https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRule[Destination rule documentation, window="_blank"]
--
-https://github.com/istio/istio/blob/0e9cecab053aab744a7c3a731aacb07fd794d5f9/pilot/pkg/model/push_context.go#L879[Istio source code for merging, window="_blank"]
--
+https://github.com/kiali/kiali/tree/master/business/checkers/destination_rules/multi_match_checker.go[Validator source code, window="_blank"] +
+https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRule[Destination rule documentation, window="_blank"] +
+https://github.com/istio/istio/blob/0e9cecab053aab744a7c3a731aacb07fd794d5f9/pilot/pkg/model/push_context.go#L879[Istio source code for merging, window="_blank"] +
 https://istio.io/help/ops/traffic-management/deploy-guidelines/#multiple-virtual-services-and-destination-rules-for-the-same-host[Istio documentation: Multiple virtual services and destination rules for the same host, window="_blank"]
 
 '''
 
+:numbered:
 === This host has no matching entry in the service registry (service, workload or service entries)
+:numbered!:
 
 Istio applies traffic rules for services after the routing has happened. These can include different settings such as connection pooling, circuit breakers, load balancing, detection, etc. Istio can define the same rules for all services under a host or different rules for different versions of the service. The host must a service that is defined in the platform's service registry or as a ServiceEntry. Short names are extended to include '.namespace.cluster' using the namespace of the destination rule, not the service itself. FQDN is evaluated as is. It is recommended to use the FQDN to prevent any confusion.
 
@@ -134,13 +136,14 @@ include::/data/files/validation_examples/002.yaml[]
 
 ==== See Also
 
-https://github.com/kiali/kiali/tree/master/business/checkers/destination_rules/no_host_checker.go[Validator source code, window="_blank"]
--
+https://github.com/kiali/kiali/tree/master/business/checkers/destination_rules/no_host_checker.go[Validator source code, window="_blank"] +
 https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRule[Destination rule documentation, window="_blank"]
 
 '''
 
-==== This subset’s labels are not found in any matching host
+:numbered:
+=== This subset’s labels are not found in any matching host
+:numbered!:
 
 Istio applies traffic rules for services after the routing has happened. These can include different settings such as connection pooling, circuit breakers, load balancing, detection, etc. Istio can define the same rules for all services under a host or different rules for different versions of the service. The host must a service that is defined in the platform's service registry or as a ServiceEntry. Short names are extended to include '.namespace.cluster' using the namespace of the destination rule, not the service itself. FQDN is evaluated as is. It is recommended to use the FQDN to prevent any confusion.
 
@@ -167,12 +170,14 @@ include::/data/files/validation_examples/003.yaml[]
 
 ==== See Also
 
-https://github.com/kiali/kiali/tree/master/business/checkers/destination_rules/no_host_checker.go[Validator source code, window="_blank"]
--
+https://github.com/kiali/kiali/tree/master/business/checkers/destination_rules/no_host_checker.go[Validator source code, window="_blank"] +
 https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRule[Destination rule documentation, window="_blank"]
 
 '''
+
+:numbered:
 === MeshPolicy enabling mTLS is missing
+:numbered!:
 
 Istio has the ability to define mTLS communications at mesh level. In order to do that, Istio needs one DestinationRule and one MeshPolicy. The DestinationRule configures all the clients of the mesh to use mTLS protocol on their connections. The MeshPolicy defines what authentication methods can be accepted on the workload of the whole mesh.
 If the MeshPolicy is not found or doesn't exist and the mesh-wide DestinationRule is on ISTIO_MUTUAL mode, all the communication will return 500 errors.
@@ -193,12 +198,14 @@ include::/data/files/validation_examples/004.yaml[]
 
 ==== See Also
 
-https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/meshwide_mtls_checker.go[Validator source code, window="_blank"]
--
+https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/meshwide_mtls_checker.go[Validator source code, window="_blank"] +
 https://istio.io/docs/tasks/security/authn-policy/#globally-enabling-istio-mutual-tls[Globally enabling Istio mutual TLS, window="_blank"]
 
 '''
+
+:numbered:
 === mTLS settings of a non-local Destination Rule are overridden
+:numbered!:
 
 Istio allows you to define DestinationRule at three different levels: mesh, namespace and service level. A mesh may have multiple DestinationRules. In case of having two DestinationRules on the first one is at a lower level than the second one, the first one overrides the TLS values of the second one.
 
@@ -223,7 +230,10 @@ include::/data/files/validation_examples/005.yaml[]
 https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/traffic_policy_checker.go[Validator source code, window="_blank"]
 
 '''
+
+:numbered:
 === Policy enabling namespace-wide mTLS is missing
+:numbered!:
 
 Istio has the ability to define mTLS communications at namespace level. In order to do that, Istio needs both a DestinationRule and a Policy targeting all the clients/workloads of the specific namespace. The Policy will allow mTLS authentication method for all the workloads within a namespace. The DestinationRule will define all the clients within the namespace to start communications in mTLS mode.
 If the Policy is not found and the DestinationRule is on STRICT mode in that namespace, all the communications within that namespace will return 500 errors.
@@ -244,12 +254,14 @@ include::/data/files/validation_examples/006.yaml[]
 ----
 
 ==== See Also
-https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/namespaceswide_mtls_checker.go[Validator source code, window="_blank"]
--
+https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/namespaceswide_mtls_checker.go[Validator source code, window="_blank"] +
 https://istio.io/docs/tasks/security/authn-policy/#enable-mutual-tls-per-namespace-or-service[Enabling Istio mutual TLS per namespace, window="_blank"]
 
 '''
+
+:numbered:
 === Policy with TLS strict mode found, it should be permissive
+:numbered!:
 
 Istio needs both a DestinationRule and Policy to enable mTLS communications. The Policy will configure the authentication method accepted for all the targeted workloads. The DestinationRule will define which is the authentication method that the clients of specific workloads has to start communications with.
 
@@ -269,12 +281,14 @@ include::/data/files/validation_examples/007.yaml[]
 
 ==== See Also
 
-https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/disabled_namespacewide_mtls_checker.go[Validator source code, window="_blank"]
--
+https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/disabled_namespacewide_mtls_checker.go[Validator source code, window="_blank"] +
 https://istio.io/docs/tasks/security/authn-policy/#enable-mutual-tls-per-namespace-or-service[Enabling Istio mutual TLS per namespace, window="_blank"]
 
 '''
+
+:numbered:
 === MeshPolicy enabling mTLS found, permissive policy is needed
+:numbered!:
 
 Istio needs both a DestinationRule and Policy to enable mTLS communications. The Policy will configure the authentication method accepted for all the targeted workloads. The DestinationRule will define which is the authentication method that the clients of specific workloads has to start communications with.
 
@@ -296,16 +310,17 @@ include::/data/files/validation_examples/008.yaml[]
 
 ==== See Also
 
-https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/disabled_namespacewide_mtls_checker.go[Validator source code, window="_blank"]
--
+https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/disabled_namespacewide_mtls_checker.go[Validator source code, window="_blank"] +
 https://istio.io/docs/tasks/security/authn-policy/#globally-enabling-istio-mutual-tls[Globally enabling Istio mutual TLS, window="_blank"]
 
 '''
 
 [#virtualservices]
+:numbered:
 == VirtualServices
 
 === DestinationWeight on route doesn't have a valid service (host not found)
+:numbered!:
 
 VirtualService will route matching requests to a service inside your mesh. Routing can also match a subset of traffic to a certain version of it for example. Any service inside the mesh must be targeted by its name, the IP address are only allowed for hosts defined through a Gateway. Host must be in a short name or FQDN format. Short name will evaluate to VS' namespace, regardless of where the actual service might be placed.
 
@@ -328,13 +343,14 @@ include::/data/files/validation_examples/102.yaml[]
 
 ==== See Also
 
-https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/no_host_checker.go[Validator source code, window="_blank"]
--
+https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/no_host_checker.go[Validator source code, window="_blank"] +
 https://istio.io/docs/reference/config/istio.networking.v1alpha3/#Destination[Destination documentation, window="_blank"]
 
 '''
 
+:numbered:
 === VirtualService is pointing to a non-existent gateway
+:numbered!:
 
 By default, VirtualService routes will apply to sidecars inside the mesh. The gateway field allows to override that default and if anything is defined, the VS will only apply to those selected. 'mesh' is a reserved gateway name and means all the sidecars in the mesh. If one wishes to apply the VS to gateways as well as the sidecars, the 'mesh' keyword must be used as one of the gateways. Incorrect gateways will mean that the VS is not applied correctly.
 
@@ -359,7 +375,9 @@ https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/no
 
 '''
 
+:numbered:
 === Subset not found
+:numbered!:
 
 VirtualService will route matching requests to a service inside your mesh. Routing can also match a subset of traffic to a certain version of it for example. The subsets referred in a VirtualService have to be defined in one DestinationRule.
 
@@ -383,7 +401,9 @@ include::/data/files/validation_examples/105.yaml[]
 
 https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/subset_presence_checker.go[source code, window="_blank"]
 
+:numbered:
 === VirtualService doesn't define any route protocol
+:numbered!:
 
 VirtualService is a defined set of rules for routing certain type of traffic to target destinations with rules. At least one, 'tcp', 'http' or 'tls' must be defined.
 
@@ -404,13 +424,14 @@ include::/data/files/validation_examples/103.yaml[]
 
 ==== See Also
 
-https://github.com/istio/istio/blob/0e9cecab053aab744a7c3a731aacb07fd794d5f9/pilot/pkg/model/validation.go#L1628[Istio validation for route types, window="_blank"]
--
+https://github.com/istio/istio/blob/0e9cecab053aab744a7c3a731aacb07fd794d5f9/pilot/pkg/model/validation.go#L1628[Istio validation for route types, window="_blank"] +
 https://github.com/kiali/kiali/blob/master/business/checkers/virtual_services/no_host_checker.go[Validator source code, window="_blank"]
 
 '''
 
+:numbered:
 === More than one Virtual Service for same host
+:numbered!:
 
 A VirtualService defines a set of traffic routing rules to apply when a host is addressed. Each routing rule defines matching criteria for traffic of a specific protocol. If the traffic is matched, then it is sent to a named destination service (or subset/version of it) defined in the registry.
 
@@ -436,9 +457,11 @@ https://istio.io/help/ops/traffic-management/deploy-guidelines/#multiple-virtual
 '''
 
 [#services]
+:numbered:
 == Services
 
 === Port name must follow <protocol>[-suffix] form
+:numbered!:
 
 Istio requires the service ports to follow the naming form of 'protocol-suffix' where the '-suffix' part is optional. If the naming does not match this form (or is undefined), Istio treats all the traffic TCP instead of the defined protocol in the definition. Dash is a required character between protocol and suffix. For example, 'http2foo' is not valid, while 'http2-foo' is (for http2 protocol).
 
@@ -459,13 +482,14 @@ include::/data/files/validation_examples/701.yaml[]
 
 ==== See Also
 
-https://github.com/kiali/kiali/blob/master/business/checkers/services/port_mapping_checker.go[Validator source code, window="_blank"]
--
+https://github.com/kiali/kiali/blob/master/business/checkers/services/port_mapping_checker.go[Validator source code, window="_blank"] +
 https://github.com/istio/istio.io/blob/master/content/help/faq/traffic-management/naming-port-convention.md[Istio documentation port naming convention, window="_blank"]
 
 '''
 
+:numbered:
 === Service port and deployment port do not match
+:numbered!:
 
 Service definition has a combination of labels and port definitions that are not matching to any workloads. This means the deployment will be unsuccessful and no traffic can flow between these two resources.
 
@@ -490,9 +514,11 @@ https://github.com/kiali/kiali/blob/master/business/checkers/services/port_mappi
 
 
 [#meshpolicies]
+:numbered:
 == Mesh Policies
 
 === Mesh-wide Destination Rule enabling mTLS is missing
+:numbered!:
 
 Istio has the ability to define mTLS communications at mesh level. In order to do that, Istio needs one DestinationRule and one MeshPolicy. The DestinationRule configures all the clients of the mesh to use mTLS protocol on their connections. The MeshPolicy defines what authentication methods can be accepted on the workload of the whole mesh.
 If the DestinationRule is not found or doesn't exist and the MeshPolicy is on STRICT mode, all the communication will return 500 errors.
@@ -513,14 +539,15 @@ include::/data/files/validation_examples/401.yaml[]
 
 ==== See Also
 
-https://github.com/kiali/kiali/tree/master/business/checkers/meshpolicies/mesh_mtls_checker.go[Validator source code, window="_blank"]
--
+https://github.com/kiali/kiali/tree/master/business/checkers/meshpolicies/mesh_mtls_checker.go[Validator source code, window="_blank"] +
 https://istio.io/docs/tasks/security/authn-policy/#globally-enabling-istio-mutual-tls[Globally enabling Istio mutual TLS, window="_blank"]
 
 [#serviceroles]
+:numbered:
 == ServiceRoles and ServiceRoleBindings
 
 === Unable to find all the defined services
+:numbered!:
 
 Services can be listed with an exact match, prefix match as well as suffix match. Using "*" refers to all the services in this namespace. This error indicates the services list is pointing to a service that can not be found from this namespace.
 
@@ -541,13 +568,14 @@ include::/data/files/validation_examples/501.yaml[]
 
 ==== See Also
 
-https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_checker.go[Validator source code, window="_blank"]
--
+https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_checker.go[Validator source code, window="_blank"] +
 https://istio.io/docs/reference/config/authorization/istio.rbac.v1alpha1/#AccessRule[Istio documentation, window="_blank"]
 
 '''
 
+:numbered:
 === ServiceRole can only point to current namespace
+:numbered!:
 
 Services can be listed with an exact match, prefix match as well as suffix match. Using "*" refers to all the services in this namespace. Although FQDN can be used, the namespace of the services must be the same as ServiceRole's deployment.
 
@@ -568,13 +596,14 @@ include::/data/files/validation_examples/502.yaml[]
 
 ==== See Also
 
-https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_checker.go[Validator source code, window="_blank"]
--
+https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_checker.go[Validator source code, window="_blank"] +
 https://istio.io/docs/reference/config/authorization/istio.rbac.v1alpha1/#AccessRule[Istio documentation, window="_blank"]
 
 '''
 
+:numbered:
 === ServiceRole does not exists in this namespace
+:numbered!:
 
 ServiceRoleBinding assigns a ServiceRole to subjects. As such, it must refer to a ServiceRole object and this object can only reside in the same namespace (cross-namespace refers are not valid).
 
@@ -595,15 +624,17 @@ include::/data/files/validation_examples/601.yaml[]
 
 ==== See Also
 
-https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_binding_checker.go[Validator source code, window="_blank"]
--
+https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_binding_checker.go[Validator source code, window="_blank"] +
 https://istio.io/docs/reference/config/authorization/istio.rbac.v1alpha1/#ServiceRoleBinding[Istio documentation, window="_blank"]
+
 
 [#generic]
 
+:numbered:
 == Unknown
 
 === Unable to verify the validity, cross-namespace validation is not supported for this field
+:numbered!:
 
 In certain cases, Kiali is unable to validate the field since it spans another namespace to which the validator is not capable of looking at. In such cases, Kiali will mark this field with a grey icon indicating that the fields correctness could not be verified. This does not necessarily mean there is an error, but that the user should be careful and do the validation manually.
 

--- a/content/documentation/features/validation/index.adoc
+++ b/content/documentation/features/validation/index.adoc
@@ -575,9 +575,11 @@ Unable to find all the defined services
 
 === Description
 
+Services can be listed with an exact match, prefix match as well as suffix match. Using "*" refers to all the services in this namespace. This error indicates the services list is pointing to a service that can not be found from this namespace.
 
 === Resolution
 
+Deploy the missing services or fix the services list to point to correct services.
 
 === Severity
 
@@ -587,12 +589,12 @@ Error
 
 [source, yaml]
 ----
-<TODO REQUIRES EXAMPLE>
 ----
 
 === See Also
 
 https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_checker.go[Validator source code, window="_blank"]
+https://istio.io/docs/reference/config/authorization/istio.rbac.v1alpha1/#AccessRule[Istio documentation, window="_blank"]
 
 '''
 
@@ -602,7 +604,11 @@ ServiceRole can only point to current namespace
 
 === Description
 
+Services can be listed with an exact match, prefix match as well as suffix match. Using "*" refers to all the services in this namespace. Although FQDN can be used, the namespace of the services must be the same as ServiceRole's deployment. 
+
 === Resolution
+
+If the services in question are located in another namespace, deploy this ServiceRole to that namespace. Or deploy the services to this namespace.
 
 === Severity
 
@@ -617,6 +623,7 @@ Error
 === See Also
 
 https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_checker.go[Validator source code, window="_blank"]
+https://istio.io/docs/reference/config/authorization/istio.rbac.v1alpha1/#AccessRule[Istio documentation, window="_blank"]
 
 '''
 
@@ -626,7 +633,11 @@ ServiceRole does not exists in this namespace
 
 === Description
 
+ServiceRoleBinding assigns a ServiceRole to subjects. As such, it must refer to a ServiceRole object and this object can only reside in the same namespace (cross-namespace refers are not valid).
+
 === Resolution
+
+Deploy the missing ServiceRole to the same namespace.
 
 === Severity
 
@@ -640,7 +651,8 @@ Error
 
 === See Also
 
-https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_checker.go[Validator source code, window="_blank"]
+https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_binding_checker.go[Validator source code, window="_blank"]
+https://istio.io/docs/reference/config/authorization/istio.rbac.v1alpha1/#ServiceRoleBinding[Istio documentation, window="_blank"]
 
 [#generic]
 

--- a/content/documentation/features/validation/index.adoc
+++ b/content/documentation/features/validation/index.adoc
@@ -29,7 +29,7 @@ Remove the duplicate gateway entries or merge the two gateway definitions into a
 
 ==== Severity
 
-Warning
+icon:exclamation-triangle[] Warning
 
 ==== Example
 
@@ -58,7 +58,7 @@ Deploy the missing workload or fix the selector to target a correct location.
 
 ==== Severity
 
-Warning
+icon:exclamation-triangle[] Warning
 
 ==== Example
 
@@ -90,7 +90,7 @@ Either merge the settings to a single Destination Rule or split the subsets in s
 
 ==== Severity
 
-Warning
+icon:exclamation-triangle[] Warning
 
 ==== Example
 
@@ -123,7 +123,7 @@ Correct the host to point to a correct service (in this namespace or with FQDN t
 
 ==== Severity
 
-Error
+icon:times-circle[] Error
 
 ==== Example
 
@@ -156,7 +156,7 @@ Also, verify that the labels are correctly matching a workload with the intended
 
 ==== Severity
 
-Error
+icon:times-circle[] Error
 
 ==== Example
 
@@ -182,7 +182,7 @@ Add a MeshPolicy named as default without specifying targets but setting peers m
 
 ==== Severity
 
-Error
+icon:times-circle[] Error
 
 ==== Example
 
@@ -209,7 +209,7 @@ Merging the TLS settings to one of the DestinationRules is the only way to fix t
 
 ==== Severity
 
-Warning
+icon:exclamation-triangle[] Warning
 
 ==== Example
 
@@ -234,7 +234,7 @@ Add a Policy named as default without specifying targets but setting peers mTLS 
 
 ==== Severity
 
-Error
+icon:times-circle[] Error
 
 ==== Example
 
@@ -258,7 +258,7 @@ Kiali has found that there is a DestinationRule sending traffic without mTLS aut
 
 ==== Severity
 
-Error
+icon:times-circle[] Error
 
 ==== Example
 
@@ -285,7 +285,7 @@ There are two ways to fix this situation. You can either change the MeshPolicy t
 
 ==== Severity
 
-Error
+icon:times-circle[] Error
 
 ==== Example
 
@@ -317,7 +317,7 @@ Correct the host to point to a correct service (in this namespace or with FQDN t
 
 ==== Severity
 
-Error
+icon:times-circle[] Error
 
 ==== Example
 
@@ -344,7 +344,7 @@ Fix the possible gateway field to target all necessary gateways or remove the fi
 
 ==== Severity
 
-Error
+icon:times-circle[] Error
 
 ==== Example
 
@@ -370,7 +370,7 @@ Fix the routes that points to a non existing subsets. It might be fixing a typo 
 
 ==== Severity
 
-Error
+icon:times-circle[] Error
 
 ==== Example
 
@@ -393,7 +393,7 @@ This appears to be a configuration error. Fix the definition.
 
 ==== Severity
 
-Error
+icon:times-circle[] Error
 
 ==== Example
 
@@ -420,7 +420,7 @@ This is valid configuration only if VirtualService is bound to a gateway, sideca
 
 ==== Severity
 
-Warning
+icon:exclamation-triangle[] Warning
 
 ==== Example
 
@@ -448,7 +448,7 @@ Rename the service port name field to follow the form and the traffic will flow 
 
 ==== Severity
 
-Error
+icon:times-circle[] Error
 
 ==== Example
 
@@ -475,7 +475,7 @@ Fix the port definitions in the workload or in the service definition to ensure 
 
 ==== Severity
 
-Error
+icon:times-circle[] Error
 
 ==== Example
 
@@ -502,7 +502,7 @@ Add a DestinationRule named as default with "*.cluster" host and ISTIO_MUTUAL as
 
 ==== Severity
 
-Error
+icon:times-circle[] Error
 
 ==== Example
 
@@ -530,7 +530,7 @@ Deploy the missing services or fix the services list to point to correct service
 
 ==== Severity
 
-Error
+icon:times-circle[] Error
 
 ==== Example
 
@@ -557,7 +557,7 @@ If the services in question are located in another namespace, deploy this Servic
 
 ==== Severity
 
-Error
+icon:times-circle[] Error
 
 ==== Example
 
@@ -584,7 +584,7 @@ Deploy the missing ServiceRole to the same namespace.
 
 ==== Severity
 
-Error
+icon:times-circle[] Error
 
 ==== Example
 

--- a/content/documentation/features/validation/index.adoc
+++ b/content/documentation/features/validation/index.adoc
@@ -39,7 +39,7 @@ Warning
 
 [source, yaml]
 ----
-include::/public/files/validation_examples/201.yaml[]
+include::/data/files/validation_examples/201.yaml[]
 ----
 
 === See Also
@@ -108,7 +108,7 @@ Warning
 
 [source, yaml]
 ----
-include::/public/files/validation_examples/001.yaml[]
+include::/data/files/validation_examples/001.yaml[]
 ----
 
 === See Also
@@ -144,7 +144,7 @@ Error
 
 [source, yaml]
 ----
-include::/public/files/validation_examples/002.yaml[]
+include::/data/files/validation_examples/002.yaml[]
 ----
 
 === See Also
@@ -181,7 +181,7 @@ Error
 
 [source, yaml]
 ----
-include::/public/files/validation_examples/003.yaml[]
+include::/data/files/validation_examples/003.yaml[]
 ----
 
 === See Also
@@ -196,10 +196,11 @@ https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRul
 MeshPolicy enabling mTLS is missing
 
 === Description
-
+Istio has the ability to define mTLS communications at mesh level. In order to do that, Istio needs one DestinationRule and one MeshPolicy. The DestinationRule configures all the clients of the mesh to use mTLS protocol on their connections. The MeshPolicy defines what authentication methods can be accepted on the workload(s) of the whole mesh.
+If the MeshPolicy is not found or doesn't exist and the mesh-wide DestinationRule is on STRICT mode, all the communication will return 500 errors.
 
 === Resolution
-
+Add a MeshPolicy named as default without specifying targets but setting peers mtls mode to STRICT or PERMISSIVE.
 
 === Severity
 
@@ -209,10 +210,14 @@ Error
 
 [source, yaml]
 ----
+include::/data/files/validation_examples/004.yaml[]
 ----
 
 === See Also
 
+https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/meshwide_mtls_checker.go[Validator source code, window="_blank"]
+-
+https://istio.io/docs/tasks/security/authn-policy/#globally-enabling-istio-mutual-tls[Globally enabling Istio mutual TLS, window="_blank"]
 
 '''
 === Error message
@@ -227,15 +232,18 @@ mTLS settings of a non-local Destination Rule are overridden
 
 === Severity
 
-Error
+Warning
 
 === Example
 
 [source, yaml]
 ----
+include::/data/files/validation_examples/005.yaml[]
 ----
 
 === See Also
+
+https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/traffic_policy_checker.go[Validator source code, window="_blank"]
 
 '''
 === Error message
@@ -243,10 +251,12 @@ Error
 Policy enabling namespace-wide mTLS is missing
 
 === Description
-
+Istio has the ability to define mTLS communications at namespace level. In order to do that, Istio needs both a DestinationRule and a Policy targetting all the clients/workloads of the specific namespace. The Policy will allow mTLS authentication method for all the workloads within a namespace. The DestinationRule will define all the clients within the namespace to start communications in mTLS mode.
+If the Policy is not found and the DestinationRule is on STRICT mode in that namespace, all the communications within that namespace will return 500 errors.
 
 === Resolution
-
+A Policy enabling mTLS method is needed for the workloads in the namespace. Otherwise all the clients will start mTLS connections that those workloads won't be ready to manage.
+Add a Policy named as default without specifying targets but setting peers mTLS mode to STRICT or PERMISSIVE in the same namespace as the DestinationRule.
 
 === Severity
 
@@ -256,10 +266,13 @@ Error
 
 [source, yaml]
 ----
+include::/data/files/validation_examples/006.yaml[]
 ----
 
 === See Also
-
+https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/namespaceswide_mtls_checker.go[Validator source code, window="_blank"]
+-
+https://istio.io/docs/tasks/security/authn-policy/#enable-mutual-tls-per-namespace-or-service[Enabling Istio mutual TLS per namespace, window="_blank"]
 
 '''
 === Error message
@@ -280,10 +293,14 @@ Error
 
 [source, yaml]
 ----
+include::/data/files/validation_examples/007.yaml[]
 ----
 
 === See Also
 
+https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/disabled_namespacewide_mtls_checker.go[Validator source code, window="_blank"]
+-
+https://istio.io/docs/tasks/security/authn-policy/#enable-mutual-tls-per-namespace-or-service[Enabling Istio mutual TLS per namespace, window="_blank"]
 
 '''
 === Error message
@@ -304,10 +321,14 @@ Error
 
 [source, yaml]
 ----
+include::/data/files/validation_examples/008.yaml[]
 ----
 
 === See Also
 
+https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/disabled_namespacewide_mtls_checker.go[Validator source code, window="_blank"]
+-
+https://istio.io/docs/tasks/security/authn-policy/#globally-enabling-istio-mutual-tls[Globally enabling Istio mutual TLS, window="_blank"]
 
 '''
 
@@ -336,7 +357,7 @@ Error
 
 [source, yaml]
 ----
-include::/public/files/validation_examples/102.yaml[]
+include::/data/files/validation_examples/102.yaml[]
 ----
 
 === See Also
@@ -367,7 +388,7 @@ Error
 
 [source, yaml]
 ----
-include::/public/files/validation_examples/101.yaml[]
+include::/data/files/validation_examples/101.yaml[]
 ----
 
 === See Also
@@ -394,7 +415,7 @@ Error
 
 [source, yaml]
 ----
-include::/public/files/validation_examples/105.yaml[]
+include::/data/files/validation_examples/105.yaml[]
 ----
 
 === See Also
@@ -421,7 +442,7 @@ Error
 
 [source, yaml]
 ----
-include::/public/files/validation_examples/103.yaml[]
+include::/data/files/validation_examples/103.yaml[]
 ----
 
 === See Also
@@ -452,7 +473,7 @@ Warning
 
 [source, yaml]
 ----
-include::/public/files/validation_examples/104.yaml[]
+include::/data/files/validation_examples/104.yaml[]
 ----
 
 === See Also
@@ -479,7 +500,7 @@ Error
 
 [source, yaml]
 ----
-include::/public/files/validation_examples/104.yaml[]
+include::/data/files/validation_examples/104.yaml[]
 ----
 
 === See Also
@@ -570,7 +591,7 @@ Error
 
 [source, yaml]
 ----
-include::/public/files/validation_examples/401.yaml[]
+include::/data/files/validation_examples/401.yaml[]
 ----
 
 === See Also

--- a/content/documentation/features/validation/index.adoc
+++ b/content/documentation/features/validation/index.adoc
@@ -18,8 +18,6 @@ toc::[]
 [#gateways]
 == Gateways
 
-<todo some sort of list/table structure?>
-
 === Error message
 
 More than one Gateway for the same host port combination
@@ -52,19 +50,21 @@ https://istio.io/docs/reference/config/istio.networking.v1alpha3/#Gateway[Istio 
 
 === Error message
 
-Port name must follow <protocol>[-suffix] form
+No matching workload found for gateway selector in this namespace
 
 === Description
 
-Istio requires the service ports to follow the naming form of 'protocol-suffix' where the '-suffix' part is optional. If the naming does not match this form (or is undefined), Istio treats all the traffic TCP instead of the defined protocol in the definition. Dash is a required character between protocol and suffix. For example, 'http2foo' is not valid, while 'http2-foo' is (for http2 protocol).
+A label selector to match the workload to which this gateway should be applied to. This validation will only check the current namespace for matching workloads as this is recommended (and potentially in the future required) by the Istio. Excluded from this check are the default "istio-ingressgateway" and "istio-egressgateway" workloads which Istio ships with.
+
+Although your traffic might be correctly routed to a workload in other namespace, this is not a guaranteed behavior and thus a warning is flagged in such cases also.
 
 === Resolution
 
-Rename the service port name field to follow the form and the traffic will flow correctly. 
+Deploy the missing workload or fix the selector to target a correct location. 
 
 === Severity
 
-Error
+Warning
 
 === Example
 
@@ -75,8 +75,8 @@ Error
 
 === See Also
 
-https://github.com/kiali/kiali/blob/master/business/checkers/gateways/port_checker.go[Validator source code, window="_blank"]
-https://github.com/istio/istio.io/blob/master/content/help/faq/traffic-management/naming-port-convention.md[Istio documentation port naming convention, window="_blank"]
+https://github.com/kiali/kiali/blob/master/business/checkers/gateways/selector_checker.go[Validator source code, window="_blank"]
+https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Gateway[Istio documentation for gateways, window="_blank"]
 
 [#destinationrules]
 == Destination rules
@@ -118,7 +118,7 @@ https://istio.io/help/ops/traffic-management/deploy-guidelines/#multiple-virtual
 '''
 === Error message
 
-This host has no matching workloads
+This host has no matching entry in the service registry (service, workload or service entries)
 
 === Description
 
@@ -201,13 +201,9 @@ Error
 
 [source, yaml]
 ----
-include::/files/validation_examples/004.yaml
 ----
 
 === See Also
-
-https://github.com/kiali/kiali/blob/master/business/checkers/destinationrules/meshwide_mtls_checker.go[Validator source code, window="_blank"]
-https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRule[Destination rule documentation, window="_blank"]
 
 
 '''
@@ -229,14 +225,80 @@ Error
 
 [source, yaml]
 ----
-include::/files/validation_examples/004.yaml
 ----
 
 === See Also
 
-https://github.com/kiali/kiali/blob/master/business/checkers/destinationrules/meshwide_mtls_checker.go[Validator source code, window="_blank"]
-https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRule[Destination rule documentation, window="_blank"]
+'''
+=== Error message
 
+Policy enabling namespace-wide mTLS is missing
+
+=== Description
+
+
+=== Resolution
+
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+----
+
+=== See Also
+
+
+'''
+=== Error message
+
+Policy with TLS strict mode found, it should be permissive
+
+=== Description
+
+
+=== Resolution
+
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+----
+
+=== See Also
+
+
+'''
+=== Error message
+
+MeshPolicy enabling mTLS found, permissive policy is needed
+
+=== Description
+
+
+=== Resolution
+
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+----
+
+=== See Also
 
 
 '''
@@ -414,9 +476,10 @@ include::/files/validation_examples/104.yaml
 
 https://istio.io/help/ops/traffic-management/deploy-guidelines/#multiple-virtual-services-and-destination-rules-for-the-same-host[Istio documention Multiple virtual services for the same host, window="_blank"]
 
+'''
 
-[#serviceentries]
-== ServiceEntries
+[#services]
+== Services
 
 === Error message
 
@@ -443,8 +506,36 @@ Error
 
 === See Also
 
-https://github.com/kiali/kiali/blob/master/business/checkers/serviceentries/port_checker.go[Validator source code, window="_blank"]
+https://github.com/kiali/kiali/blob/master/business/checkers/services/port_mapping_checker.go[Validator source code, window="_blank"]
 https://github.com/istio/istio.io/blob/master/content/help/faq/traffic-management/naming-port-convention.md[Istio documentation port naming convention, window="_blank"]
+
+'''
+
+=== Error message
+
+Service port and deployment port do not match
+
+=== Description
+
+Service definition has a combination of labels and port definitions that are not matching to any workloads. This means the deployment will be unsuccessful and no traffic can flow between these two resources.
+
+=== Resolution
+
+Fix the port definitions in the workload or in the service definition to ensure they match.
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+----
+
+=== See Also
+
+https://github.com/kiali/kiali/blob/master/business/checkers/services/port_mapping_checker.go[Validator source code, window="_blank"]
 
 
 [#meshpolicies]
@@ -474,3 +565,92 @@ include::/files/validation_examples/401.yaml
 === See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/mesh_policies_checker.go[Validator source code, window="_blank"]
+
+[#serviceroles]
+== ServiceRoles and ServiceRoleBindings
+
+=== Error message
+
+Unable to find all the defined services
+
+=== Description
+
+
+=== Resolution
+
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+<TODO REQUIRES EXAMPLE>
+----
+
+=== See Also
+
+https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_checker.go[Validator source code, window="_blank"]
+
+'''
+
+=== Error message
+
+ServiceRole can only point to current namespace
+
+=== Description
+
+=== Resolution
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+----
+
+=== See Also
+
+https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_checker.go[Validator source code, window="_blank"]
+
+'''
+
+=== Error message
+
+ServiceRole does not exists in this namespace
+
+=== Description
+
+=== Resolution
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+----
+
+=== See Also
+
+https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_checker.go[Validator source code, window="_blank"]
+
+[#generic]
+
+== Unknown
+
+=== Error message
+
+Unable to verify the validity, cross-namespace validation is not supported for this field
+
+=== Description
+
+In certain cases, Kiali is unable to validate the field since it spans another namespace to which the validator is not capable of looking at. In such cases, Kiali will mark this field with a grey icon indicating that the fields correctness could not be verified. This does not necessarily mean there is an error, but that the user should be careful and do the validation manually.
+

--- a/content/documentation/features/validation/index.adoc
+++ b/content/documentation/features/validation/index.adoc
@@ -9,7 +9,7 @@ weight: 1
 :sectnums:
 :linkattrs:
 :toc: left
-:toclevels: 1
+:toclevels: 2
 toc::[]
 :toc-title: List of validations
 :keywords: Kiali Documentation
@@ -19,30 +19,26 @@ toc::[]
 [#gateways]
 == Gateways
 
-=== Error message
-
-More than one Gateway for the same host port combination
-
-=== Description
+=== More than one Gateway for the same host port combination
 
 Gateway creates a proxy that will forward the inbound traffic for the exposed ports. If two different gateways expose the same ports for the same host, this creates ambiguity inside Istio as either of these gateways could handle the traffic. This is most likely a configuration error. This check is done across all namespaces the user has access to.
 
-=== Resolution
+==== Resolution
 
 Remove the duplicate gateway entries or merge the two gateway definitions into a single one.
 
-=== Severity
+==== Severity
 
 Warning
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/201.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/gateways/multi_match_checker.go[Validator source code, window=_blank]
 -
@@ -50,32 +46,28 @@ https://istio.io/docs/reference/config/istio.networking.v1alpha3/#Gateway[Istio 
 
 '''
 
-=== Error message
-
-No matching workload found for gateway selector in this namespace
-
-=== Description
+=== No matching workload found for gateway selector in this namespace
 
 A label selector to match the workload to which this gateway should be applied to. This validation will only check the current namespace for matching workloads as this is recommended (and potentially in the future required) by the Istio. Excluded from this check are the default "istio-ingressgateway" and "istio-egressgateway" workloads which Istio ships with.
 
 Although your traffic might be correctly routed to a workload in other namespace, this is not a guaranteed behavior and thus a warning is flagged in such cases also.
 
-=== Resolution
+==== Resolution
 
 Deploy the missing workload or fix the selector to target a correct location.
 
-=== Severity
+==== Severity
 
 Warning
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/202.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/blob/master/business/checkers/gateways/selector_checker.go[Validator source code, window="_blank"]
 -
@@ -84,11 +76,7 @@ https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Gateway[Isti
 [#destinationrules]
 == Destination rules
 
-=== Error message
-
-More than one Destination Rule for the same host subset combination
-
-=== Description
+=== More than one Destination Rule for the same host subset combination
 
 Istio applies traffic rules for services after the routing has happened. These can include different settings such as connection pooling, circuit breakers, load balancing, detection, etc. Istio can define the same rules for all services under a host or different rules for different versions of the service. 
 
@@ -96,22 +84,22 @@ This validation warning could be a result of duplicate definition of the same su
 
 Istio will silently ignore the duplicate subsets and merge these destination rules without letting the user know. Only the first seen rule (by Istio) per subset is used and information from multiple definitions is not merged. While the routing *might* work correctly, this is most likely a configuration error. It may lead to a undesired behavior if one of the offending rules is removed or modified and that is probably not the intention of the deployer of this service. Also, if the two offending destination rules have different policies for traffic routing the wrong one might be used.
 
-=== Resolution
+==== Resolution
 
 Either merge the settings to a single Destination Rule or split the subsets in such a way that they do not interleave. This ensures that the routing behavior stays consistent.
 
-=== Severity
+==== Severity
 
 Warning
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/001.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/destination_rules/multi_match_checker.go[Validator source code, window="_blank"]
 -
@@ -122,32 +110,29 @@ https://github.com/istio/istio/blob/0e9cecab053aab744a7c3a731aacb07fd794d5f9/pil
 https://istio.io/help/ops/traffic-management/deploy-guidelines/#multiple-virtual-services-and-destination-rules-for-the-same-host[Istio documentation: Multiple virtual services and destination rules for the same host, window="_blank"]
 
 '''
-=== Error message
 
-This host has no matching entry in the service registry (service, workload or service entries)
-
-=== Description
+=== This host has no matching entry in the service registry (service, workload or service entries)
 
 Istio applies traffic rules for services after the routing has happened. These can include different settings such as connection pooling, circuit breakers, load balancing, detection, etc. Istio can define the same rules for all services under a host or different rules for different versions of the service. The host must a service that is defined in the platform's service registry or as a ServiceEntry. Short names are extended to include '.namespace.cluster' using the namespace of the destination rule, not the service itself. FQDN is evaluated as is. It is recommended to use the FQDN to prevent any confusion.
 
 If the host is not found, Istio will ignore the defined rules.
 
-=== Resolution
+==== Resolution
 
 Correct the host to point to a correct service (in this namespace or with FQDN to other namespaces) or deploy the missing service to the mesh.
 
-=== Severity
+==== Severity
 
 Error
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/002.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/destination_rules/no_host_checker.go[Validator source code, window="_blank"]
 -
@@ -155,11 +140,7 @@ https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRul
 
 '''
 
-=== Error message
-
-This subset’s labels are not found in any matching host
-
-=== Description
+==== This subset’s labels are not found in any matching host
 
 Istio applies traffic rules for services after the routing has happened. These can include different settings such as connection pooling, circuit breakers, load balancing, detection, etc. Istio can define the same rules for all services under a host or different rules for different versions of the service. The host must a service that is defined in the platform's service registry or as a ServiceEntry. Short names are extended to include '.namespace.cluster' using the namespace of the destination rule, not the service itself. FQDN is evaluated as is. It is recommended to use the FQDN to prevent any confusion.
 
@@ -167,169 +148,153 @@ Subsets can override the global settings defined in the DR for a host.
 
 If the host is not found, Istio will ignore the defined rules.
 
-=== Resolution
+==== Resolution
 
 Correct the host to point to a correct service (in this namespace or with FQDN to other namespaces) or deploy the missing service to the mesh. If the hostname is equal to the one used otherwise in the DR, consider removing the duplicate host resolution.
 
 Also, verify that the labels are correctly matching a workload with the intended service.
 
-=== Severity
+==== Severity
 
 Error
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/003.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/destination_rules/no_host_checker.go[Validator source code, window="_blank"]
 -
 https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRule[Destination rule documentation, window="_blank"]
 
 '''
-=== Error message
+=== MeshPolicy enabling mTLS is missing
 
-MeshPolicy enabling mTLS is missing
-
-=== Description
 Istio has the ability to define mTLS communications at mesh level. In order to do that, Istio needs one DestinationRule and one MeshPolicy. The DestinationRule configures all the clients of the mesh to use mTLS protocol on their connections. The MeshPolicy defines what authentication methods can be accepted on the workload of the whole mesh.
 If the MeshPolicy is not found or doesn't exist and the mesh-wide DestinationRule is on ISTIO_MUTUAL mode, all the communication will return 500 errors.
 
-=== Resolution
+==== Resolution
 Add a MeshPolicy named as default without specifying targets but setting peers mtls mode to STRICT or PERMISSIVE. The MeshPolicy should be like link:/data/files/validation_examples/401.yaml[this, window="_blank"].
 
-=== Severity
+==== Severity
 
 Error
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/004.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/meshwide_mtls_checker.go[Validator source code, window="_blank"]
 -
 https://istio.io/docs/tasks/security/authn-policy/#globally-enabling-istio-mutual-tls[Globally enabling Istio mutual TLS, window="_blank"]
 
 '''
-=== Error message
-
-mTLS settings of a non-local Destination Rule are overridden
-
-=== Description
+=== mTLS settings of a non-local Destination Rule are overridden
 
 Istio allows you to define DestinationRule at three different levels: mesh, namespace and service level. A mesh may have multiple DestinationRules. In case of having two DestinationRules on the first one is at a lower level than the second one, the first one overrides the TLS values of the second one.
 
-=== Resolution
+==== Resolution
 
 This validation aims to warn Kiali users that they may be disabling/enabling mTLS from the higher DestinationRule.
 Merging the TLS settings to one of the DestinationRules is the only way to fix this validation. However, this is a valid scenario so it might be impossible to remove this warning.
 
-=== Severity
+==== Severity
 
 Warning
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/005.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/traffic_policy_checker.go[Validator source code, window="_blank"]
 
 '''
-=== Error message
+=== Policy enabling namespace-wide mTLS is missing
 
-Policy enabling namespace-wide mTLS is missing
-
-=== Description
 Istio has the ability to define mTLS communications at namespace level. In order to do that, Istio needs both a DestinationRule and a Policy targeting all the clients/workloads of the specific namespace. The Policy will allow mTLS authentication method for all the workloads within a namespace. The DestinationRule will define all the clients within the namespace to start communications in mTLS mode.
 If the Policy is not found and the DestinationRule is on STRICT mode in that namespace, all the communications within that namespace will return 500 errors.
 
-=== Resolution
+==== Resolution
 A Policy enabling mTLS method is needed for the workloads in the namespace. Otherwise all the clients will start mTLS connections that those workloads won't be ready to manage.
 Add a Policy named as default without specifying targets but setting peers mTLS mode to STRICT or PERMISSIVE in the same namespace as the DestinationRule.
 
-=== Severity
+==== Severity
 
 Error
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/006.yaml[]
 ----
 
-=== See Also
+==== See Also
 https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/namespaceswide_mtls_checker.go[Validator source code, window="_blank"]
 -
 https://istio.io/docs/tasks/security/authn-policy/#enable-mutual-tls-per-namespace-or-service[Enabling Istio mutual TLS per namespace, window="_blank"]
 
 '''
-=== Error message
+=== Policy with TLS strict mode found, it should be permissive
 
-Policy with TLS strict mode found, it should be permissive
-
-=== Description
 Istio needs both a DestinationRule and Policy to enable mTLS communications. The Policy will configure the authentication method accepted for all the targeted workloads. The DestinationRule will define which is the authentication method that the clients of specific workloads has to start communications with.
 
-=== Resolution
+==== Resolution
 Kiali has found that there is a DestinationRule sending traffic without mTLS authentication method. There are two different ways to fix this situation. You can either change the Policy applying to PERMISSIVE mode or change the DestinationRule to start communications using mTLS.
 
-=== Severity
+==== Severity
 
 Error
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/007.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/disabled_namespacewide_mtls_checker.go[Validator source code, window="_blank"]
 -
 https://istio.io/docs/tasks/security/authn-policy/#enable-mutual-tls-per-namespace-or-service[Enabling Istio mutual TLS per namespace, window="_blank"]
 
 '''
-=== Error message
+=== MeshPolicy enabling mTLS found, permissive policy is needed
 
-MeshPolicy enabling mTLS found, permissive policy is needed
-
-=== Description
 Istio needs both a DestinationRule and Policy to enable mTLS communications. The Policy will configure the authentication method accepted for all the targeted workloads. The DestinationRule will define which is the authentication method that the clients of specific workloads has to start communications with.
 
 Kiali found a DestinationRule starting communications without TLS but there was a MeshPolicy allowing services to accept only requests in mTLS.
 
-=== Resolution
+==== Resolution
 There are two ways to fix this situation. You can either change the MeshPolicy to enable PERMISSIVE mode to all the workloads in the mesh or change the DestinatonRule to enable mTLS instead of disabling it (change the mode to ISTIO_MUTUAL).
 
-=== Severity
+==== Severity
 
 Error
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/008.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/destinationrules/disabled_namespacewide_mtls_checker.go[Validator source code, window="_blank"]
 -
@@ -340,32 +305,28 @@ https://istio.io/docs/tasks/security/authn-policy/#globally-enabling-istio-mutua
 [#virtualservices]
 == VirtualServices
 
-=== Error message
-
-DestinationWeight on route doesn't have a valid service (host not found)
-
-=== Description
+=== DestinationWeight on route doesn't have a valid service (host not found)
 
 VirtualService will route matching requests to a service inside your mesh. Routing can also match a subset of traffic to a certain version of it for example. Any service inside the mesh must be targeted by its name, the IP address are only allowed for hosts defined through a Gateway. Host must be in a short name or FQDN format. Short name will evaluate to VS' namespace, regardless of where the actual service might be placed.
 
 If the host is not found, Istio will ignore the defined rules. However, if a subset with a Destination Rule is not found it will affect all the subsets and all the routings. As such, care must be taken that the Destination rule is available before deploying the Virtual Service.
 
-=== Resolution
+==== Resolution
 
 Correct the host to point to a correct service (in this namespace or with FQDN to other namespaces), deploy the missing service to the mesh or remove the configuration linking to that non-existing service.
 
-=== Severity
+==== Severity
 
 Error
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/102.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/no_host_checker.go[Validator source code, window="_blank"]
 -
@@ -373,86 +334,75 @@ https://istio.io/docs/reference/config/istio.networking.v1alpha3/#Destination[De
 
 '''
 
-=== Error message
-
-VirtualService is pointing to a non-existent gateway
-
-=== Description
+=== VirtualService is pointing to a non-existent gateway
 
 By default, VirtualService routes will apply to sidecars inside the mesh. The gateway field allows to override that default and if anything is defined, the VS will only apply to those selected. 'mesh' is a reserved gateway name and means all the sidecars in the mesh. If one wishes to apply the VS to gateways as well as the sidecars, the 'mesh' keyword must be used as one of the gateways. Incorrect gateways will mean that the VS is not applied correctly.
 
-=== Resolution
+==== Resolution
 
 Fix the possible gateway field to target all necessary gateways or remove the field if the default 'mesh' is enough.
 
-=== Severity
+==== Severity
 
 Error
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/101.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/no_gateway_checker.go[Validator source code, window="_blank"]
 
 '''
 
-=== Error message
+=== Subset not found
 
-Subset not found
-
-=== Description
 VirtualService will route matching requests to a service inside your mesh. Routing can also match a subset of traffic to a certain version of it for example. The subsets referred in a VirtualService have to be defined in one DestinationRule.
 
 If one route in the VirtualService points to a subset that doesn't exist Istio won't be able to send traffic to a service.
 
-=== Resolution
+==== Resolution
 Fix the routes that points to a non existing subsets. It might be fixing a typo in the subset's name or defining the missing subset in a DestinationRule.
 
-=== Severity
+==== Severity
 
 Error
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/105.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/subset_presence_checker.go[source code, window="_blank"]
 
-=== Error message
-
-VirtualService doesn't define any route protocol
-
-=== Description
+=== VirtualService doesn't define any route protocol
 
 VirtualService is a defined set of rules for routing certain type of traffic to target destinations with rules. At least one, 'tcp', 'http' or 'tls' must be defined.
 
-=== Resolution
+==== Resolution
 
 This appears to be a configuration error. Fix the definition.
 
-=== Severity
+==== Severity
 
 Error
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/103.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/istio/istio/blob/0e9cecab053aab744a7c3a731aacb07fd794d5f9/pilot/pkg/model/validation.go#L1628[Istio validation for route types, window="_blank"]
 -
@@ -460,30 +410,26 @@ https://github.com/kiali/kiali/blob/master/business/checkers/virtual_services/no
 
 '''
 
-=== Error message
-
-More than one Virtual Service for same host
-
-=== Description
+=== More than one Virtual Service for same host
 
 A VirtualService defines a set of traffic routing rules to apply when a host is addressed. Each routing rule defines matching criteria for traffic of a specific protocol. If the traffic is matched, then it is sent to a named destination service (or subset/version of it) defined in the registry.
 
-=== Resolution
+==== Resolution
 
 This is valid configuration only if VirtualService is bound to a gateway, sidecars do not accept this behavior. There are several caveats when using this method and defining the same parts in multiple Virtual Service definitions is not recommended. While Istio will merge the configuration, it does not guarantee any ordering for cross-resource merging and only the first seen configuration is applied (rest ignored). As recommended, each VS definition should have a 'catch-all' situation, but this can only be defined in a definition affecting the same host.
 
-=== Severity
+==== Severity
 
 Warning
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/104.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://istio.io/help/ops/traffic-management/deploy-guidelines/#multiple-virtual-services-and-destination-rules-for-the-same-host[Istio documention Multiple virtual services for the same host, window="_blank"]
 
@@ -492,30 +438,26 @@ https://istio.io/help/ops/traffic-management/deploy-guidelines/#multiple-virtual
 [#services]
 == Services
 
-=== Error message
-
-Port name must follow <protocol>[-suffix] form
-
-=== Description
+=== Port name must follow <protocol>[-suffix] form
 
 Istio requires the service ports to follow the naming form of 'protocol-suffix' where the '-suffix' part is optional. If the naming does not match this form (or is undefined), Istio treats all the traffic TCP instead of the defined protocol in the definition. Dash is a required character between protocol and suffix. For example, 'http2foo' is not valid, while 'http2-foo' is (for http2 protocol).
 
-=== Resolution
+==== Resolution
 
 Rename the service port name field to follow the form and the traffic will flow correctly.
 
-=== Severity
+==== Severity
 
 Error
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/701.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/blob/master/business/checkers/services/port_mapping_checker.go[Validator source code, window="_blank"]
 -
@@ -523,30 +465,26 @@ https://github.com/istio/istio.io/blob/master/content/help/faq/traffic-managemen
 
 '''
 
-=== Error message
-
-Service port and deployment port do not match
-
-=== Description
+=== Service port and deployment port do not match
 
 Service definition has a combination of labels and port definitions that are not matching to any workloads. This means the deployment will be unsuccessful and no traffic can flow between these two resources.
 
-=== Resolution
+==== Resolution
 
 Fix the port definitions in the workload or in the service definition to ensure they match.
 
-=== Severity
+==== Severity
 
 Error
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/702.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/blob/master/business/checkers/services/port_mapping_checker.go[Validator source code, window="_blank"]
 
@@ -554,29 +492,26 @@ https://github.com/kiali/kiali/blob/master/business/checkers/services/port_mappi
 [#meshpolicies]
 == Mesh Policies
 
-=== Error message
+=== Mesh-wide Destination Rule enabling mTLS is missing
 
-Mesh-wide Destination Rule enabling mTLS is missing
-
-=== Description
 Istio has the ability to define mTLS communications at mesh level. In order to do that, Istio needs one DestinationRule and one MeshPolicy. The DestinationRule configures all the clients of the mesh to use mTLS protocol on their connections. The MeshPolicy defines what authentication methods can be accepted on the workload of the whole mesh.
 If the DestinationRule is not found or doesn't exist and the MeshPolicy is on STRICT mode, all the communication will return 500 errors.
 
-=== Resolution
+==== Resolution
 Add a DestinationRule named as default with "*.cluster" host and ISTIO_MUTUAL as tls trafficPolicy mode. The DestinationRule should be like link:/data/files/validation_examples/004.yaml[this, window="_blank"].
 
-=== Severity
+==== Severity
 
 Error
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/401.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/meshpolicies/mesh_mtls_checker.go[Validator source code, window="_blank"]
 -
@@ -585,30 +520,26 @@ https://istio.io/docs/tasks/security/authn-policy/#globally-enabling-istio-mutua
 [#serviceroles]
 == ServiceRoles and ServiceRoleBindings
 
-=== Error message
-
-Unable to find all the defined services
-
-=== Description
+=== Unable to find all the defined services
 
 Services can be listed with an exact match, prefix match as well as suffix match. Using "*" refers to all the services in this namespace. This error indicates the services list is pointing to a service that can not be found from this namespace.
 
-=== Resolution
+==== Resolution
 
 Deploy the missing services or fix the services list to point to correct services.
 
-=== Severity
+==== Severity
 
 Error
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/501.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_checker.go[Validator source code, window="_blank"]
 -
@@ -616,30 +547,26 @@ https://istio.io/docs/reference/config/authorization/istio.rbac.v1alpha1/#Access
 
 '''
 
-=== Error message
-
-ServiceRole can only point to current namespace
-
-=== Description
+=== ServiceRole can only point to current namespace
 
 Services can be listed with an exact match, prefix match as well as suffix match. Using "*" refers to all the services in this namespace. Although FQDN can be used, the namespace of the services must be the same as ServiceRole's deployment.
 
-=== Resolution
+==== Resolution
 
 If the services in question are located in another namespace, deploy this ServiceRole to that namespace. Or deploy the services to this namespace.
 
-=== Severity
+==== Severity
 
 Error
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/502.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_checker.go[Validator source code, window="_blank"]
 -
@@ -647,30 +574,26 @@ https://istio.io/docs/reference/config/authorization/istio.rbac.v1alpha1/#Access
 
 '''
 
-=== Error message
-
-ServiceRole does not exists in this namespace
-
-=== Description
+=== ServiceRole does not exists in this namespace
 
 ServiceRoleBinding assigns a ServiceRole to subjects. As such, it must refer to a ServiceRole object and this object can only reside in the same namespace (cross-namespace refers are not valid).
 
-=== Resolution
+==== Resolution
 
 Deploy the missing ServiceRole to the same namespace.
 
-=== Severity
+==== Severity
 
 Error
 
-=== Example
+==== Example
 
 [source, yaml]
 ----
 include::/data/files/validation_examples/601.yaml[]
 ----
 
-=== See Also
+==== See Also
 
 https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_binding_checker.go[Validator source code, window="_blank"]
 -
@@ -680,11 +603,7 @@ https://istio.io/docs/reference/config/authorization/istio.rbac.v1alpha1/#Servic
 
 == Unknown
 
-=== Error message
-
-Unable to verify the validity, cross-namespace validation is not supported for this field
-
-=== Description
+=== Unable to verify the validity, cross-namespace validation is not supported for this field
 
 In certain cases, Kiali is unable to validate the field since it spans another namespace to which the validator is not capable of looking at. In such cases, Kiali will mark this field with a grey icon indicating that the fields correctness could not be verified. This does not necessarily mean there is an error, but that the user should be careful and do the validation manually.
 

--- a/content/documentation/features/validation/index.adoc
+++ b/content/documentation/features/validation/index.adoc
@@ -2,7 +2,7 @@
 title: "Validation"
 date: 2019-02-26T14:53:00+02:00
 draft: false
-type: "documentation/overview"
+type: "features/validation"
 weight: 1
 ---
 

--- a/content/documentation/features/validation/index.adoc
+++ b/content/documentation/features/validation/index.adoc
@@ -163,7 +163,7 @@ This subset’s labels are not found in any matching host
 
 Istio applies traffic rules for services after the routing has happened. These can include different settings such as connection pooling, circuit breakers, load balancing, detection, etc. Istio can define the same rules for all services under a host or different rules for different versions of the service. The host must a service that is defined in the platform's service registry or as a ServiceEntry. Short names are extended to include '.namespace.cluster' using the namespace of the destination rule, not the service itself. FQDN is evaluated as is. It is recommended to use the FQDN to prevent any confusion.
 
-Subsets can override the global settings defined in the DR for a host. 
+Subsets can override the global settings defined in the DR for a host.
 
 If the host is not found, Istio will ignore the defined rules.
 
@@ -196,11 +196,11 @@ https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRul
 MeshPolicy enabling mTLS is missing
 
 === Description
-Istio has the ability to define mTLS communications at mesh level. In order to do that, Istio needs one DestinationRule and one MeshPolicy. The DestinationRule configures all the clients of the mesh to use mTLS protocol on their connections. The MeshPolicy defines what authentication methods can be accepted on the workload(s) of the whole mesh.
-If the MeshPolicy is not found or doesn't exist and the mesh-wide DestinationRule is on STRICT mode, all the communication will return 500 errors.
+Istio has the ability to define mTLS communications at mesh level. In order to do that, Istio needs one DestinationRule and one MeshPolicy. The DestinationRule configures all the clients of the mesh to use mTLS protocol on their connections. The MeshPolicy defines what authentication methods can be accepted on the workload of the whole mesh.
+If the MeshPolicy is not found or doesn't exist and the mesh-wide DestinationRule is on ISTIO_MUTUAL mode, all the communication will return 500 errors.
 
 === Resolution
-Add a MeshPolicy named as default without specifying targets but setting peers mtls mode to STRICT or PERMISSIVE.
+Add a MeshPolicy named as default without specifying targets but setting peers mtls mode to STRICT or PERMISSIVE. The MeshPolicy should be like /data/files/validation_examples/401.yaml[].
 
 === Severity
 
@@ -522,7 +522,7 @@ Istio requires the service ports to follow the naming form of 'protocol-suffix' 
 
 === Resolution
 
-Rename the service port name field to follow the form and the traffic will flow correctly. 
+Rename the service port name field to follow the form and the traffic will flow correctly.
 
 === Severity
 
@@ -532,7 +532,7 @@ Error
 
 [source, yaml]
 ----
-<TODO REQUIRES EXAMPLE>
+include::/data/files/validation_examples/701.yaml[]
 ----
 
 === See Also
@@ -563,6 +563,7 @@ Error
 
 [source, yaml]
 ----
+include::/data/files/validation_examples/702.yaml[]
 ----
 
 === See Also
@@ -578,10 +579,11 @@ https://github.com/kiali/kiali/blob/master/business/checkers/services/port_mappi
 Mesh-wide Destination Rule enabling mTLS is missing
 
 === Description
-
+Istio has the ability to define mTLS communications at mesh level. In order to do that, Istio needs one DestinationRule and one MeshPolicy. The DestinationRule configures all the clients of the mesh to use mTLS protocol on their connections. The MeshPolicy defines what authentication methods can be accepted on the workload of the whole mesh.
+If the DestinationRule is not found or doesn't exist and the MeshPolicy is on STRICT mode, all the communication will return 500 errors.
 
 === Resolution
-
+Add a DestinationRule named as default with "*.cluster" host and ISTIO_MUTUAL as tls trafficPolicy mode. The DestinationRule should be like link:/data/files/validation_examples/004.yaml[this, window="_blank"].
 
 === Severity
 
@@ -596,7 +598,9 @@ include::/data/files/validation_examples/401.yaml[]
 
 === See Also
 
-https://github.com/kiali/kiali/tree/master/business/checkers/mesh_policies_checker.go[Validator source code, window="_blank"]
+https://github.com/kiali/kiali/tree/master/business/checkers/meshpolicies/mesh_mtls_checker.go[Validator source code, window="_blank"]
+-
+https://istio.io/docs/tasks/security/authn-policy/#globally-enabling-istio-mutual-tls[Globally enabling Istio mutual TLS, window="_blank"]
 
 [#serviceroles]
 == ServiceRoles and ServiceRoleBindings
@@ -621,11 +625,13 @@ Error
 
 [source, yaml]
 ----
+include::/data/files/validation_examples/501.yaml[]
 ----
 
 === See Also
 
 https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_checker.go[Validator source code, window="_blank"]
+-
 https://istio.io/docs/reference/config/authorization/istio.rbac.v1alpha1/#AccessRule[Istio documentation, window="_blank"]
 
 '''
@@ -636,7 +642,7 @@ ServiceRole can only point to current namespace
 
 === Description
 
-Services can be listed with an exact match, prefix match as well as suffix match. Using "*" refers to all the services in this namespace. Although FQDN can be used, the namespace of the services must be the same as ServiceRole's deployment. 
+Services can be listed with an exact match, prefix match as well as suffix match. Using "*" refers to all the services in this namespace. Although FQDN can be used, the namespace of the services must be the same as ServiceRole's deployment.
 
 === Resolution
 
@@ -650,11 +656,13 @@ Error
 
 [source, yaml]
 ----
+include::/data/files/validation_examples/502.yaml[]
 ----
 
 === See Also
 
 https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_checker.go[Validator source code, window="_blank"]
+-
 https://istio.io/docs/reference/config/authorization/istio.rbac.v1alpha1/#AccessRule[Istio documentation, window="_blank"]
 
 '''
@@ -679,11 +687,13 @@ Error
 
 [source, yaml]
 ----
+include::/data/files/validation_examples/601.yaml[]
 ----
 
 === See Also
 
 https://github.com/kiali/kiali/blob/master/business/checkers/authorization/service_binding_checker.go[Validator source code, window="_blank"]
+-
 https://istio.io/docs/reference/config/authorization/istio.rbac.v1alpha1/#ServiceRoleBinding[Istio documentation, window="_blank"]
 
 [#generic]

--- a/content/documentation/features/validation/index.adoc
+++ b/content/documentation/features/validation/index.adoc
@@ -1,16 +1,17 @@
 ---
-title: "Validation"
+title: "Validations"
 date: 2019-02-26T14:53:00+02:00
 draft: false
 type: "features/validation"
 weight: 1
 ---
 
-= Validation
 :sectnums:
+:linkattrs:
 :toc: left
+:toclevels: 1
 toc::[]
-:toc-title: Validation
+:toc-title: List of validations
 :keywords: Kiali Documentation
 :icons: font
 :imagesdir: /images/documentation/overview/
@@ -24,11 +25,11 @@ More than one Gateway for the same host port combination
 
 === Description
 
-Gateway creates a proxy that will forward the inbound traffic for the exposed ports. If two different gateways expose the same ports for the same host, this creates ambiquity inside Istio as either of these gateways could handle the traffic. This is most likely a configuration error. This check is done across all namespaces the user has access to. 
+Gateway creates a proxy that will forward the inbound traffic for the exposed ports. If two different gateways expose the same ports for the same host, this creates ambiquity inside Istio as either of these gateways could handle the traffic. This is most likely a configuration error. This check is done across all namespaces the user has access to.
 
 === Resolution
 
-Remove the duplicate gateway entries or merge the two gateway definitions into a single one. 
+Remove the duplicate gateway entries or merge the two gateway definitions into a single one.
 
 === Severity
 
@@ -38,13 +39,14 @@ Warning
 
 [source, yaml]
 ----
-include::/files/validation_examples/201.yaml
+include::/public/files/validation_examples/201.yaml[]
 ----
 
 === See Also
 
-https://github.com/kiali/kiali/tree/master/business/checkers/gateways/multi_match_checker.go[Validator source code, window="_blank"]
-https://istio.io/docs/reference/config/istio.networking.v1alpha3/#Gateway[Istio Gateway documentation, window="_blank"]
+https://github.com/kiali/kiali/tree/master/business/checkers/gateways/multi_match_checker.go[Validator source code, window=_blank]
+-
+https://istio.io/docs/reference/config/istio.networking.v1alpha3/#Gateway[Istio Gateway documentation, window=_blank]
 
 '''
 
@@ -60,7 +62,7 @@ Although your traffic might be correctly routed to a workload in other namespace
 
 === Resolution
 
-Deploy the missing workload or fix the selector to target a correct location. 
+Deploy the missing workload or fix the selector to target a correct location.
 
 === Severity
 
@@ -76,6 +78,7 @@ Warning
 === See Also
 
 https://github.com/kiali/kiali/blob/master/business/checkers/gateways/selector_checker.go[Validator source code, window="_blank"]
+-
 https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Gateway[Istio documentation for gateways, window="_blank"]
 
 [#destinationrules]
@@ -105,14 +108,17 @@ Warning
 
 [source, yaml]
 ----
-include::/files/validation_examples/001.yaml
+include::/public/files/validation_examples/001.yaml[]
 ----
 
 === See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/destination_rules/multi_match_checker.go[Validator source code, window="_blank"]
+-
 https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRule[Destination rule documentation, window="_blank"]
+-
 https://github.com/istio/istio/blob/0e9cecab053aab744a7c3a731aacb07fd794d5f9/pilot/pkg/model/push_context.go#L879[Istio source code for merging, window="_blank"]
+-
 https://istio.io/help/ops/traffic-management/deploy-guidelines/#multiple-virtual-services-and-destination-rules-for-the-same-host[Istio documentation: Multiple virtual services and destination rules for the same host, window="_blank"]
 
 '''
@@ -138,12 +144,13 @@ Error
 
 [source, yaml]
 ----
-include::/files/validation_examples/002.yaml
+include::/public/files/validation_examples/002.yaml[]
 ----
 
 === See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/destination_rules/no_host_checker.go[Validator source code, window="_blank"]
+-
 https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRule[Destination rule documentation, window="_blank"]
 
 '''
@@ -174,12 +181,13 @@ Error
 
 [source, yaml]
 ----
-include::/files/validation_examples/003.yaml
+include::/public/files/validation_examples/003.yaml[]
 ----
 
 === See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/destination_rules/no_host_checker.go[Validator source code, window="_blank"]
+-
 https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRule[Destination rule documentation, window="_blank"]
 
 '''
@@ -328,12 +336,13 @@ Error
 
 [source, yaml]
 ----
-include::/files/validation_examples/102.yaml
+include::/public/files/validation_examples/102.yaml[]
 ----
 
 === See Also
 
 https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/no_host_checker.go[Validator source code, window="_blank"]
+-
 https://istio.io/docs/reference/config/istio.networking.v1alpha3/#Destination[Destination documentation, window="_blank"]
 
 '''
@@ -358,7 +367,7 @@ Error
 
 [source, yaml]
 ----
-include::/files/validation_examples/101.yaml
+include::/public/files/validation_examples/101.yaml[]
 ----
 
 === See Also
@@ -385,7 +394,7 @@ Error
 
 [source, yaml]
 ----
-include::/files/validation_examples/105.yaml
+include::/public/files/validation_examples/105.yaml[]
 ----
 
 === See Also
@@ -412,12 +421,13 @@ Error
 
 [source, yaml]
 ----
-include::/files/validation_examples/103.yaml
+include::/public/files/validation_examples/103.yaml[]
 ----
 
 === See Also
 
 https://github.com/istio/istio/blob/0e9cecab053aab744a7c3a731aacb07fd794d5f9/pilot/pkg/model/validation.go#L1628[Istio validation for route types, window="_blank"]
+-
 https://github.com/kiali/kiali/blob/master/business/checkers/virtual_services/no_host_checker.go[Validator source code, window="_blank"]
 
 '''
@@ -442,7 +452,7 @@ Warning
 
 [source, yaml]
 ----
-include::/files/validation_examples/104.yaml
+include::/public/files/validation_examples/104.yaml[]
 ----
 
 === See Also
@@ -469,7 +479,7 @@ Error
 
 [source, yaml]
 ----
-include::/files/validation_examples/104.yaml
+include::/public/files/validation_examples/104.yaml[]
 ----
 
 === See Also
@@ -507,6 +517,7 @@ Error
 === See Also
 
 https://github.com/kiali/kiali/blob/master/business/checkers/services/port_mapping_checker.go[Validator source code, window="_blank"]
+-
 https://github.com/istio/istio.io/blob/master/content/help/faq/traffic-management/naming-port-convention.md[Istio documentation port naming convention, window="_blank"]
 
 '''
@@ -559,7 +570,7 @@ Error
 
 [source, yaml]
 ----
-include::/files/validation_examples/401.yaml
+include::/public/files/validation_examples/401.yaml[]
 ----
 
 === See Also

--- a/content/documentation/features/validation/index.adoc
+++ b/content/documentation/features/validation/index.adoc
@@ -72,7 +72,7 @@ Warning
 
 [source, yaml]
 ----
-<TODO REQUIRES EXAMPLE>
+include::/data/files/validation_examples/202.yaml[]
 ----
 
 === See Also
@@ -200,7 +200,7 @@ Istio has the ability to define mTLS communications at mesh level. In order to d
 If the MeshPolicy is not found or doesn't exist and the mesh-wide DestinationRule is on ISTIO_MUTUAL mode, all the communication will return 500 errors.
 
 === Resolution
-Add a MeshPolicy named as default without specifying targets but setting peers mtls mode to STRICT or PERMISSIVE. The MeshPolicy should be like /data/files/validation_examples/401.yaml[].
+Add a MeshPolicy named as default without specifying targets but setting peers mtls mode to STRICT or PERMISSIVE. The MeshPolicy should be like link:/data/files/validation_examples/401.yaml[this, window="_blank"].
 
 === Severity
 
@@ -226,9 +226,12 @@ mTLS settings of a non-local Destination Rule are overridden
 
 === Description
 
+Istio allows you to define DestinationRule at three different levels: mesh, namespace and service level. A mesh may have multiple DestinationRules. In case of having two DestinationRules on the first one is at a lower level than the second one, the first one overrides the TLS values of the second one.
 
 === Resolution
 
+This validation aims to warn Kiali users that they may be disabling/enabling mTLS from the higher DestinationRule.
+Merging the TLS settings to one of the DestinationRules is the only way to fix this validation. However, this is a valid scenario so it might be impossible to remove this warning.
 
 === Severity
 
@@ -280,10 +283,10 @@ https://istio.io/docs/tasks/security/authn-policy/#enable-mutual-tls-per-namespa
 Policy with TLS strict mode found, it should be permissive
 
 === Description
-
+Istio needs both a DestinationRule and Policy to enable mTLS communications. The Policy will configure the authentication method accepted for all the targeted workloads. The DestinationRule will define which is the authentication method that the clients of specific workloads has to start communications with.
 
 === Resolution
-
+Kiali has found that there is a DestinationRule sending traffic without mTLS authentication method. There are two different ways to fix this situation. You can either change the Policy applying to PERMISSIVE mode or change the DestinationRule to start communications using mTLS.
 
 === Severity
 
@@ -308,10 +311,12 @@ https://istio.io/docs/tasks/security/authn-policy/#enable-mutual-tls-per-namespa
 MeshPolicy enabling mTLS found, permissive policy is needed
 
 === Description
+Istio needs both a DestinationRule and Policy to enable mTLS communications. The Policy will configure the authentication method accepted for all the targeted workloads. The DestinationRule will define which is the authentication method that the clients of specific workloads has to start communications with.
 
+Kiali found a DestinationRule starting communications without TLS but there was a MeshPolicy allowing services to accept only requests in mTLS.
 
 === Resolution
-
+There are two ways to fix this situation. You can either change the MeshPolicy to enable PERMISSIVE mode to all the workloads in the mesh or change the DestinatonRule to enable mTLS instead of disabling it (change the mode to ISTIO_MUTUAL).
 
 === Severity
 
@@ -428,7 +433,7 @@ VirtualService doesn't define any route protocol
 
 === Description
 
-VirtualService is a defined set of rules for routing certain type of traffic to target destinations with rules. At least one, 'tcp', 'http' or 'tls' must be defined. 
+VirtualService is a defined set of rules for routing certain type of traffic to target destinations with rules. At least one, 'tcp', 'http' or 'tls' must be defined.
 
 === Resolution
 
@@ -463,7 +468,7 @@ More than one Virtual Service for same host
 
 === Resolution
 
-This is valid configuration only if VirtualService is bound to a gateway, sidecars do not accept this behavior. There are several caveats when using this method and defining the same parts in multiple Virtual Service definitions is not recommended. While Istio will merge the configuration, it does not guarantee any ordering for cross-resource merging and only the first seen configuration is applied (rest ignored). As recommended, each VS definition shold have a 'catch-all' situation, but this can only be defined in a definition affecting the same host. 
+This is valid configuration only if VirtualService is bound to a gateway, sidecars do not accept this behavior. There are several caveats when using this method and defining the same parts in multiple Virtual Service definitions is not recommended. While Istio will merge the configuration, it does not guarantee any ordering for cross-resource merging and only the first seen configuration is applied (rest ignored). As recommended, each VS definition shold have a 'catch-all' situation, but this can only be defined in a definition affecting the same host.
 
 === Severity
 

--- a/content/documentation/overview/validation/index.adoc
+++ b/content/documentation/overview/validation/index.adoc
@@ -1,0 +1,476 @@
+---
+title: "Validation"
+date: 2019-02-26T14:53:00+02:00
+draft: false
+type: "documentation/overview"
+weight: 1
+---
+
+= Validation
+:sectnums:
+:toc: left
+toc::[]
+:toc-title: Validation
+:keywords: Kiali Documentation
+:icons: font
+:imagesdir: /images/documentation/overview/
+
+[#gateways]
+== Gateways
+
+<todo some sort of list/table structure?>
+
+=== Error message
+
+More than one Gateway for the same host port combination
+
+=== Description
+
+Gateway creates a proxy that will forward the inbound traffic for the exposed ports. If two different gateways expose the same ports for the same host, this creates ambiquity inside Istio as either of these gateways could handle the traffic. This is most likely a configuration error. This check is done across all namespaces the user has access to. 
+
+=== Resolution
+
+Remove the duplicate gateway entries or merge the two gateway definitions into a single one. 
+
+=== Severity
+
+Warning
+
+=== Example
+
+[source, yaml]
+----
+include::/files/validation_examples/201.yaml
+----
+
+=== See Also
+
+https://github.com/kiali/kiali/tree/master/business/checkers/gateways/multi_match_checker.go[Validator source code, window="_blank"]
+https://istio.io/docs/reference/config/istio.networking.v1alpha3/#Gateway[Istio Gateway documentation, window="_blank"]
+
+'''
+
+=== Error message
+
+Port name must follow <protocol>[-suffix] form
+
+=== Description
+
+Istio requires the service ports to follow the naming form of 'protocol-suffix' where the '-suffix' part is optional. If the naming does not match this form (or is undefined), Istio treats all the traffic TCP instead of the defined protocol in the definition. Dash is a required character between protocol and suffix. For example, 'http2foo' is not valid, while 'http2-foo' is (for http2 protocol).
+
+=== Resolution
+
+Rename the service port name field to follow the form and the traffic will flow correctly. 
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+<TODO REQUIRES EXAMPLE>
+----
+
+=== See Also
+
+https://github.com/kiali/kiali/blob/master/business/checkers/gateways/port_checker.go[Validator source code, window="_blank"]
+https://github.com/istio/istio.io/blob/master/content/help/faq/traffic-management/naming-port-convention.md[Istio documentation port naming convention, window="_blank"]
+
+[#destinationrules]
+== Destination rules
+
+=== Error message
+
+More than one Destination Rule for the same host subset combination
+
+=== Description
+
+Istio applies traffic rules for services after the routing has happened. These can include different settings such as connection pooling, circuit breakers, load balancing, detection, etc. Istio can define the same rules for all services under a host or different rules for different versions of the service. 
+
+This validation warning could be a result of duplicate definition of the same subsets as well as from rules that apply to all subsets. Also, a combination of one DR (Destination Rule) applying to all subsets and another defining behavior for only some subsets will trigger this validation warning.
+
+Istio will silently ignore the duplicate subsets and merge these destination rules without letting the user know. Only the first seen rule (by Istio) per subset is used and information from multiple definitions is not merged. While the routing *might* work correctly, this is most likely a configuration error. It may lead to a undesired behavior if one of the offending rules is removed or modified and that is probably not the intention of the deployer of this service. Also, if the two offending destination rules have different policies for traffic routing the wrong one might be used.
+
+=== Resolution
+
+Either merge the settings to a single Destination Rule or split the subsets in such a way that they do not interleave. This ensures that the routing behavior stays consistent.
+
+=== Severity
+
+Warning
+
+=== Example
+
+[source, yaml]
+----
+include::/files/validation_examples/001.yaml
+----
+
+=== See Also
+
+https://github.com/kiali/kiali/tree/master/business/checkers/destination_rules/multi_match_checker.go[Validator source code, window="_blank"]
+https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRule[Destination rule documentation, window="_blank"]
+https://github.com/istio/istio/blob/0e9cecab053aab744a7c3a731aacb07fd794d5f9/pilot/pkg/model/push_context.go#L879[Istio source code for merging, window="_blank"]
+https://istio.io/help/ops/traffic-management/deploy-guidelines/#multiple-virtual-services-and-destination-rules-for-the-same-host[Istio documentation: Multiple virtual services and destination rules for the same host, window="_blank"]
+
+'''
+=== Error message
+
+This host has no matching workloads
+
+=== Description
+
+Istio applies traffic rules for services after the routing has happened. These can include different settings such as connection pooling, circuit breakers, load balancing, detection, etc. Istio can define the same rules for all services under a host or different rules for different versions of the service. The host must a service that is defined in the platform's service registry or as a ServiceEntry. Short names are extended to include '.namespace.cluster' using the namespace of the destination rule, not the service itself. FQDN is evaluated as is. It is recommended to use the FQDN to prevent any confusion.
+
+If the host is not found, Istio will ignore the defined rules.
+
+=== Resolution
+
+Correct the host to point to a correct service (in this namespace or with FQDN to other namespaces) or deploy the missing service to the mesh.
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+include::/files/validation_examples/002.yaml
+----
+
+=== See Also
+
+https://github.com/kiali/kiali/tree/master/business/checkers/destination_rules/no_host_checker.go[Validator source code, window="_blank"]
+https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRule[Destination rule documentation, window="_blank"]
+
+'''
+
+=== Error message
+
+This subset’s labels are not found in any matching host
+
+=== Description
+
+Istio applies traffic rules for services after the routing has happened. These can include different settings such as connection pooling, circuit breakers, load balancing, detection, etc. Istio can define the same rules for all services under a host or different rules for different versions of the service. The host must a service that is defined in the platform's service registry or as a ServiceEntry. Short names are extended to include '.namespace.cluster' using the namespace of the destination rule, not the service itself. FQDN is evaluated as is. It is recommended to use the FQDN to prevent any confusion.
+
+Subsets can override the global settings defined in the DR for a host. 
+
+If the host is not found, Istio will ignore the defined rules.
+
+=== Resolution
+
+Correct the host to point to a correct service (in this namespace or with FQDN to other namespaces) or deploy the missing service to the mesh. If the hostname is equal to the one used otherwise in the DR, consider removing the duplicate host resolution.
+
+Also, verify that the labels are correctly matching a workload with the intended service.
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+include::/files/validation_examples/003.yaml
+----
+
+=== See Also
+
+https://github.com/kiali/kiali/tree/master/business/checkers/destination_rules/no_host_checker.go[Validator source code, window="_blank"]
+https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRule[Destination rule documentation, window="_blank"]
+
+'''
+=== Error message
+
+MeshPolicy enabling mTLS is missing
+
+=== Description
+
+
+=== Resolution
+
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+include::/files/validation_examples/004.yaml
+----
+
+=== See Also
+
+https://github.com/kiali/kiali/blob/master/business/checkers/destinationrules/meshwide_mtls_checker.go[Validator source code, window="_blank"]
+https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRule[Destination rule documentation, window="_blank"]
+
+
+'''
+=== Error message
+
+mTLS settings of a non-local Destination Rule are overridden
+
+=== Description
+
+
+=== Resolution
+
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+include::/files/validation_examples/004.yaml
+----
+
+=== See Also
+
+https://github.com/kiali/kiali/blob/master/business/checkers/destinationrules/meshwide_mtls_checker.go[Validator source code, window="_blank"]
+https://istio.io/docs/reference/config/istio.networking.v1alpha3/#DestinationRule[Destination rule documentation, window="_blank"]
+
+
+
+'''
+
+[#virtualservices]
+== VirtualServices
+
+=== Error message
+
+DestinationWeight on route doesn't have a valid service (host not found)
+
+=== Description
+
+VirtualService will route matching requests to a service inside your mesh. Routing can also match a subset of traffic to a certain version of it for example. Any service inside the mesh must be targeted by its name, the IP address are only allowed for hosts defined through a Gateway. Host must be in a short name or FQDN format. Short name will evaluate to VS' namespace, regardless of where the actual service might be placed.
+
+If the host is not found, Istio will ignore the defined rules. However, if a subset with a Destination Rule is not found it will affect all the subsets and all the routings. As such, care must be taken that the Destination rule is available before deploying the Virtual Service.
+
+=== Resolution
+
+Correct the host to point to a correct service (in this namespace or with FQDN to other namespaces), deploy the missing service to the mesh or remove the configuration linking to that non-existing service.
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+include::/files/validation_examples/102.yaml
+----
+
+=== See Also
+
+https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/no_host_checker.go[Validator source code, window="_blank"]
+https://istio.io/docs/reference/config/istio.networking.v1alpha3/#Destination[Destination documentation, window="_blank"]
+
+'''
+
+=== Error message
+
+VirtualService is pointing to a non-existent gateway
+
+=== Description
+
+By default, VirtualService routes will apply to sidecars inside the mesh. The gateway field allows to override that default and if anything is defined, the VS will only apply to those selected. 'mesh' is a reserved gateway name and means all the sidecars in the mesh. If one wishes to apply the VS to gateways as well as the sidecars, the 'mesh' keyword must be used as one of the gateways. Incorrect gateways will mean that the VS is not applied correctly.
+
+=== Resolution
+
+Fix the possible gateway field to target all necessary gateways or remove the field if the default 'mesh' is enough.
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+include::/files/validation_examples/101.yaml
+----
+
+=== See Also
+
+https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/no_gateway_checker.go[Validator source code, window="_blank"]
+
+'''
+
+=== Error message
+
+Subset not found
+
+=== Description
+
+
+=== Resolution
+
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+include::/files/validation_examples/105.yaml
+----
+
+=== See Also
+
+https://github.com/kiali/kiali/tree/master/business/checkers/virtual_services/subset_presence_checker.go[source code, window="_blank"]
+
+=== Error message
+
+VirtualService doesn't define any route protocol
+
+=== Description
+
+VirtualService is a defined set of rules for routing certain type of traffic to target destinations with rules. At least one, 'tcp', 'http' or 'tls' must be defined. 
+
+=== Resolution
+
+This appears to be a configuration error. Fix the definition.
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+include::/files/validation_examples/103.yaml
+----
+
+=== See Also
+
+https://github.com/istio/istio/blob/0e9cecab053aab744a7c3a731aacb07fd794d5f9/pilot/pkg/model/validation.go#L1628[Istio validation for route types, window="_blank"]
+https://github.com/kiali/kiali/blob/master/business/checkers/virtual_services/no_host_checker.go[Validator source code, window="_blank"]
+
+'''
+
+=== Error message
+
+More than one Virtual Service for same host
+
+=== Description
+
+
+
+=== Resolution
+
+This is valid configuration only if VirtualService is bound to a gateway, sidecars do not accept this behavior. There are several caveats when using this method and defining the same parts in multiple Virtual Service definitions is not recommended. While Istio will merge the configuration, it does not guarantee any ordering for cross-resource merging and only the first seen configuration is applied (rest ignored). As recommended, each VS definition shold have a 'catch-all' situation, but this can only be defined in a definition affecting the same host. 
+
+=== Severity
+
+Warning
+
+=== Example
+
+[source, yaml]
+----
+include::/files/validation_examples/104.yaml
+----
+
+=== See Also
+
+https://istio.io/help/ops/traffic-management/deploy-guidelines/#multiple-virtual-services-and-destination-rules-for-the-same-host[Istio documention Multiple virtual services for the same host, window="_blank"]
+
+'''
+
+=== Error message
+
+Destination field is mandatory
+
+=== Description
+
+
+
+=== Resolution
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+include::/files/validation_examples/104.yaml
+----
+
+=== See Also
+
+https://istio.io/help/ops/traffic-management/deploy-guidelines/#multiple-virtual-services-and-destination-rules-for-the-same-host[Istio documention Multiple virtual services for the same host, window="_blank"]
+
+
+[#serviceentries]
+== ServiceEntries
+
+=== Error message
+
+Port name must follow <protocol>[-suffix] form
+
+=== Description
+
+Istio requires the service ports to follow the naming form of 'protocol-suffix' where the '-suffix' part is optional. If the naming does not match this form (or is undefined), Istio treats all the traffic TCP instead of the defined protocol in the definition. Dash is a required character between protocol and suffix. For example, 'http2foo' is not valid, while 'http2-foo' is (for http2 protocol).
+
+=== Resolution
+
+Rename the service port name field to follow the form and the traffic will flow correctly. 
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+<TODO REQUIRES EXAMPLE>
+----
+
+=== See Also
+
+https://github.com/kiali/kiali/blob/master/business/checkers/serviceentries/port_checker.go[Validator source code, window="_blank"]
+https://github.com/istio/istio.io/blob/master/content/help/faq/traffic-management/naming-port-convention.md[Istio documentation port naming convention, window="_blank"]
+
+
+[#meshpolicies]
+== Mesh Policies
+
+=== Error message
+
+Mesh-wide Destination Rule enabling mTLS is missing
+
+=== Description
+
+
+=== Resolution
+
+
+=== Severity
+
+Error
+
+=== Example
+
+[source, yaml]
+----
+include::/files/validation_examples/401.yaml
+----
+
+=== See Also
+
+https://github.com/kiali/kiali/tree/master/business/checkers/mesh_policies_checker.go[Validator source code, window="_blank"]

--- a/data/files/validation_examples/001.yaml
+++ b/data/files/validation_examples/001.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews-dr1
+spec:
+  host: reviews
+  trafficPolicy:
+    loadBalancer:
+      simple: RANDOM
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+  - name: v3
+    labels:
+      version: v3
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews-dr2
+spec:
+  host: reviews
+  trafficPolicy:
+    loadBalancer:
+      simple: RANDOM
+  subsets:
+  - name: v1
+    labels:
+      version: v1

--- a/data/files/validation_examples/002.yaml
+++ b/data/files/validation_examples/002.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews
+spec:
+  host: notpresent
+  trafficPolicy:
+    loadBalancer:
+      simple: RANDOM
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+  - name: v3
+    labels:
+      version: v3

--- a/data/files/validation_examples/003.yaml
+++ b/data/files/validation_examples/003.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews
+spec:
+  host: reviews
+  trafficPolicy:
+    loadBalancer:
+      simple: RANDOM
+  subsets:
+  - name: v1
+    labels:
+      version: v10
+  - name: v2
+    labels:
+      notfoundlabel: v2
+  - name: v3
+    labels:
+      version: v3

--- a/data/files/validation_examples/004.yaml
+++ b/data/files/validation_examples/004.yaml
@@ -1,0 +1,10 @@
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "default"
+  namespace: "istio-system"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/data/files/validation_examples/005.yaml
+++ b/data/files/validation_examples/005.yaml
@@ -1,0 +1,30 @@
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "default"
+  namespace: "istio-system"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews
+spec:
+  host: reviews
+  trafficPolicy:
+    loadBalancer:
+      simple: RANDOM
+  subsets:
+  - name: v1
+    labels:
+      version: v10
+  - name: v2
+    labels:
+      version: v2
+  - name: v3
+    labels:
+      version: v3

--- a/data/files/validation_examples/006.yaml
+++ b/data/files/validation_examples/006.yaml
@@ -1,0 +1,10 @@
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "enable-mtls"
+  namespace: "bookinfo"
+spec:
+  host: "*.bookinfo.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/data/files/validation_examples/007.yaml
+++ b/data/files/validation_examples/007.yaml
@@ -1,0 +1,20 @@
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "disable-mtls"
+  namespace: "bookinfo"
+spec:
+  host: "*.bookinfo.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "default"
+  namespace: "bookinfo"
+spec:
+  peers:
+  - mtls:
+      mode: STRICT

--- a/data/files/validation_examples/008.yaml
+++ b/data/files/validation_examples/008.yaml
@@ -1,0 +1,19 @@
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "default"
+  namespace: "bookinfo"
+spec:
+  host: "*.bookinfo.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "MeshPolicy"
+metadata:
+  name: "default"
+spec:
+  peers:
+  - mtls:
+      mode: STRICT

--- a/data/files/validation_examples/101.yaml
+++ b/data/files/validation_examples/101.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: details
+spec:
+  hosts:
+  - details
+  gateways:
+  - bookinfo-gateway
+  http:
+  - route:
+    - destination:
+        host: details
+        subset: v2

--- a/data/files/validation_examples/102.yaml
+++ b/data/files/validation_examples/102.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: details
+spec:
+  hosts:
+  - details
+  http:
+  - route:
+    - destination:
+        host: nonexistentsvc
+        subset: v2

--- a/data/files/validation_examples/103.yaml
+++ b/data/files/validation_examples/103.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: details
+spec:
+  hosts:
+  - details

--- a/data/files/validation_examples/104.yaml
+++ b/data/files/validation_examples/104.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews
+spec:
+  hosts:
+    - reviews
+  http:
+  - route:
+    - destination:
+        host: reviews
+        subset: v1
+      weight: 90
+    - destination:
+        host: reviews
+        subset: v2
+      weight: 10
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-cp
+spec:
+  hosts:
+    - reviews
+  http:
+  - route:
+    - destination:
+        host: reviews
+        subset: v1
+      weight: 90
+    - destination:
+        host: reviews
+        subset: v2
+      weight: 10

--- a/data/files/validation_examples/105.yaml
+++ b/data/files/validation_examples/105.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews
+spec:
+  hosts:
+    - reviews
+  http:
+  - route:
+    - destination:
+        host: reviews
+        subset: nosubset
+      weight: 90
+    - destination:
+        host: reviews
+        subset: v2
+      weight: 10

--- a/data/files/validation_examples/106.yaml
+++ b/data/files/validation_examples/106.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews
+spec:
+  hosts:
+    - reviews
+  http:
+  - route:
+    - destination:
+    - destination:
+        host: reviews
+        subset: v2
+      weight: 10

--- a/data/files/validation_examples/107.yaml
+++ b/data/files/validation_examples/107.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews
+spec:
+  hosts:
+    - reviews
+  http:
+  - route:
+    - destination:
+        host: reviews
+        subset: v1
+      weight: abc
+    - destination:
+        host: reviews
+        subset: v2
+      weight: 20

--- a/data/files/validation_examples/108.yaml
+++ b/data/files/validation_examples/108.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews
+spec:
+  hosts:
+    - reviews
+  http:
+  - route:
+    - destination:
+        host: reviews
+        subset: v1
+      weight: 110
+    - destination:
+        host: reviews
+        subset: v2
+      weight: 20

--- a/data/files/validation_examples/109.yaml
+++ b/data/files/validation_examples/109.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews
+spec:
+  hosts:
+    - reviews
+  http:
+  - route:
+    - destination:
+        host: reviews
+        subset: v1
+      weight: 90
+    - destination:
+        host: reviews
+        subset: v2
+      weight: 20

--- a/data/files/validation_examples/110.yaml
+++ b/data/files/validation_examples/110.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews
+spec:
+  hosts:
+    - reviews
+  http:
+  - route:
+    - destination:
+        host: reviews
+        subset: v1
+      weight: 90
+    - destination:
+        host: reviews
+        subset: v2

--- a/data/files/validation_examples/201.yaml
+++ b/data/files/validation_examples/201.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: bookinfo-gateway
+  namespace: bookinfo
+spec:
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: bookinfo-gateway-copy
+  namespace: bookinfo2
+spec:
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---

--- a/data/files/validation_examples/202.yaml
+++ b/data/files/validation_examples/202.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: bookinfo-gateway
+  namespace: bookinfo
+spec:
+  selector:
+    app: nonexisting # workload doesn't exist in the namespace
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"

--- a/data/files/validation_examples/401.yaml
+++ b/data/files/validation_examples/401.yaml
@@ -1,0 +1,8 @@
+# Make sure there isn't any DestinationRule enabling meshwide mTLS
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "MeshPolicy"
+metadata:
+  name: "default"
+spec:
+  peers:
+  - mtls: {}

--- a/data/files/validation_examples/501.yaml
+++ b/data/files/validation_examples/501.yaml
@@ -1,0 +1,12 @@
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: details-reviews-viewer
+  namespace: bookinfo
+spec:
+  rules:
+  - services: ["wrongservice.bookinfo.svc.cluster.local", "reviews.bookinfo.svc.cluster.local"]
+    methods: ["GET"]
+    constraints:
+      - key: "destination.labels[version]"
+        values: ["v1"]

--- a/data/files/validation_examples/502.yaml
+++ b/data/files/validation_examples/502.yaml
@@ -1,0 +1,12 @@
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: details-reviews-viewer
+  namespace: bookinfo
+spec:
+  rules:
+  - services: ["details.test.svc.cluster.local", "reviews.bookinfo.svc.cluster.local"]
+    methods: ["GET"]
+    constraints:
+      - key: "destination.labels[version]"
+        values: ["v1"]

--- a/data/files/validation_examples/601.yaml
+++ b/data/files/validation_examples/601.yaml
@@ -1,0 +1,24 @@
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: details-reviews-viewer
+  namespace: default
+spec:
+  rules:
+  - services: ["details.bookinfo.svc.cluster.local", "reviews.bookinfo.svc.cluster.local"]
+    methods: ["GET"]
+    constraints:
+      - key: "destination.labels[version]"
+        values: ["v1"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRoleBinding
+metadata:
+  name: bind-details-reviews
+  namespace: bookinfo
+spec:
+  subjects:
+  - user: "cluster.local/ns/bookinfo/sa/bookinfo-productpage"
+  roleRef:
+    kind: ServiceRole
+    name: "details-reviews-viewer"

--- a/data/files/validation_examples/701.yaml
+++ b/data/files/validation_examples/701.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratings-java-svc
+  namespace: bookinfo
+  labels:
+    app: ratings
+    service: ratings-svc
+spec:
+  ports:
+  - port: 9080
+    name: wrong-http
+  selector:
+    app: ratings-java
+    version: v1

--- a/data/files/validation_examples/702.yaml
+++ b/data/files/validation_examples/702.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratings-java-svc
+  namespace: ratings-java
+  labels:
+    app: ratings
+    service: ratings-svc
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: ratings-java
+    version: v1
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: ratings-java
+  namespace: ratings-java
+  labels:
+    app: ratings-java
+    version: v1
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+         sidecar.istio.io/inject: "true"
+      labels:
+        app: ratings-java
+        version: v1
+    spec:
+      containers:
+      - name: ratings-java
+        image: pilhuhn/ratings-java:f
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080

--- a/static/css/kiali_style.css
+++ b/static/css/kiali_style.css
@@ -380,6 +380,10 @@ code {
   list-style: none;
 }
 
+.sectlevel2 {
+  margin-left: 15px;
+}
+
 div.kiali-video {
   height: 100vh;
   visibility: visible;


### PR DESCRIPTION
This is still work in progress and is only linked from the top level menu under overview. While this documentation format works fine in the Github's rendering (and normal AsciiDoc) it does not work with our layout.

For that reason, I'd be happy to receive some ideas how to make this readable and how to make those inclusions work. I'd really want to add in the further work some more examples without embedding and copying the stuff to this document.

Also, mTLS stuff is missing, @xeviknal hopefully provides the text for those parts. I also don't want old deprecated Galley catched stuff to be included.