### PR TITLE
Small command mistake in uninstall section

### DIFF
--- a/content/documentation/getting-started/index.adoc
+++ b/content/documentation/getting-started/index.adoc
@@ -154,7 +154,7 @@ To uninstall the Kiali Operator, simply remove the `kiali-operator` namespace al
 
 [source,bash]
 ----
-oc delete namespace -n kiali-operator
+oc delete namespace kiali-operator
 ----
 
 == Additional Notes


### PR DESCRIPTION
Fixing small error type in Uninstall section:

> oc delete namespace kiali-operator

instead of 

> oc delete namespace -n kiali-operator