### PR TITLE
Add kiali events on our home page

### DIFF
--- a/themes/kiali/layouts/index.html.html
+++ b/themes/kiali/layouts/index.html.html
@@ -9,6 +9,7 @@
   {{ partial "home/blog-latest-section.html" . }}
   {{ partial "home/video-latest-section.html" . }}
   {{ partial "home/video-sprint-demo-section.html" . }}
+  {{ partial "home/events-latest-section.html" . }}
   </main>
 {{ end }}
 

--- a/themes/kiali/layouts/partials/home/blog-latest-section.html
+++ b/themes/kiali/layouts/partials/home/blog-latest-section.html
@@ -1,7 +1,7 @@
   {{- $maxBlogPosts := .Site.Params.maxBlogPosts }}
   {{/*expTimestamp: expire content every 1hour (6000s)*/}}
   {{- $expTimestamp := div now.Unix 6000 }}
-  {{- $mediumURL    := printf "https://api.rss2json.com/v1/api.json?timestamp=%s&rss_url=https://medium.com/feed/kialiproject" $expTimestamp }}
+  {{- $mediumURL    := printf "https://api.rss2json.com/v1/api.json?timestamp=%d&rss_url=https://medium.com/feed/kialiproject" $expTimestamp }}
   {{- $json         := getJSON $mediumURL }}
   {{- $posts        := first $maxBlogPosts $json.items }}
   {{- $latestPost   := index $json.items 1 }}

--- a/themes/kiali/layouts/partials/home/events-latest-section.html
+++ b/themes/kiali/layouts/partials/home/events-latest-section.html
@@ -1,0 +1,43 @@
+  {{- $maxBlogPosts := .Site.Params.maxBlogPosts }}
+  {{- $expTimestamp := div now.Unix 6000 }}
+  {{- $formURL      := printf "https://docs.google.com/spreadsheets/d/e/2PACX-1vQEuJ1_zcsbU5f0wdsZ5ytwyV5h3Q9ufHdc4rqEGnqBvlBNANKqwYyV8YxXJ9qj2gxBzuSMc4zvao5R/pub?gid=0&single=true&output=csv&ts=%d" $expTimestamp }}
+  {{- $csv          := getCSV "," $formURL }}
+  {{- $events       := first $maxBlogPosts $csv }}
+  {{- $latestEvent := index $csv 1 }}
+
+  <section id="blog-latest" data-lastpubat="{{ index $latestEvent 0 }}">
+    <h1>
+      Events and talks
+    </h1>
+    <div id="go-to-blog-link">
+      <a href="https://bit.ly/3egKs58" target="_blank">
+        Contribute
+        <span class="fas fa-external-link-alt" />
+      </a>
+    </div>
+
+    <div id="blog-blocks">
+      {{ range $i, $r := $events }}
+        {{ if gt $i 0 }}
+          {{ $link    := index $r 7 }}
+          {{ $title   := index $r 1 }}
+          {{ $author  := index $r 4 }}
+          {{ $dateRaw := index $r 2 }}
+          {{ $date    := $dateRaw }}
+          {{ $summary := index $r 3 | plainify | truncate 150 }}
+
+          <a href="{{ $link }}" title="{{ $title }}" target="_blank">
+            <div>
+              <header>
+                <div>{{ $date }}</div>
+                <div><span class="fas fa-calendar" /></div>
+              </header>
+              <h1>{{ $title }}</h2>
+              <p>{{ $author }}</p>
+            </div>
+          </a>
+        {{ end }}
+      {{ end }}
+    </div>
+  </section>
+

--- a/themes/kiali/layouts/partials/home/events-latest-section.html
+++ b/themes/kiali/layouts/partials/home/events-latest-section.html
@@ -1,5 +1,5 @@
   {{- $maxBlogPosts := .Site.Params.maxBlogPosts }}
-  {{- $expTimestamp := div now.Unix 6000 }}
+  {{- $expTimestamp := div now.Unix 600 }}
   {{- $formURL      := printf "https://docs.google.com/spreadsheets/d/e/2PACX-1vQEuJ1_zcsbU5f0wdsZ5ytwyV5h3Q9ufHdc4rqEGnqBvlBNANKqwYyV8YxXJ9qj2gxBzuSMc4zvao5R/pub?gid=0&single=true&output=csv&ts=%d" $expTimestamp }}
   {{- $csv          := getCSV "," $formURL }}
   {{- $events       := first $maxBlogPosts $csv }}
@@ -23,7 +23,7 @@
           {{ $title   := index $r 1 }}
           {{ $author  := index $r 4 }}
           {{ $dateRaw := index $r 2 }}
-          {{ $date    := $dateRaw }}
+          {{ $date    := dateFormat "January 2, 2006" $dateRaw }}
           {{ $summary := index $r 3 | plainify | truncate 150 }}
 
           <a href="{{ $link }}" title="{{ $title }}" target="_blank">


### PR DESCRIPTION
I've added a new section in our home page where events related to kiali are going to be listed.

The source of this is a Google SpreadSheets which only the kiali team can edit. This spreadsheet is similar to the resulting one from the public form available to the community: bit.ly/3egKs58

If this PR gets merged, I'll invite to all of the kiali team to that spreadsheet.

wdyt?