### PR TITLE
KIALI-3060 Reduce developer API cropping

### DIFF
--- a/scripts/template.hbs
+++ b/scripts/template.hbs
@@ -9,6 +9,7 @@ weight = 8
 <style>
     .menu-content {
         top: 60px !important;
+        width: 330px !important;
         height: calc(100vh - 60px);
     }
 </style>

--- a/static/css/kiali_style.css
+++ b/static/css/kiali_style.css
@@ -409,6 +409,8 @@ div.kiali-video {
 /* Last articles in medium */
 
 .blog {
+  margin-left: auto;
+  margin-right: auto;
   width: 1120px;
 }
 

--- a/themes/canvas/static/style.css
+++ b/themes/canvas/static/style.css
@@ -95,19 +95,19 @@
 -----------------------------------------------------------------*/
 
 @media (min-width: 576px) {
-	.container { max-width: 540px; }
+	.container { max-width: 90%; }
 }
 
 @media (min-width: 768px) {
-	.container { max-width: 750px; }
+	.container { max-width: 90%; }
 }
 
 @media (min-width: 992px) {
-	.container { max-width: 970px; }
+	.container { max-width: 90%; }
 }
 
 @media (min-width: 1200px) {
-	.container { max-width: 1170px; }
+	.container { max-width: 90%; }
 }
 
 


### PR DESCRIPTION
- Increase the dev API menu width to prevent cropping (at least for today's entries)
- Increase the overall width of usable space (to 90%) for all of the pages using the
  current theme.

Note: to do a test build of this you need to pull the branch and then:
> make build
> make serve

Before:
![image](https://user-images.githubusercontent.com/2104052/60531489-1d925680-9cc9-11e9-93c2-350295b00585.png)
After:
![image](https://user-images.githubusercontent.com/2104052/60531119-41a16800-9cc8-11e9-86ea-808cdabab9a0.png)
