### PR TITLE
Add pages for Release Notes and Security Bulletins

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,6 +12,23 @@ baseURL = "https://kiali.io"
 
 [menu]
   [[menu.main]]
+      identifier = "news"
+      name = "News"
+      url = "/news"
+      weight =  1
+  [[menu.main]]
+      identifier = "news_sec_adv"
+      name = "Security Bulletins"
+      url = "/news/security-bulletins"
+      weight =  1
+      parent = "news"
+  [[menu.main]]
+      identifier = "news_rel_notes"
+      name = "Release Notes"
+      url = "/news/release-notes"
+      weight =  2
+      parent = "news"
+  [[menu.main]]
       identifier = "documentation"
       name = "Documentation"
       url = "/documentation"

--- a/content/news/_index.adoc
+++ b/content/news/_index.adoc
@@ -1,0 +1,9 @@
+---
+title: "News"
+date: 2020-03-23T18:17:04-03:00
+draft: false
+---
+
+News about the Kiali project.
+
+:sectlinks:

--- a/content/news/_index.adoc
+++ b/content/news/_index.adoc
@@ -2,8 +2,10 @@
 title: "News"
 date: 2020-03-23T18:17:04-03:00
 draft: false
+hideIndex: true
 ---
 
 News about the Kiali project.
 
-:sectlinks:
+* link:/news/security-bulletins[Security Bulletins]
+* link:/news/release-notes[Release Notes]

--- a/content/news/release-notes.adoc
+++ b/content/news/release-notes.adoc
@@ -1,0 +1,22 @@
+---
+title: "Release Notes"
+date: 2020-03-23T18:17:04-03:00
+draft: false
+---
+
+Here you can find the release notes for each of the released versions.
+Those are only enumerations, for more in-depth information you can check
+our https://www.youtube.com/channel/UCcm2NzDN_UCZKk2yYmOpc5w[demo
+meetings] and https://medium.com/kialiproject[our blog].
+
+Please also note that not all changes are listed there, mostly only new
+features and breaking changes. If you think that a change should be
+listed here and is not, please get in touch.
+
+== Version 1.15.0
+
+* https://github.com/kiali/kiali/issues/976[Fixes edges for Kafka events]
+* https://github.com/kiali/kiali/issues/2276[Support canonical_service fields in Istio 1.5+ telemetry]
+* https://github.com/kiali/kiali/issues/1894[Validate against Telemetry v2 in Istio 1.5]
+* https://github.com/kiali/kiali/issues/2081[Add validations for AuthorizationPolicy objects]
+* https://github.com/kiali/kiali/issues/1383[Add a notification that object has been modified by someone else]

--- a/content/news/security-bulletins/KIALI-SECURITY-001.adoc
+++ b/content/news/security-bulletins/KIALI-SECURITY-001.adoc
@@ -1,0 +1,34 @@
+---
+title: "KIALI-SECURITY-001 - Some placeholder vulnerability"
+date: 2020-03-23T18:17:04-03:00
+draft: false
+description: "Foo Bar"
+---
+
+* **Disclosure date**: March 23, 2020
+* **Affected Releases**: 1.0 to 1.15.0
+* **Impact Score**: 1.0
+* **Related**: Some placeholder vulnerability.
+
+Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+Lorem Ipsum has been the industry's standard dummy text ever since the 1500s,
+when an unknown printer took a galley of type and scrambled it to make a type
+specimen book. It has survived not only five centuries, but also the leap into
+electronic typesetting, remaining essentially unchanged. It was popularised in
+the 1960s with the release of Letraset sheets containing Lorem Ipsum passages,
+and more recently with desktop publishing software like Aldus PageMaker
+including versions of Lorem Ipsum.
+
+== Detection
+
+Run command:
+
+[source,bash]
+----
+kubectl apply -f patch-example
+----
+
+== Mitigation
+
+Update to the new version.
+

--- a/content/news/security-bulletins/_index.adoc
+++ b/content/news/security-bulletins/_index.adoc
@@ -1,0 +1,7 @@
+---
+title: "Security Bulletins"
+date: 2020-03-23T18:17:04-03:00
+draft: false
+---
+
+Disclosed security vulnerabilities and their mitigation.

