### PR TITLE
Move validations to main_doc menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -55,12 +55,6 @@ relativeURLs = true
           url = "/documentation/latest/features"
           weight = 1
           parent="main_doc"
-          [[menu.main]]
-             identifier = "validation"
-             name = "Validation"
-             url = "/documentation/latest/validations"
-             weight = 1
-             parent="doc_features"
       [[menu.main]]
           identifier = "doc_installation_guide"
           name = "Installation Guide"
@@ -74,34 +68,40 @@ relativeURLs = true
           weight = 3
           parent="main_doc"
       [[menu.main]]
+          identifier = "validations"
+          name = "Validations"
+          url = "/documentation/latest/validations"
+          weight = 4
+          parent="main_doc"
+      [[menu.main]]
           identifier = "doc_runtimes"
           name = "Custom Dashboards"
           url = "/documentation/latest/runtimes-monitoring"
-          weight = 4
+          weight = 5
           parent="main_doc"
       [[menu.main]]
           identifier = "doc_tracing"
           name = "Distributed Tracing"
           url = "/documentation/latest/distributed-tracing"
-          weight = 5
+          weight = 6
           parent="main_doc"
       [[menu.main]]
           identifier = "doc_extensions"
           name = "Extensions"
           url = "/documentation/latest/extensions"
-          weight = 6
+          weight = 7
           parent="main_doc"
       [[menu.main]]
           identifier = "doc_swagger"
           name = "Developer API"
           url = "/documentation/latest/developer-api"
-          weight = 7
+          weight = 8
           parent="main_doc"
       [[menu.main]]
           identifier = "doc_glossary"
           name = "Glossary"
           url = "/documentation/latest/glossary"
-          weight = 8
+          weight = 9
           parent="main_doc"
           [[menu.main]]
               identifier = "concepts"
@@ -125,7 +125,7 @@ relativeURLs = true
           identifier = "doc_archive"
           name = "Older Releases"
           url = "/documentation"
-          weight = 9
+          weight = 10
           parent="main_doc"
   [[menu.main]]
       identifier = "main_faq"


### PR DESCRIPTION
Minor change to have a better clean menu.
Validations is an important entry in the menu and it deserves to be in the main menu to be less "hidden".