### PR TITLE
Add version to Makefile to conform to CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# Points to the next version that is going to be released,
+# it is changed automatically by the release scripts
+VERSION ?= v1.20.0
+
 HUGO_VERSION ?= 0.53
 CONTAINER_RUNTIME ?= docker
 


### PR DESCRIPTION
This does the same as the operator CI Makefile, which contains a version that is updated by the release scripts.