### PR TITLE
Fix FAQ Links

### DIFF
--- a/content/documentation/edge/faq/general/how-do-i-access-kiai.adoc
+++ b/content/documentation/edge/faq/general/how-do-i-access-kiai.adoc
@@ -5,7 +5,7 @@ weight: 10
 :icons: font
 
 *_This assumes that you have used the
-link:{{< ref "/documentation/latest/installation-guide" >}}[Installation guide] to
+link:{{< ref "/documentation/edge/installation-guide" >}}[Installation guide] to
 install Kiali._*
 
 *If you are using OpenShift*, installation exposes Kiali through a route. The

--- a/content/documentation/v1.10/faq/general/how-do-i-access-kiai.adoc
+++ b/content/documentation/v1.10/faq/general/how-do-i-access-kiai.adoc
@@ -5,7 +5,7 @@ weight: 10
 :icons: font
 
 *_This assumes that you have used the
-link:{{< ref "/documentation/getting-started" >}}[Getting started instructions] to
+link:{{< ref "/documentation/v1.10/getting-started" >}}[Getting started instructions] to
 install Kiali._*
 
 *If you are using OpenShift*, installation exposes Kiali through a route. The

--- a/content/documentation/v1.11/faq/general/how-do-i-access-kiai.adoc
+++ b/content/documentation/v1.11/faq/general/how-do-i-access-kiai.adoc
@@ -5,7 +5,7 @@ weight: 10
 :icons: font
 
 *_This assumes that you have used the
-link:{{< ref "/documentation/getting-started" >}}[Getting started instructions] to
+link:{{< ref "/documentation/v1.11/getting-started" >}}[Getting started instructions] to
 install Kiali._*
 
 *If you are using OpenShift*, installation exposes Kiali through a route. The

--- a/content/documentation/v1.12/faq/general/how-do-i-access-kiai.adoc
+++ b/content/documentation/v1.12/faq/general/how-do-i-access-kiai.adoc
@@ -5,7 +5,7 @@ weight: 10
 :icons: font
 
 *_This assumes that you have used the
-link:{{< ref "/documentation/getting-started" >}}[Getting started instructions] to
+link:{{< ref "/documentation/v1.12/getting-started" >}}[Getting started instructions] to
 install Kiali._*
 
 *If you are using OpenShift*, installation exposes Kiali through a route. The

--- a/content/documentation/v1.13/faq/general/how-do-i-access-kiai.adoc
+++ b/content/documentation/v1.13/faq/general/how-do-i-access-kiai.adoc
@@ -5,7 +5,7 @@ weight: 10
 :icons: font
 
 *_This assumes that you have used the
-link:{{< ref "/documentation/getting-started" >}}[Getting started instructions] to
+link:{{< ref "/documentation/v1.13/getting-started" >}}[Getting started instructions] to
 install Kiali._*
 
 *If you are using OpenShift*, installation exposes Kiali through a route. The

--- a/content/documentation/v1.14/faq/general/how-do-i-access-kiai.adoc
+++ b/content/documentation/v1.14/faq/general/how-do-i-access-kiai.adoc
@@ -5,7 +5,7 @@ weight: 10
 :icons: font
 
 *_This assumes that you have used the
-link:{{< ref "/documentation/getting-started" >}}[Getting started instructions] to
+link:{{< ref "/documentation/v1.14/getting-started" >}}[Getting started instructions] to
 install Kiali._*
 
 *If you are using OpenShift*, installation exposes Kiali through a route. The

--- a/content/documentation/v1.15/faq/general/how-do-i-access-kiai.adoc
+++ b/content/documentation/v1.15/faq/general/how-do-i-access-kiai.adoc
@@ -5,7 +5,7 @@ weight: 10
 :icons: font
 
 *_This assumes that you have used the
-link:{{< ref "/documentation/getting-started" >}}[Getting started instructions] to
+link:{{< ref "/documentation/v1.15/getting-started" >}}[Getting started instructions] to
 install Kiali._*
 
 *If you are using OpenShift*, installation exposes Kiali through a route. The

--- a/content/documentation/v1.16/faq/general/how-do-i-access-kiai.adoc
+++ b/content/documentation/v1.16/faq/general/how-do-i-access-kiai.adoc
@@ -5,7 +5,7 @@ weight: 10
 :icons: font
 
 *_This assumes that you have used the
-link:{{< ref "/documentation/getting-started" >}}[Getting started instructions] to
+link:{{< ref "/documentation/v1.16/getting-started" >}}[Getting started instructions] to
 install Kiali._*
 
 *If you are using OpenShift*, installation exposes Kiali through a route. The

--- a/content/documentation/v1.17/faq/general/how-do-i-access-kiai.adoc
+++ b/content/documentation/v1.17/faq/general/how-do-i-access-kiai.adoc
@@ -5,7 +5,7 @@ weight: 10
 :icons: font
 
 *_This assumes that you have used the
-link:{{< ref "/documentation/getting-started" >}}[Getting started instructions] to
+link:{{< ref "/documentation/v1.17/getting-started" >}}[Getting started instructions] to
 install Kiali._*
 
 *If you are using OpenShift*, installation exposes Kiali through a route. The

--- a/content/documentation/v1.18/faq/general/how-do-i-access-kiai.adoc
+++ b/content/documentation/v1.18/faq/general/how-do-i-access-kiai.adoc
@@ -5,7 +5,7 @@ weight: 10
 :icons: font
 
 *_This assumes that you have used the
