### PR TITLE
Fix filtering on listing page

### DIFF
--- a/themes/kiali/layouts/_default/list.html.html
+++ b/themes/kiali/layouts/_default/list.html.html
@@ -14,7 +14,7 @@
         {{ $pagesOfSection := (where .Site.Pages.ByWeight "Section" .Section) }}
         {{ $childPages := (where (where $pagesOfSection "Parent" "!=" nil) "Parent.File.Path" .File.Path) }}
         {{ range $childPages }}
-          {{ if not (in .Permalink "/documentation/latest/") }}
+          {{ if not (strings.HasSuffix .Permalink "/documentation/latest/") }}
           <li>
             <a href="{{ .Permalink }}">{{ .Name }}</a>
           </li>


### PR DESCRIPTION
This fixes an error on the layout that was filtering the index page when accessing it through the `latest` endpoint (accessing the version directly was ok, though).

This happens because Hugo does not know about symlinks and can not expand the url, unfortunately.

Before:
![image](https://user-images.githubusercontent.com/14752/87385723-27ee5e00-c575-11ea-97e0-e715fb046e5b.png)

After:
![image](https://user-images.githubusercontent.com/14752/87385740-3177c600-c575-11ea-9cbb-8efd54d5fff9.png)