### PR TITLE
Use relative links to fix staging deploys

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@ languageCode = "en-us"
 title = "Kiali"
 theme = "kiali"
 baseURL = "https://kiali.io"
-relativeURLs = false
+relativeURLs = true
 
 [params]
     custom_css = [


### PR DESCRIPTION
By our configuration, all links are not relative but have the `kiali.io` root to them. This breaks staging deploys on netlify, as it points all links to production.

This does not affect:

* Copying links, the browser adds the root automatically.
* SEO, the relative links are counted the same.