### PR TITLE
Add deprecation for "login" and "ldap" auth strategies; add documentation for "openid" strategy

### DIFF
--- a/content/documentation/getting-started/index.adoc
+++ b/content/documentation/getting-started/index.adoc
@@ -244,9 +244,13 @@ Kiali supports several different login options.
 
 *login*: This option allows a user to log in to Kiali using a username and password. This is the default option if using Kubernetes.
 
+icon:bullhorn[size=2x]{nbsp} The _login_ strategy is deprecated and it will be removed in a following release. As an alternative, use the _token_ strategy, which provides similar authentication experience to the link:https://github.com/kubernetes/dashboard[Kubernetes Dashboard].
+
 *anonymous*: This option removes any login requirement. A user will not be presented the login page and will automatically have access to Kiali without having to present any credentials.
 
 *ldap*: This option allows a user to log in to Kiali using a username and passphrase that is authenticated via a backend LDAP server. This option requires that you configure additional settings in the Kiali CR under `auth.ldap` - see below for an example. If you want to use this option, you cannot use the operator deploy script to configure Kiali for you - you must create the Kiali CR and either pass it to the deploy script via `--kiali-cr` or do not have the script deploy a Kiali CR (`--operator-install-kiali=false`) but instead deploy the Kiali CR directly into your cluster yourself.
