### PR TITLE
Add anchors to each section title, for better traffic forwarding

### DIFF
--- a/content/contribute/index.adoc
+++ b/content/contribute/index.adoc
@@ -6,6 +6,7 @@ menu:
   main:
     weight: 30
 ---
+
 :sectlinks:
 
 == Kiali is Open Source

--- a/content/contribute/index.adoc
+++ b/content/contribute/index.adoc
@@ -6,6 +6,7 @@ menu:
   main:
     weight: 30
 ---
+:sectlinks:
 
 == Kiali is Open Source
 

--- a/content/documentation/architecture.adoc
+++ b/content/documentation/architecture.adoc
@@ -5,6 +5,8 @@ draft: false
 weight: 4
 ---
 
+:sectlinks:
+
 = Kiali architecture
 :imagesdir: /images/documentation/architecture
 

--- a/content/documentation/distributed-tracing/index.adoc
+++ b/content/documentation/distributed-tracing/index.adoc
@@ -7,6 +7,7 @@ weight: 6
 ---
 
 :linkattrs:
+:sectlinks:
 
 = Tracing your application in Kiali
 :sectnums:

--- a/content/documentation/features/index.adoc
+++ b/content/documentation/features/index.adoc
@@ -12,6 +12,7 @@ menu:
     weight: 1
 ---
 
+:sectlinks:
 :linkattrs:
 :toc: macro
 :toc-title: Kiali Features

--- a/content/documentation/getting-started/index.adoc
+++ b/content/documentation/getting-started/index.adoc
@@ -17,6 +17,7 @@ menu:
 :keywords: Kiali Getting Started
 :icons: font
 :imagesdir: /images/gettingstarted/
+:sectlinks:
 
 toc::[]
 

--- a/content/documentation/glossary/concepts/index.adoc
+++ b/content/documentation/glossary/concepts/index.adoc
@@ -4,6 +4,8 @@ date: 2018-06-20T19:04:38+02:00
 draft: false
 ---
 
+:sectlinks:
+
 = Kiali Concepts Glossary
 :sectnums:
 :toc: left

--- a/content/documentation/glossary/networking/index.adoc
+++ b/content/documentation/glossary/networking/index.adoc
@@ -4,6 +4,8 @@ date: 2018-06-20T19:04:38+02:00
 draft: false
 ---
 
+:sectlinks:
+
 = Kiali Networking Glossary
 :sectnums:
 :toc: left

--- a/content/documentation/glossary/observability/index.adoc
+++ b/content/documentation/glossary/observability/index.adoc
@@ -4,6 +4,8 @@ date: 2018-06-20T19:04:38+02:00
 draft: false
 ---
 
+:sectlinks:
+
 = Kiali Observability Glossary
 :sectnums:
 :toc: left

--- a/content/documentation/runtimes-monitoring/index.adoc
+++ b/content/documentation/runtimes-monitoring/index.adoc
@@ -7,6 +7,7 @@ weight: 5
 ---
 
 :linkattrs:
+:sectlinks:
 
 = Monitoring your application runtimes
 :sectnums:

--- a/content/documentation/validations/index.adoc
+++ b/content/documentation/validations/index.adoc
@@ -7,6 +7,7 @@ weight: 1
 ---
 
 :sectnums:
+:sectlinks:
 :linkattrs:
 :toc: left
 :toclevels: 2

--- a/content/faq/general/how-can-i-get-in-touch.adoc
+++ b/content/faq/general/how-can-i-get-in-touch.adoc
@@ -3,6 +3,7 @@ title: How can I get in touch?
 weight: 60
 ---
 :icons: font
+:sectlinks:
 
 * Follow our https://twitter.com/kialiproject[twitter] account.
 * Watch our videos using https://www.youtube.com/channel/UCcm2NzDN_UCZKk2yYmOpc5w[youtube].

--- a/content/faq/general/how-contribute.adoc
+++ b/content/faq/general/how-contribute.adoc
@@ -3,6 +3,7 @@ title: How can I contribute?
 weight: 30
 ---
 :icons: font
+:sectlinks:
 
 Contributions are highly welcome. We look forward to community feedback, additions, and bug reports.
 

--- a/themes/kiali/layouts/faq/single.html
+++ b/themes/kiali/layouts/faq/single.html
@@ -30,7 +30,11 @@
       </nav>
 
       {{ range $q := $sorted_questions }}
-        <h2 id="{{ $q.File.BaseFileName | urlize }}" class="question">{{ $q.Title }}</h2>
+        <h2 id="{{ $q.File.BaseFileName | urlize }}" class="question">
+          <a class="link" href="#{{ $q.File.BaseFileName | urlize }}">
+            {{ $q.Title }}
+          </a>
+        </h2>
         {{ $q.Content }}
       {{ end }}
     </main>


### PR DESCRIPTION
Adding anchor links to sections. Ease the job of sharing only one section of the page.
The current scenario for me is for sharing the events form.

Closes: kiali/kiali#1526