### PR TITLE
Point Makefile to correct version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Points to the next version that is going to be released,
 # it is changed automatically by the release scripts
-VERSION ?= v1.20.0
+VERSION ?= v1.21.0
 
 HUGO_VERSION ?= 0.53
 CONTAINER_RUNTIME ?= docker


### PR DESCRIPTION
When doing the manual release for v1.20, I forgot to change the version in the Makefile to the correct one (the next one going to be released).

This PR fixes that.