-link:{{< ref "/documentation/getting-started" >}}[Getting started instructions] to
+link:{{< ref "/documentation/v1.18/getting-started" >}}[Getting started instructions] to
 install Kiali._*
 
 *If you are using OpenShift*, installation exposes Kiali through a route. The

--- a/content/documentation/v1.19/faq/general/how-do-i-access-kiai.adoc
+++ b/content/documentation/v1.19/faq/general/how-do-i-access-kiai.adoc
@@ -5,7 +5,7 @@ weight: 10
 :icons: font
 
 *_This assumes that you have used the
-link:{{< ref "/documentation/getting-started" >}}[Getting started instructions] to
+link:{{< ref "/documentation/v1.19/installation-guide" >}}[Installation Guide] to
 install Kiali._*
 
 *If you are using OpenShift*, installation exposes Kiali through a route. The

--- a/content/documentation/v1.5/faq/general/how-do-i-access-kiai.adoc
+++ b/content/documentation/v1.5/faq/general/how-do-i-access-kiai.adoc
@@ -5,7 +5,7 @@ weight: 10
 :icons: font
 
 *_This assumes that you have used the
-link:{{< ref "/documentation/getting-started" >}}[Getting started instructions] to
+link:{{< ref "/documentation/v1.5/getting-started" >}}[Getting started instructions] to
 install Kiali._*
 
 *If you are using OpenShift*, installation exposes Kiali through a route. The

--- a/content/documentation/v1.6/faq/general/how-do-i-access-kiai.adoc
+++ b/content/documentation/v1.6/faq/general/how-do-i-access-kiai.adoc
@@ -5,7 +5,7 @@ weight: 10
 :icons: font
 
 *_This assumes that you have used the
-link:{{< ref "/documentation/getting-started" >}}[Getting started instructions] to
+link:{{< ref "/documentation/v1.6/getting-started" >}}[Getting started instructions] to
 install Kiali._*
 
 *If you are using OpenShift*, installation exposes Kiali through a route. The

--- a/content/documentation/v1.7/faq/general/how-do-i-access-kiai.adoc
+++ b/content/documentation/v1.7/faq/general/how-do-i-access-kiai.adoc
@@ -5,7 +5,7 @@ weight: 10
 :icons: font
 
 *_This assumes that you have used the
-link:{{< ref "/documentation/getting-started" >}}[Getting started instructions] to
+link:{{< ref "/documentation/v1.7/getting-started" >}}[Getting started instructions] to
 install Kiali._*
 
 *If you are using OpenShift*, installation exposes Kiali through a route. The

--- a/content/documentation/v1.8/faq/general/how-do-i-access-kiai.adoc
+++ b/content/documentation/v1.8/faq/general/how-do-i-access-kiai.adoc
@@ -5,7 +5,7 @@ weight: 10
 :icons: font
 
 *_This assumes that you have used the
-link:{{< ref "/documentation/getting-started" >}}[Getting started instructions] to
+link:{{< ref "/documentation/v1.8/getting-started" >}}[Getting started instructions] to
 install Kiali._*
 
 *If you are using OpenShift*, installation exposes Kiali through a route. The

--- a/content/documentation/v1.9/faq/general/how-do-i-access-kiai.adoc
+++ b/content/documentation/v1.9/faq/general/how-do-i-access-kiai.adoc
@@ -5,7 +5,7 @@ weight: 10
 :icons: font
 
 *_This assumes that you have used the
-link:{{< ref "/documentation/getting-started" >}}[Getting started instructions] to
+link:{{< ref "/documentation/v1.9/getting-started" >}}[Getting started instructions] to
 install Kiali._*
 
 *If you are using OpenShift*, installation exposes Kiali through a route. The

--- a/themes/kiali/layouts/faq/list.html
+++ b/themes/kiali/layouts/faq/list.html
@@ -18,7 +18,9 @@
         {{ $sorted_questions := sort $questions ".Params.weight" }}
         {{ $url := .RelPermalink }}
         {{ range $sorted_questions }}
-          <li role="none"><a href="{{ $url }}#{{ .File.BaseFileName | urlize }}">{{ .Title }}</a></li>
+          <li role="none"><a name="{{ .File.BaseFileName }}" href="#{{ .File.BaseFileName | urlize }}">{{ .Title }}</a></li>
+
+          <p>{{ .Content }}</p>
         {{ end }}
       </ul>
     {{ end }}

--- a/themes/kiali/layouts/faq/list.html
+++ b/themes/kiali/layouts/faq/list.html
@@ -12,7 +12,7 @@
     {{ .Content }}
 
     {{ range .Data.Pages.ByWeight }}
-      <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
+      <h2>{{ .LinkTitle }}</h2>
       <ul>
         {{ $questions := .Resources.ByType "page" }}
         {{ $sorted_questions := sort $questions ".Params.weight" }}


### PR DESCRIPTION
Closes https://github.com/kiali/kiali/issues/2994

So, at it turns out, our faq being (barely) functional before the versioning is just an unlikely alignment between hugo and the content  we had at the time. As soon as things get more complicated it breaks down horribly.

This should fix some of the problems, at least the ones we've encountered until now.

* Fix header links.
* Add the content directly to the page.
* Fix some of the links on old versions of the "getting-started" page.

Proof of life:
![image](https://user-images.githubusercontent.com/14752/87578610-0a231500-c6ab-11ea-8c58-4dadcc252fc3.png)