### PR TITLE
Force presence of a table of contents on faq pages

### DIFF
--- a/themes/kiali/layouts/faq/list.html
+++ b/themes/kiali/layouts/faq/list.html
@@ -12,17 +12,32 @@
     {{ .Content }}
 
     {{ range .Data.Pages.ByWeight }}
-      <h2>{{ .LinkTitle }}</h2>
       <ul>
-        {{ $questions := .Resources.ByType "page" }}
-        {{ $sorted_questions := sort $questions ".Params.weight" }}
-        {{ $url := .RelPermalink }}
-        {{ range $sorted_questions }}
-          <li role="none"><a name="{{ .File.BaseFileName }}" href="#{{ .File.BaseFileName | urlize }}">{{ .Title }}</a></li>
-
-          <p>{{ .Content }}</p>
-        {{ end }}
+        <li role="none">
+          {{ .Title }}
+          <ul>
+            {{ $questions := .Resources.ByType "page" }}
+            {{ $sorted_questions := sort $questions ".Params.weight" }}
+            {{ $url := .RelPermalink }}
+            {{ range $sorted_questions }}
+              <li role="none"><a href="#{{ .File.BaseFileName }}">{{ .Title }}</a></li>
+            {{ end }}
+          </ul>
+        </li>
       </ul>
+    {{ end }}
+
+    {{ range .Data.Pages.ByWeight }}
+      <h3>{{ .LinkTitle }}</h3>
+
+      {{ $questions := .Resources.ByType "page" }}
+      {{ $sorted_questions := sort $questions ".Params.weight" }}
+      {{ $url := .RelPermalink }}
+      {{ range $sorted_questions }}
+        <h5><a name="{{ .File.BaseFileName }}" href="#{{ .File.BaseFileName }}">{{ .Title }}</a></h5>
+
+        <p>{{ .Content }}</p>
+      {{ end }}
     {{ end }}
   </main>
 </article>


### PR DESCRIPTION
So, continuing on the work of hugo making things that should be simple not so simple, this commit brings back a table of contents, explicit on the layout.

This commit also cleans up the generated html a little by not using a list for the page contents.

It should look like this now:
![image](https://user-images.githubusercontent.com/14752/87625272-1dac9b00-c700-11ea-9c9d-0d11fef6bd18.png)