--- a/content/news/security-bulletins/_index.adoc
+++ b/content/news/security-bulletins/_index.adoc
@@ -4,4 +4,22 @@ date: 2020-03-23T18:17:04-03:00
 draft: false
 ---
 
+:toc: left
+toc::[]
+:toc-title: All previous disclosures
+
 Disclosed security vulnerabilities and their mitigation.
+
+[cols="20%,15%,15%,50%",options="header"]
+|===
+|Disclosure
+|Date
+|Affected Releases
+|Related
+
+|link:/news/security-bulletins/KIALI-SECURITY-001[KIALI-SECURITY-001]
+|March 23, 2020
+|1.0 to 1.15.0
+|Some placeholder vulnerability.
+
+|===

--- a/content/news/security-bulletins/_index.adoc
+++ b/content/news/security-bulletins/_index.adoc
@@ -2,11 +2,8 @@
 title: "Security Bulletins"
 date: 2020-03-23T18:17:04-03:00
 draft: false
+hideIndex: true
 ---
-
-:toc: left
-toc::[]
-:toc-title: All previous disclosures
 
 Disclosed security vulnerabilities and their mitigation.
 
@@ -17,7 +14,7 @@ Disclosed security vulnerabilities and their mitigation.
 |Affected Releases
 |Related
 
-|link:/news/security-bulletins/KIALI-SECURITY-001[KIALI-SECURITY-001]
+|link:/news/security-bulletins/kiali-security-001[KIALI-SECURITY-001]
 |March 23, 2020
 |1.0 to 1.15.0
 |Some placeholder vulnerability.

--- a/themes/kiali/layouts/_default/list.html.html
+++ b/themes/kiali/layouts/_default/list.html.html
@@ -7,17 +7,19 @@
   <main>
     {{ .Content }}
 
-    <h1>Index</h1>
+    {{ if ne .Params.hideIndex true }}
+      <h1>Index</h1>
 
-    <ol>
-      {{ $pagesOfSection := (where .Site.Pages.ByWeight "Section" .Section) }}
-      {{ $childPages := (where (where $pagesOfSection "Parent" "!=" nil) "Parent.File.Path" .File.Path) }}
-      {{ range $childPages }}
-      <li>
-        <a href="{{ .Permalink }}">{{ .Name }}</a>
-      </li>
-      {{ end }}
-    </ol>
+      <ol>
+        {{ $pagesOfSection := (where .Site.Pages.ByWeight "Section" .Section) }}
+        {{ $childPages := (where (where $pagesOfSection "Parent" "!=" nil) "Parent.File.Path" .File.Path) }}
+        {{ range $childPages }}
+        <li>
+          <a href="{{ .Permalink }}">{{ .Name }}</a>
+        </li>
+        {{ end }}
+      </ol>
+    {{ end }}
   </main>
 </article>
 {{ end }}


### PR DESCRIPTION
Closes https://github.com/kiali/kiali/issues/2536.

Release notes come from epics/epic subtasks on Sprint 36, while security bulletin is just an example.

What is still broken (and will be fixed in other PRs):

* Hovering the menu item opens the dropdown menu in an incorrect
position:

![image](https://user-images.githubusercontent.com/14752/77364679-89bf5980-6d33-11ea-9b36-847cac20fca9.png)

* Tables do not work on our layout, breaking horribly for some reason. Need more work to investigate on this.

## Screenshots

News page:
![image](https://user-images.githubusercontent.com/14752/77364796-bbd0bb80-6d33-11ea-9a92-8248f6c0d091.png)

Release notes:
![image](https://user-images.githubusercontent.com/14752/77364803-bf644280-6d33-11ea-95c6-c08c1534831a.png)

Security bulletins list:
![image](https://user-images.githubusercontent.com/14752/77364849-d1de7c00-6d33-11ea-87ab-a85c11f7f5d4.png)

Security bulletin page:
![image](https://user-images.githubusercontent.com/14752/77364868-d9058a00-6d33-11ea-934e-94ef08efbe56.png)

