### PR TITLE
remove accessible_namespaces from documented helm command

### DIFF
--- a/content/documentation/staging/quick-start/index.adoc
+++ b/content/documentation/staging/quick-start/index.adoc
@@ -56,7 +56,6 @@ icon:bullhorn[size=1x]{nbsp} If you already installed Kiali resources, you must 
 helm install \
   --namespace istio-system \
   --set auth.strategy="anonymous" \
-  --set deployment.accessible_namespaces[0]="**" \
   --repo https://kiali.org/helm-charts \
   kiali-server \
   kiali-server

--- a/content/documentation/v1.22/quick-start/index.adoc
+++ b/content/documentation/v1.22/quick-start/index.adoc
@@ -56,7 +56,6 @@ icon:bullhorn[size=1x]{nbsp} If you already installed Kiali resources, you must 
 helm install \
   --namespace istio-system \
   --set auth.strategy="anonymous" \
-  --set deployment.accessible_namespaces[0]="**" \
   --repo https://kiali.org/helm-charts \
   kiali-server \
   kiali-server


### PR DESCRIPTION
zsh has different syntax for brackets on command lines, but since accessible namespaces is ** by default, just don't specify it. This makes the documented command the same on all platforms.

fixes: https://github.com/kiali/kiali/issues/3108