### PR TITLE
Add script to fill all versioned git tags retroactively

### DIFF
--- a/scripts/backfill-tags.sh
+++ b/scripts/backfill-tags.sh
@@ -17,7 +17,14 @@ die() {
 
 # TODO: rename
 create_kiali_io_tags() {
+  # We need to get the latest tags from the repo so we don't overwrite them.
+  echo "Updating kiali.io to get the latest tags..."
+  git fetch --all --tags
+
   pushd "${KIALI_REPO}" &>/dev/null || die "pushd failed."
+
+  echo "Updating Kiali core repository to get the latest tags..."
+  git fetch --all --tags
 
   # - List all versions in semver order
   # - Remove old versions that were tagged incorrectly (like "0.2.0")

--- a/scripts/backfill-tags.sh
+++ b/scripts/backfill-tags.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# This script does the migration process necessary for documentation
-# versioning. It is to be removed after that initiative is done.
-
+# This script does the backfilling of tags for our legacy version, to be used
+# for the versioned documentation migration. It is kept here for archiving
+# purposes.
+#
 # Be careful running it as it creates tags on the current repo you're on.
 # Run with "-f" to disable dry run mode.
 

--- a/sync-tags.sh
+++ b/sync-tags.sh
@@ -1,20 +1,19 @@
 #!/bin/bash
 
+# This script does the migration process necessary for documentation
+# versioning. It is to be removed after that initiative is done.
+
+# Be careful running it as it creates tags on the current repo you're on.
+# Run with "-f" to disable dry run mode.
+
 KIALI_REPO="${KIALI_REPO:-${GOPATH}/src/github.com/kiali/kiali}"
-FIRST_NON_LEGACY_VERSION="v1.17.0"
-
-compare_dates() {
-  local date1=$(date -d "${1}" +%s)
-  local date2=$(date -d "${2}" +%s)
-
-  [ ${date1} -ge ${date2} ]
-}
+FIRST_LEGACY_VERSION="v1.0.0"
+LAST_LEGACY_VERSION="v1.17.0"
 
 # TODO: rename
 create_kiali_io_tags() {
   pushd ${KIALI_REPO} &>/dev/null
 
-  # In order:
   # - List all versions in semver order
   # - Remove old versions that were tagged incorrectly (like "0.2.0")
   # - Remove snapshot versions
@@ -24,31 +23,35 @@ create_kiali_io_tags() {
   # Removing those versions from the list is safe because we are only going to
   # iterate over legacy tags. New tags are supposed to be created on version
   # release.
-  local versions=$(git tag -l --sort=v:refname \
-    | egrep -v "^[^v]" \
-    | grep -v -- "-snapshot" \
-    | egrep -v "\\.[^0-9]+$" \
-    | egrep -v "\\.[^0]$")
-  local start_date=$(git show -s --format="%ci" ${version} | cut -f 1 -d" ")
+  local versions=$(git tag -l --sort=v:refname | egrep "v[0-9]+\\.[0-9]+\\.0$")
+  local start_date=$(git show -s --format="%at" ${FIRST_LEGACY_VERSION})
+  local end_date=$(git show -s --format="%at" ${LAST_LEGACY_VERSION})
 
   for version in ${versions}; do
-    local commit_date=$(git show -s --format="%ci" ${version})
+    local commit_date=$(git show -s --format="%at" ${version})
 
-    if compare_dates ${start_date} ${commit_date}; then
-      popd &>/dev/null
+    [ "${commit_date}" -lt "${start_date}" ] && continue
+    [ "${commit_date}" -gt "${end_date}" ]  && continue
 
-      local latest_commit_on_tag=$(git rev-list -1 --before=$(date +%Y-%m-%d -d "${commit_date} - 1 minute") --format="%ci" master \
-        | grep commit | sed -e "s/commit //" \
-        | tail -n 1)
+    popd &>/dev/null
 
-      echo "Creating tag for version ${version}"
+    # Important: here we only fetch merge commits, so we don't point at incomplete work.
+    local latest_commit_on_tag=$(git rev-list -1 --merges --before=$(date +%s -d "@$(echo "${commit_date} - 1" | bc)") --format="%at" master \
+      | grep commit | sed -e "s/commit //" \
+      | tail -n 1)
+
+    echo "Creating tag for version ${version}..."
+
+    if [ "${1}" = "-f" ]; then
       git tag ${version} ${latest_commit_on_tag} || echo "Version ${version} already exists"
-
-      pushd ${KIALI_REPO} &>/dev/null
+    else
+      echo "git tag ${version} ${latest_commit_on_tag}"
     fi
+
+    pushd ${KIALI_REPO} &>/dev/null
   done
 
   popd &>/dev/null
 }
 
-create_kiali_io_tags
+create_kiali_io_tags ${1}

--- a/sync-tags.sh
+++ b/sync-tags.sh
@@ -49,7 +49,7 @@ create_kiali_io_tags() {
     if [ "${1}" = "-f" ]; then
       git tag "${version}" "${latest_commit_on_tag}" || echo "Version ${version} already exists"
     else
-      echo "git tag ${version} ${latest_commit_on_tag}"
+      echo "DRY_RUN: git tag ${version} ${latest_commit_on_tag}"
     fi
 
     pushd "${KIALI_REPO}" &>/dev/null || die "pushd failed."

--- a/sync-tags.sh
+++ b/sync-tags.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+KIALI_REPO="${KIALI_REPO:-${GOPATH}/src/github.com/kiali/kiali}"
+FIRST_NON_LEGACY_VERSION="v1.17.0"
+
+compare_dates() {
+  local date1=$(date -d "${1}" +%s)
+  local date2=$(date -d "${2}" +%s)
+
+  [ ${date1} -ge ${date2} ]
+}
+
+# TODO: rename
+create_kiali_io_tags() {
+  pushd ${KIALI_REPO} &>/dev/null
+
+  # In order:
+  # - List all versions in semver order
+  # - Remove old versions that were tagged incorrectly (like "0.2.0")
+  # - Remove snapshot versions
+  # - Remove some named quickfix versions, (like "v0.9.1.helmfix")
+  # - Remove patch versions as they are out of order
+  #
+  # Removing those versions from the list is safe because we are only going to
+  # iterate over legacy tags. New tags are supposed to be created on version
+  # release.
+  local versions=$(git tag -l --sort=v:refname \
+    | egrep -v "^[^v]" \
+    | grep -v -- "-snapshot" \
+    | egrep -v "\\.[^0-9]+$" \
+    | egrep -v "\\.[^0]$")
+  local start_date=$(git show -s --format="%ci" ${version} | cut -f 1 -d" ")
+
+  for version in ${versions}; do
+    local commit_date=$(git show -s --format="%ci" ${version})
+
+    if compare_dates ${start_date} ${commit_date}; then
+      popd &>/dev/null
+
+      local latest_commit_on_tag=$(git rev-list -1 --before=$(date +%Y-%m-%d -d "${commit_date} - 1 minute") --format="%ci" master \
+        | grep commit | sed -e "s/commit //" \
+        | tail -n 1)
+
+      echo "Creating tag for version ${version}"
+      git tag ${version} ${latest_commit_on_tag} || echo "Version ${version} already exists"
+
+      pushd ${KIALI_REPO} &>/dev/null
+    fi
+  done
+
+  popd &>/dev/null
+}
+
+create_kiali_io_tags


### PR DESCRIPTION
Part of https://github.com/kiali/kiali/issues/2181.

This is a script that I need to run on the repository to generate the tags for older versions that we released, so I can use those tags to generate the versioned documentation.

After this is merged, I am going to run it on the repo and push the tags generated by it.