### PR TITLE
Relative Link into FAQ page: baseURL introduction degraded dev experience on FAQ

### DIFF
--- a/themes/kiali/layouts/faq/list.html
+++ b/themes/kiali/layouts/faq/list.html
@@ -16,7 +16,7 @@
       <ul>
         {{ $questions := .Resources.ByType "page" }}
         {{ $sorted_questions := sort $questions ".Params.weight" }}
-        {{ $url := .Permalink }}
+        {{ $url := .RelPermalink }}
         {{ range $sorted_questions }}
           <li role="none"><a href="{{ $url }}#{{ .File.BaseFileName | urlize }}">{{ .Title }}</a></li>
         {{ end }}

--- a/themes/kiali/layouts/faq/list.html
+++ b/themes/kiali/layouts/faq/list.html
@@ -12,7 +12,7 @@
     {{ .Content }}
 
     {{ range .Data.Pages.ByWeight }}
-      <h2><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></h2>
+      <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
       <ul>
         {{ $questions := .Resources.ByType "page" }}
         {{ $sorted_questions := sort $questions ".Params.weight" }}


### PR DESCRIPTION
The introduction of a baseURL made the staging environment of netlify have problems in the FAQ page. Links where absolute so it was pointing to production environment.
https://github.com/kiali/kiali.io/pull/198#issuecomment-583170747

This branch fixes that making hugo serve relative path instead.