### PR TITLE
Add a 'Getting Started Video' section 

### DIFF
--- a/themes/kiali/layouts/index.html.html
+++ b/themes/kiali/layouts/index.html.html
@@ -7,6 +7,7 @@
   {{ partial "home/about-section.html" . }}
   {{ partial "home/features-section.html" . }}
   {{ partial "home/blog-latest-section.html" . }}
+  {{ partial "home/video-getting-started-section.html" . }}
   {{ partial "home/video-latest-section.html" . }}
   {{ partial "home/video-sprint-demo-section.html" . }}
   {{ partial "home/events-latest-section.html" . }}

--- a/themes/kiali/layouts/partials/home/video-getting-started-section.html
+++ b/themes/kiali/layouts/partials/home/video-getting-started-section.html
@@ -1,6 +1,6 @@
 <section id="video-latest">
     <h1>
-        Latest videos
+        Getting started videos
         <span class="go-to-videos-link">
           <a href="https://www.youtube.com/channel/UCcm2NzDN_UCZKk2yYmOpc5w" target="_blank">
             Go to videos
@@ -10,8 +10,8 @@
     </h1>
 
     <div class="embed-video-links">
-        <iframe class="video-iframe-links" src="https://www.youtube.com/embed/z7cZDPV9Ge0"></iframe>
-        <iframe class="video-iframe-links" src="https://www.youtube.com/embed/OCXMU5IjOMM"></iframe>
-        <iframe class="video-iframe-links" src="https://www.youtube.com/embed/CC_dl4zSZiU"></iframe>
+        <iframe class="video-iframe-links" src="https://www.youtube.com/embed/0Ho1twJ9Udg"></iframe>
+        <iframe class="video-iframe-links" src="https://www.youtube.com/embed/MNyrHnzneV8"></iframe>
+        <iframe class="video-iframe-links" src="https://www.youtube.com/embed/v4MN04nQNCU"></iframe>
     </div>
 </section>


### PR DESCRIPTION
This adds a 'Getting Started Videos' so that the 'Latest videos' section can be just that the latest cool videos; but that we have a highly visible place for beginners to see how to use Kiali.

fixes: https://github.com/kiali/kiali/issues/3117