### PR TITLE
Add Netlify badges

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,12 @@
 :toc: macro
 :toc-title:
-toc::[]
 
 = Kiali.io
+
+[![Netlify Status](https://api.netlify.com/api/v1/badges/05b3eed1-6ea2-41a1-8b64-c76bda241be6/deploy-status)](https://app.netlify.com/sites/kiali/deploys)
+
+toc::[]
+
 This repository contains the source code for https://kiali.io website.
 
 The website is written in link:https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[AsciiDoc], generated using link:https://gohugo.io/[Hugo], and hosted on GitHub.

--- a/themes/kiali/layouts/partials/mastfoot.html
+++ b/themes/kiali/layouts/partials/mastfoot.html
@@ -1,4 +1,12 @@
 <footer id="footer">
+  <!-- Netlify badge. Don't remove while the website is hosted by Netlify on the Open source plan.
+    See https://www.netlify.com/legal/open-source-policy/ -->
+  <section id="footer-netlify">
+    <a href="https://www.netlify.com">
+      <img src="https://www.netlify.com/img/global/badges/netlify-dark.svg"/>
+    </a>
+  </section>
+
   <!-- Social icons -->
   <section id="footer-social-icons">
     <a href="https://medium.com/kialiproject" target="_blank"

--- a/themes/kiali/static/css/kiali.css
+++ b/themes/kiali/static/css/kiali.css
@@ -617,6 +617,10 @@ body > header div.search-container input:valid ~ i.search-icon {
   color: var(--kiali-font-color);
 }
 
+#footer-netlify {
+  float: right;
+}
+
 /* Magnific Popup */
 div.kiali-video {
   height: 100vh;


### PR DESCRIPTION
The Open source plan of Netlify requires to place a badge in the
website. This PR is adding the badge at the footer.

Also, a deploy badge is added in README.md to see the result of the last
build and have access to the logs.