+
+icon:bullhorn[size=2x]{nbsp} The _ldap_ strategy is deprecated and it will be removed in a following release. As an alternative, use the _openid_ strategy and use an OpenID provider that supports LDAP integration.
 
 *openshift*: If you have deployed Kiali on OpenShift you can use this option (this is the default option if you're using OpenShift). With this option, users log in to Kiali with the OpenShift OAuth login. What users can access in Kiali will now be based on their user roles in OpenShift using the Kubernetes RBAC.
 
@@ -277,6 +281,8 @@ auth:
 ----
 
 ==== LDAP
+
+icon:bullhorn[size=2x]{nbsp} The _ldap_ strategy is deprecated and it will be removed in a following release. As an alternative, use the _openid_ strategy and use an OpenID provider that supports LDAP integration.
 
 The `ldap` login option requires additional settings in the `auth.ldap` section. For example:
 

--- a/content/documentation/getting-started/index.adoc
+++ b/content/documentation/getting-started/index.adoc
@@ -100,7 +100,7 @@ The version of Kiali packaged with Istio or Maistra may not contain the most rec
 
 Installing the latest version of Kiali is done using the Kiali Operator. The Kiali Operator is a link:https://coreos.com/operators/[Kubernetes Operator]. The Kiali Operator manages your Kiali installation. The Kiali Operator watches the Kiali Custom Resource (CR), a YAML file that holds the Kiali configuration. When you modify the Kiali CR, the operator installs, updates, or uninstalls Kiali as needed.
 
-Below are three options for installing the Kiali Operator. If you're replacing an existing Kiali Operator you will be prompted for confirmation. Depending on the installation option the operator may then install Kiali. If you're replacing an existing Kiali you will be prompted for confirmation. For new Kiali installations, you will be prompted for the authentication strategy. See link:#_login_options[Login Options] for more on the `login`, `anonymous`, `ldap`, `openshift` and `token` authentication strategies. Depending on the chosen strategy, the installation may prompt for additional information.
+Below are three options for installing the Kiali Operator. If you're replacing an existing Kiali Operator you will be prompted for confirmation. Depending on the installation option the operator may then install Kiali. If you're replacing an existing Kiali you will be prompted for confirmation. For new Kiali installations, you will be prompted for the authentication strategy. See link:#_login_options[Login Options] for more on the `login`, `anonymous`, `ldap`, `openshift`, `token` and `openid` authentication strategies. Depending on the chosen strategy, the installation may prompt for additional information.
 
 icon:bullhorn[size=1x]{nbsp} It is only necessary to install the Kiali Operator one time. After the operator is installed you need only create or edit the Kiali CR (see link:#_create_or_edit_the_kiali_cr[Create or Edit the Kiali CR]). The Kiali config map will be managed by the Kiali Operator and should *not* be manually edited. There is no need to again perform one of the bash installations below.
 
@@ -256,11 +256,11 @@ icon:bullhorn[size=2x]{nbsp} The _ldap_ strategy is deprecated and it will be re
 
 *token*: This option allows a user to log in to Kiali using a Service Account token. This is similar to the link:https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/README.md#login-view[login view of Kubernetes Dashboard]. When using this option, the cluser RBAC will take effect and users can access only what is allowed to the Service Account.
 
+*openid*: This option allows a user to log in to Kiali using an external identity provider that implements link:https://openid.net/connect/[OpenID Connect]. When using this option, the cluser RBAC will take effect and users can access only what is allowed via the link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/[cluster's authorization mechanisms]. This strategy requires that your link:https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens[Kubernetes cluster is configured to accept tokens issued from your identity provider]. See the dedicated link:#_openid_connect[OpenID section of this page] for more information.
+
 icon:bullhorn[size=1x]{nbsp} Using the *anonymous* option will leave Kiali unsecured. Anyone who can access the console will have full access to Kiali. If you are using this option you will need to make sure that it is only available on a trusted network and that only trusted users can access it.
 
 If `login` strategy is selected during the installation, a secret containing Kiali login credentials is required to be deployed along with Kiali. In this case, the install script will prompt you to enter a username and passphrase for the credentials that you want users to enter in order to log in successfully to Kiali. The install script will store those credentials in a secret that is deployed in the same namespace where Kiali is installed.
-
-When using the `token` strategy in Kubernetes, Kiali assumes that all link:#_accessible_namespaces[accessible namespaces] are readable. Thus, for Kiali to work correctly the Service Account used to log in must have, at least, read privileges in all accessible namespaces. In OpenShift, Kiali uses the Projects API to determine the real set of readable namespaces and remove the need to adjust the accessible namespaces.
 
 icon:bullhorn[size=1x]{nbsp} If you configured the install script not to install a Kiali CR (and thus not have Kiali installed yet) via the `operator-install-kiali=false` option, you are responsible for creating this secret if you wish to install Kiali with the authentication strategy of "login". A secret is not required if your authentication strategy is not "login". The following command is a simple way to create a secret for Kiali whose user name is "admin" and password is "admin":
 [source,bash]
@@ -330,6 +330,65 @@ The configuration settings that are required to be set in order to use the LDAP 
 * ldap_port
 
 Kiali will not start if those settings are not present.
+
+==== OpenID Connect
+
+The `openid` login strategy requires additional settings in the `auth.openid` section. The minimal required attributes are `client_id` and `issuer_uri`. For example:
+
+[source,yaml]
+----
+auth:
+  strategy: openid
+  openid:
+    client_id: "kiali-client"
+    issuer_uri: "https://openid.issuer.com"
+----
+
+Please, check the
+link:https://github.com/kiali/kiali-operator/blob/8f2329c17d67d9a22c9fc1a50b468a7e80df72e6/deploy/kiali/kiali_cr.yaml#L173-L206[kiali_cr.yaml]
+file of the Kiali operator repository to learn about all available options for
+configuring the `openid` strategy.
+
+The `openid` strategy requires that your
+link:https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens[Kubernetes
+cluster is configured to accept tokens generated by your identity provider]. If
+your cluster is not properly configured, authentication will fail and users
+won't be able to log in to Kiali. Because of this, the value of `client-id`,
+`issuer_uri` and `username_claim` configuration options in Kiali are required
+to match the `--oidc-client-id`, `--oidc-issuer-url` and
+`--oidc-username-claim` flags
+link:https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server[used
+to start the cluster API server]. If one or more of these values don't match,
+users might fail to log in to Kiali.
+
+Kiali uses the OpenID identity of the logged in user to make calls to the
+cluster API. Because of this, the `openid` strategy is RBAC-enabled and only
+users with privileges on the cluster will be able to log in to Kiali.
+Depending on the options you provided in the Kiali operator CR, there will be a
+ClusterRole named either `kiali` or `kiali-viewer` that you can use to assign
+privileges.  For example, to assign privileges to the `john@example.com` OpenId
+user in the `testing` namespace, you could run the following command:
+
+[source,bash]
+----
+kubectl create rolebinding john-openid-binding --clusterrole=kiali --user="john@example.com" --namespace=testing
+----
+
+By assigning privileges this way, the user will be able to use Kiali and
+inspect only the `testing` namespace. If you need to assign cluster-wide
+permissions, assign privileges using a ClusterRoleBinding:
+
+[source,bash]
+----
+kubectl create clusterrolebinding john-openid-clusterbinding --clusterrole=kiali --user="john@example.com"
+----
+
+icon:bullhorn[size=1x]{nbsp} If you need to assign a more limited set of
+privileges, it's possible to use the `kiali` or `kiali-viewer` ClusterRoles as
+a base for creating your own customized Roles or ClusterRoles. Then, bind the
+users these customized roles. Do not edit the `kiali` nor the `kiali-viewer`
+ClusterRoles becuase they are binded to the Kiali ServiceAccount and editing
+them may lead to Kiali not working properly.
 
 [#openshift_user_permissions]
 ==== OpenShift User Permissions


### PR DESCRIPTION
Part of kiali/kiali#2863 and kiali/kiali#2862.
Fixes kiali/kiali#2864.