### PR TITLE
Sitemap.xml fix: need baseURL set to be compliant

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,7 @@
 languageCode = "en-us"
 title = "Kiali"
 theme = "kiali"
+baseURL = "https://kiali.io"
 
 [params]
     custom_css = [


### PR DESCRIPTION
Google wants us to have a sitemap.xml with absolute urls.
![Screenshot](https://user-images.githubusercontent.com/613814/73842249-7ce6b500-481c-11ea-8ef8-5366da50eb4b.png)