### PR TITLE
Add a latest videos and sprint demos section to Kiali.io. 

### DIFF
--- a/themes/kiali/layouts/index.html.html
+++ b/themes/kiali/layouts/index.html.html
@@ -7,6 +7,8 @@
   {{ partial "home/about-section.html" . }}
   {{ partial "home/features-section.html" . }}
   {{ partial "home/blog-latest-section.html" . }}
+  {{ partial "home/video-latest-section.html" . }}
+  {{ partial "home/video-sprint-demo-section.html" . }}
   </main>
 {{ end }}
 

--- a/themes/kiali/layouts/partials/home/hero-section.html
+++ b/themes/kiali/layouts/partials/home/hero-section.html
@@ -13,7 +13,7 @@
       Get started
     </a>
     <a class="button secondary" href="#blog-latest">
-      See latest blog posts
+      See latest blog posts and videos
     </a>
     </p>
 

--- a/themes/kiali/layouts/partials/home/video-latest-section.html
+++ b/themes/kiali/layouts/partials/home/video-latest-section.html
@@ -1,0 +1,17 @@
+<section id="video-latest">
+    <h1>
+        Latest videos
+        <span class="go-to-videos-link">
+          <a href="https://www.youtube.com/channel/UCcm2NzDN_UCZKk2yYmOpc5w" target="_blank">
+            Go to videos
+            <span class="fas fa-external-link-alt"/>
+          </a>
+        </span>
+    </h1>
+
+    <div class="embed-video-links">
+        <iframe class="video-iframe-links" src="https://www.youtube.com/embed/0Ho1twJ9Udg"></iframe>
+        <iframe class="video-iframe-links" src="https://www.youtube.com/embed/MNyrHnzneV8"></iframe>
+        <iframe class="video-iframe-links" src="https://www.youtube.com/embed/v4MN04nQNCU"></iframe>
+    </div>
+</section>

--- a/themes/kiali/layouts/partials/home/video-sprint-demo-section.html
+++ b/themes/kiali/layouts/partials/home/video-sprint-demo-section.html
@@ -1,0 +1,17 @@
+<section id="video-latest">
+    <h1>
+        Sprint demo videos
+        <span class="go-to-videos-link">
+        <a href="https://www.youtube.com/channel/UCcm2NzDN_UCZKk2yYmOpc5w" target="_blank">
+            Go to videos
+            <span class="fas fa-external-link-alt" />
+        </a>
+    </span>
+    </h1>
+
+    <div class="embed-video-links">
+        <iframe class="video-iframe-links" src="https://www.youtube.com/embed/FtlsIwE9P9g" ></iframe>
+        <iframe class="video-iframe-links" src="https://www.youtube.com/embed/768dlCbWYyE" ></iframe>
+        <iframe class="video-iframe-links" src="https://www.youtube.com/embed/04fGMBjHZ68" ></iframe>
+    </div>
+</section>

--- a/themes/kiali/static/css/kiali-home.css
+++ b/themes/kiali/static/css/kiali-home.css
@@ -40,6 +40,23 @@ section#hero p.buttons {
   margin-top: var(--kiali-blue-spacing);
 }
 
+.go-to-videos-link a {
+  float:right;
+  font-size: 18px
+}
+
+.embed-video-links {
+ // nothing yet
+}
+
+.video-iframe-links {
+  width:336px;
+  height:188px;
+  frameborder:0;
+  allow: "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture";
+  allowfullscreen: true;
+}
+
 @media only screen and (min-width: 850px) {
   section#hero {
     padding-top: var(--kiali-bright-green-spacing);
@@ -203,7 +220,7 @@ section#blog-latest div#blog-blocks > a > div header div:last-child {
 section#blog-latest div#blog-blocks > a > div h1 {
   font-size: 18px;
   font-weight: normal;
-  padding-bottom: var (--kiali-blue-spacing);  
+  padding-bottom: var(--kiali-blue-spacing);
 }
 
 section#blog-latest div#blog-blocks > a > div p {
@@ -234,6 +251,11 @@ section#blog-latest div#blog-blocks > a > div p {
   }
 
   #go-to-blog-link {
+    text-align: right;
+    margin: 0;
+  }
+
+  #go-to-videos-link {
     text-align: right;
     margin: 0;
   }


### PR DESCRIPTION
This uses inlined videos to show thumbnails of the videos and increase awareness of the use of Kiali.
It added two sections to Kiali.io:

1. Latest Videos
2. Sprint Demo Videos

This brings awareness to Kiali videos from both a Sprint Demo perspective and quickly learning a new feature.

New: 

<img width="1471" alt="Kiali__Service_mesh_observability_and_configuration" src="https://user-images.githubusercontent.com/1312165/78262548-953e1d80-74b5-11ea-8182-08bbaa441238.png">
