### PR TITLE
Add docs for OpenID API proxy and general reorg of auth docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -68,40 +68,58 @@ relativeURLs = true
           weight = 3
           parent="main_doc"
       [[menu.main]]
+          identifier = "doc_configuration"
+          name = "Configuration"
+          url = "/documentation/latest/configuration"
+          weight = 4
+          parent="main_doc"
+          [[menu.main]]
+              identifier = "doc_authentication"
+              name = "Authentication"
+              url = "/documentation/latest/configuration/authentication"
+              weight = 1
+              parent="doc_configuration"
+          [[menu.main]]
+              identifier = "doc_rbac"
+              name = "RBAC"
+              url = "/documentation/latest/configuration/rbac"
+              weight = 2
+              parent="doc_configuration"
+      [[menu.main]]
           identifier = "validations"
           name = "Validations"
           url = "/documentation/latest/validations"
-          weight = 4
+          weight = 5
           parent="main_doc"
       [[menu.main]]
           identifier = "doc_runtimes"
           name = "Custom Dashboards"
           url = "/documentation/latest/runtimes-monitoring"
-          weight = 5
+          weight = 6
           parent="main_doc"
       [[menu.main]]
           identifier = "doc_tracing"
           name = "Distributed Tracing"
           url = "/documentation/latest/distributed-tracing"
-          weight = 6
+          weight = 7
           parent="main_doc"
       [[menu.main]]
           identifier = "doc_extensions"
           name = "Extensions"
           url = "/documentation/latest/extensions"
-          weight = 7
+          weight = 8
           parent="main_doc"
       [[menu.main]]
           identifier = "doc_swagger"
           name = "Developer API"
           url = "/documentation/latest/developer-api"
-          weight = 8
+          weight = 9
           parent="main_doc"
       [[menu.main]]
           identifier = "doc_glossary"
           name = "Glossary"
           url = "/documentation/latest/glossary"
-          weight = 9
+          weight = 10
           parent="main_doc"
           [[menu.main]]
               identifier = "concepts"
@@ -125,7 +143,7 @@ relativeURLs = true
           identifier = "doc_archive"
           name = "Other Releases"
           url = "/documentation"
-          weight = 10
+          weight = 11
           parent="main_doc"
   [[menu.main]]
       identifier = "main_faq"

--- a/content/documentation/staging/configuration/_index.adoc
+++ b/content/documentation/staging/configuration/_index.adoc
@@ -1,0 +1,7 @@
+---
+title: "Configuration"
+date: 2020-08-25T00:00:00+02:00
+draft: false
+weight: 9
+---
+

--- a/content/documentation/staging/configuration/authentication/_index.adoc
+++ b/content/documentation/staging/configuration/authentication/_index.adoc
@@ -1,0 +1,21 @@
+---
+title: "Authentication"
+date: 2020-08-25T00:00:00+02:00
+draft: false
+weight: 9
+hideIndex: true
+---
+
+Kiali supports four authentication mechanisms:
+
+* link:{{< relref "anonymous" >}}[anonymous]: gives free access to Kiali.
+* link:{{< relref "openid" >}}[openid]: requires authentication through a third-party service to access Kiali.
+* link:{{< relref "openshift" >}}[openshift]: requires authentication through the OpenShift authentication to access Kiali.
+* link:{{< relref "token" >}}[token]: requires to provide a Kubernetes ServiceAccount token to ccess Kiali.
+
+The default authentication mechanism for OpenShift clusters is `openshift`. For
+all other Kubernetes clusters, the default mechanism is `token`.
+
+Read the dedicate page of each authentication mechanism (by clicking on the
+bullets) to learn more. All mechanisns, but `anonymous`, support link:{{<
+relref "../rbac" >}}[Role-based access control].

--- a/content/documentation/staging/configuration/authentication/_index.adoc
+++ b/content/documentation/staging/configuration/authentication/_index.adoc
@@ -11,11 +11,11 @@ Kiali supports four authentication mechanisms:
 * link:{{< relref "anonymous" >}}[anonymous]: gives free access to Kiali.
 * link:{{< relref "openid" >}}[openid]: requires authentication through a third-party service to access Kiali.
 * link:{{< relref "openshift" >}}[openshift]: requires authentication through the OpenShift authentication to access Kiali.
-* link:{{< relref "token" >}}[token]: requires to provide a Kubernetes ServiceAccount token to ccess Kiali.
+* link:{{< relref "token" >}}[token]: requires user to provide a Kubernetes ServiceAccount token to access Kiali.
 
 The default authentication mechanism for OpenShift clusters is `openshift`. For
 all other Kubernetes clusters, the default mechanism is `token`.
 
-Read the dedicate page of each authentication mechanism (by clicking on the
-bullets) to learn more. All mechanisns, but `anonymous`, support link:{{<
+Read the dedicated page of each authentication mechanism (by clicking on the
+bullets) to learn more. All mechanisms other than `anonymous` support link:{{<
 relref "../rbac" >}}[Role-based access control].

--- a/content/documentation/staging/configuration/authentication/anonymous.adoc
+++ b/content/documentation/staging/configuration/authentication/anonymous.adoc
@@ -34,7 +34,7 @@ means.
 == Set-up
 
 To use the `anonymous` strategy, use the following configuration in the Kiali
-operator resource:
+CR:
 
 [source,yaml]
 ----
@@ -71,7 +71,7 @@ Then grant the `kiali` role only in needed namespaces. For example:
 
 Alternatively, you can tell the Kiali Operator to install Kiali in "view only"
 mode (this does work for either OpenShift or Kubernetes). You do this by
-setting the `view_only_mode` to `true` in the Kiali operator resource, which
+setting the `view_only_mode` to `true` in the Kiali CR, which
 allows Kiali to read service mesh resources found in the cluster, but it does
 not allow any change:
 

--- a/content/documentation/staging/configuration/authentication/anonymous.adoc
+++ b/content/documentation/staging/configuration/authentication/anonymous.adoc
@@ -1,0 +1,83 @@
+---
+title: "Anonymous strategy"
+date: 2020-08-25T00:00:00+02:00
+draft: false
+weight: 9
+---
+
+:toc: macro
+:toc-title: In this section:
+:keywords: authentication anonymous
+:icons: font
+:sectlinks:
+
+toc::[]
+
+== Introduction
+
+The `anonymous` strategy removes any authentication requirement. Users will
+have access to Kiali without providing any credentials.
+
+Although the `anonymous` strategy doesn't provide any access protection, it's
+valid for some use-cases. Some examples known from the community:
+
+* Exposing Kiali through a reverse proxy, where the reverse proxy is providing a custom authentication mechanism.
+* Exposing Kiali on an already limited network of trusted users.
+* When Kiali is accessed through `kubectl port-forward` or alike commands that allow usage of the cluster's RBAC capabilities to limit access.
+* When developing Kiali, where a developer has a private instance on his own machine.
+
+icon:bullhorn[size=1x]{nbsp} It's worth to empasize that the `anonymous`
+strategy will leave Kiali unsecured. If you are using this option, make sure
+that Kiali is available only to trusted users, or access is protected by other
+means.
+
+== Set-up
+
+To use the `anonymous` strategy, use the following configuration in the Kiali
+operator resource:
+
+[source,yaml]
+----
+spec:
+  auth:
+    strategy: anonymous
+----
+
+The `anonymous` strategy doesn't have any additional configuration.
+
+== Access control
+
+When using the `anonymous` strategy, the content displayed in Kiali is based on
+the permissions of the Kiali service account. By default, the Kiali service
+account has cluster wide access and will be able to display everything in the
+cluster.
+
+If you are running Kiali in OpenShift, access can be customized by changing
+privileges to the Kiali ServiceAccount. For example, to reduce permissions to
+individual namespaces, first, remove the cluster-wide permissions granted by
+default:
+
+[source,bash]
+----
+  oc delete clusterrolebindings kiali
+----
+
+Then grant the `kiali` role only in needed namespaces. For example:
+
+[source,bash]
+----
+  oc adm policy add-role-to-user kiali system:serviceaccount:istio-system:kiali-service-account -n ${NAMESPACE}
+----
+
+Alternatively, you can tell the Kiali Operator to install Kiali in "view only"
+mode (this does work for either OpenShift or Kubernetes). You do this by
+setting the `view_only_mode` to `true` in the Kiali operator resource, which
+allows Kiali to read service mesh resources found in the cluster, but it does
+not allow any change:
+
+[source,yaml]
+----
+spec:
+  deployment:
+    view_only_mode: true
+----

--- a/content/documentation/staging/configuration/authentication/openid.adoc
+++ b/content/documentation/staging/configuration/authentication/openid.adoc
@@ -46,7 +46,7 @@ authenticated requests to the Kubernetes API.
 == Set-up
 
 To enable the OpenID Connect strategy, the minimal configuration you need to
-set in the Kiali operator resource is like the following:
+set in the Kiali CR is like the following:
 
 [source,yaml]
 ----
@@ -66,7 +66,7 @@ to start the cluster API server]. If these values don't match, users will fail
 to login to Kiali.
 
 If you are using a replacement or a reverse proxy for the Kubernetes API
-server, the minimal configuration is like following:
+server, the minimal configuration is like the following:
 
 [source,yaml]
 ----
@@ -91,7 +91,7 @@ file encoded in a base64 string, to trust the secure connection.
 The Kiali front-end will, by default, retrieve the string of the `sub` claim of
 the OpenID token and display it as the user name. You can customize which field
 to display as the user name by setting the `username_claim` attribute of the
-operator resource. For example:
+Kiali CR. For example:
 
 [source,yaml]
 ----
@@ -110,7 +110,7 @@ server.
 
 By default, Kiali will request access to the `openid`, `profile` and `email`
 standard scopes. If you need a different set of scopes, you can set the
-`scopes` attribute in the Kiali operator resource. For example:
+`scopes` attribute in the Kiali CR. For example:
 
 [source,yaml]
 ----
@@ -124,7 +124,7 @@ spec:
 ----
 
 The `openid` scope is forced. If you don't add it to the list of scopes to
-request, Kiali will anyway request it to the identity provider.
+request, Kiali will still request it from the identity provider.
 
 === Configuring authentication timeout
 
@@ -146,7 +146,7 @@ spec:
 
 If your OpenID provider is using a self-signed certificate, you can disable
 certificate validation by setting the `insecure_skip_verify_tls` to `true` in
-the Kiali operator resource:
+the Kiali CR:
 
 [source,yaml]
 ----
@@ -158,4 +158,3 @@ spec:
 
 icon:bullhorn[size=1x]{nbsp} You should use self-signed certificates only for
 testing purposes.
-

--- a/content/documentation/staging/configuration/authentication/openid.adoc
+++ b/content/documentation/staging/configuration/authentication/openid.adoc
@@ -1,0 +1,161 @@
+---
+title: "OpenID Connect strategy"
+date: 2020-08-25T00:00:00+02:00
+draft: false
+weight: 9
+---
+
+:toc: macro
+:toc-title: In this section:
+:keywords: authentication openid
+:icons: font
+:sectlinks:
+
+toc::[]
+
+== Introduction
+
+The `openid` authentication strategy lets you integrate Kiali to an external
+identity provider that implements link:https://openid.net/connect/[OpenID
+Connect], and allows users to login to Kiali using their existing accounts of a
+third-party system.
+
+The `openid` strategy takes advantage of the cluster's RBAC. See the link:{{<
+relref "../rbac" >}}[Role-based access control documentation] for more details.
+
+== Requirements
+
+You need either:
+
+* A link:https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens[Kubernetes cluster configured with OpenID connect integration], which results in the API server accepting tokens issued by your identity provider; or
+* A replacement or reverse proxy for the Kubernetes cluster API capable of handling the OIDC authentication.
+
+The first option is preferred if you can manipulate your cluster API server
+startup flags, which will result in your cluster to also be integrated with the
+external OpenID provider.
+
+The second option is provided for cases where you are using a managed
+Kubernetes and your cloud provider does not support configuring OpenID
+integration. Kiali assumes an implementation of a Kubernetes API server. For
+example, a community user has reported to successfully configure Kiali's OpenID
+strategy by using
+link:https://github.com/jetstack/kube-oidc-proxy[`kube-oidc-proxy`] which is a
+reverse proxy that handles the OpenID authentication and forwards the
+authenticated requests to the Kubernetes API.
+
+== Set-up
+
+To enable the OpenID Connect strategy, the minimal configuration you need to
+set in the Kiali operator resource is like the following:
+
+[source,yaml]
+----
+spec:
+  auth:
+    strategy: openid
+    openid:
+      client_id: "kiali-client"
+      issuer_uri: "https://openid.issuer.com"
+----
+
+This assumes that your Kubernetes cluster is configured with OpenID Connect
+integration. In this case, the `client-id` and `issuer_uri` attributes must
+match the `--oidc-client-id` and `--oidc-issuer-url` flags
+link:https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server[used
+to start the cluster API server]. If these values don't match, users will fail
+to login to Kiali.
+
+If you are using a replacement or a reverse proxy for the Kubernetes API
+server, the minimal configuration is like following:
+
+[source,yaml]
+----
+spec:
+  auth:
+    strategy: openid
+    openid:
+      api_proxy: "https://proxy.domain.com:port"
+      api_proxy_ca_data: "..."
+      client_id: "kiali-client"
+      issuer_uri: "https://openid.issuer.com"
+----
+
+The value of `client-id` and `issuer_uri` must match the values of the
+configuration of your reverse proxy or cluster API replacement. The `api_proxy`
+attribute is the URI of the reverse proxy or cluster API replacement (only
+HTTPS is allowed). The `api_proxy_ca_data` is the public certificate authority
+file encoded in a base64 string, to trust the secure connection.
+
+=== Configuring the displayed user name
+
+The Kiali front-end will, by default, retrieve the string of the `sub` claim of
+the OpenID token and display it as the user name. You can customize which field
+to display as the user name by setting the `username_claim` attribute of the
+operator resource. For example:
+
+[source,yaml]
+----
+spec:
+  auth:
+    openid:
+      username_claim: "email"
+----
+
+Usually, you will want the `username_claim` attribute to match the
+`--oidc-username-claim` flag used to start the Kubernetes API server, or the
+equivalent option if you are using a replacement or reverse proxy of the API
+server.
+
+=== Configuring requested scopes
+
+By default, Kiali will request access to the `openid`, `profile` and `email`
+standard scopes. If you need a different set of scopes, you can set the
+`scopes` attribute in the Kiali operator resource. For example:
+
+[source,yaml]
+----
+spec:
+  auth:
+    openid:
+      scopes:
+      - "openid"
+      - "email"
+      - "groups"
+----
+
+The `openid` scope is forced. If you don't add it to the list of scopes to
+request, Kiali will anyway request it to the identity provider.
+
+=== Configuring authentication timeout
+
+When the user is redirected to the external authentication system, by default
+Kiali will wait at most 5 minutes for the user to authenticate. After that time
+has elapsed, Kiali will reject authentication. You can adjust this timeout by
+setting the `authentication_timeout` with the number of seconds that Kiali
+should wait at most. For example:
+
+[source,yaml]
+----
+spec:
+  auth:
+    openid:
+      authentication_timeout: 60 # Wait only one minute.
+----
+
+=== Using an OpenID provider with a self-signed certificate
+
+If your OpenID provider is using a self-signed certificate, you can disable
+certificate validation by setting the `insecure_skip_verify_tls` to `true` in
+the Kiali operator resource:
+
+[source,yaml]
+----
+spec:
+  auth:
+    openid:
+      insecure_skip_verify_tls: true
+----
+
+icon:bullhorn[size=1x]{nbsp} You should use self-signed certificates only for
+testing purposes.
+

--- a/content/documentation/staging/configuration/authentication/openshift.adoc
+++ b/content/documentation/staging/configuration/authentication/openshift.adoc
@@ -19,7 +19,7 @@ The `openshift` authentication strategy is the preferred and default strategy
 when Kiali is deployed on an OpenShift cluster.
 
 When using the `openshift` strategy, a user logging into Kiali will be
-redirected to the login page of the OpenShift console. Once the user provide
+redirected to the login page of the OpenShift console. Once the user provides
 his OpenShift credentials, he will be redireted back to Kiali and will be
 logged in if the user has enough privileges.
 
@@ -31,7 +31,7 @@ details.
 
 Since `openshift` is the default strategy when deploying Kiali in OpenShift,
 you shouldn't need to configure anything. If you want to be verbose, use the
-following configuration in the Kiali operator resource:
+following configuration in the Kiali CR:
 
 [source,yaml]
 ----
@@ -41,6 +41,5 @@ spec:
 ----
 
 The `openshift` strategy doesn't have any additional configuration. The Kiali
-operator will make sure to setup the needed OpenShift OAuth resources register
+operator will make sure to setup the needed OpenShift OAuth resources to register
 Kiali as a client.
-

--- a/content/documentation/staging/configuration/authentication/openshift.adoc
+++ b/content/documentation/staging/configuration/authentication/openshift.adoc
@@ -1,0 +1,46 @@
+---
+title: "OpenShift strategy"
+date: 2020-08-25T00:00:00+02:00
+draft: false
+weight: 9
+---
+
+:toc: macro
+:toc-title: In this section:
+:keywords: authentication openshift
+:icons: font
+:sectlinks:
+
+toc::[]
+
+== Introduction
+
+The `openshift` authentication strategy is the preferred and default strategy
+when Kiali is deployed on an OpenShift cluster.
+
+When using the `openshift` strategy, a user logging into Kiali will be
+redirected to the login page of the OpenShift console. Once the user provide
+his OpenShift credentials, he will be redireted back to Kiali and will be
+logged in if the user has enough privileges.
+
+The `openshift` strategy takes advantage of the cluster's RBAC. See the
+link:{{< relref "../rbac" >}}[Role-based access control documentation] for more
+details.
+
+== Set-up
+
+Since `openshift` is the default strategy when deploying Kiali in OpenShift,
+you shouldn't need to configure anything. If you want to be verbose, use the
+following configuration in the Kiali operator resource:
+
+[source,yaml]
+----
+spec:
+  auth:
+    strategy: openshift
+----
+
+The `openshift` strategy doesn't have any additional configuration. The Kiali
+operator will make sure to setup the needed OpenShift OAuth resources register
+Kiali as a client.
+

--- a/content/documentation/staging/configuration/authentication/token.adoc
+++ b/content/documentation/staging/configuration/authentication/token.adoc
@@ -28,7 +28,7 @@ relref "../rbac" >}}[Role-based access control documentation] for more details.
 Since `token` is the default strategy when deploying Kiali in Kubernetes, you
 shouldn't need to configure anything, unless your cluster is OpenShift. If you
 want to be verbose or if you need to enable the `token` strategy in OpenShift,
-use the following configuration in the Kiali operator resource:
+use the following configuration in the Kiali CR:
 
 [source,yaml]
 ----

--- a/content/documentation/staging/configuration/authentication/token.adoc
+++ b/content/documentation/staging/configuration/authentication/token.adoc
@@ -1,0 +1,40 @@
+---
+title: "Token strategy"
+date: 2020-08-25T00:00:00+02:00
+draft: false
+weight: 9
+---
+
+:toc: macro
+:toc-title: In this section:
+:keywords: authentication token
+:icons: font
+:sectlinks:
+
+toc::[]
+
+== Introduction
+
+The `token` authentication strategy allows a user to login to Kiali using the
+token of a Kubernetes ServiceAccount. This is similar to the
+link:https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/README.md#login-view[login
+view of Kubernetes Dashboard].
+
+The `token` strategy takes advantage of the cluster's RBAC. See the link:{{<
+relref "../rbac" >}}[Role-based access control documentation] for more details.
+
+== Set-up
+
+Since `token` is the default strategy when deploying Kiali in Kubernetes, you
+shouldn't need to configure anything, unless your cluster is OpenShift. If you
+want to be verbose or if you need to enable the `token` strategy in OpenShift,
+use the following configuration in the Kiali operator resource:
+
+[source,yaml]
+----
+spec:
+  auth:
+    strategy: token
+----
+
+The `token` strategy doesn't have any additional configuration.

--- a/content/documentation/staging/configuration/rbac.adoc
+++ b/content/documentation/staging/configuration/rbac.adoc
@@ -25,7 +25,7 @@ dedicated Anonymous strategy page].
 
 Kiali uses the RBAC capabilities of the underlying cluster. Thus, RBAC is
 accomplished by using the standard RBAC features of the cluster, which is
-through ClusterRoles, ClusterRoleBinding, Roles and RoleBindings resources.
+through ClusterRoles, ClusterRoleBindings, Roles and RoleBindings resources.
 Read the
 link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/[Kubernetes
 RBAC documentation] for details. If you are using OpenShift, read the
@@ -69,13 +69,13 @@ $ kubectl create rolebinding john-openid-binding --clusterrole=kiali --user="joh
 $ oc adm policy add-role-to-user kiali john -n mynamespace # For OpenShift clusters
 ----
 
-Please, read your cluster RBAC documentation to learn how to assign privileges.
+Please read your cluster RBAC documentation to learn how to assign privileges.
 
 == Minimum required privileges to login
 
 The `get namespace` privilege in some namespace is the minimum privilege needed
 in order to be able to login to Kiali. This means you need the following
-minimal `Role` binded to the user requiring to login:
+minimal `Role` bound to the user that wants to login:
 
 [source,yaml]
 ----
@@ -106,16 +106,16 @@ kubectl describe clusterrole kiali
 icon:bullhorn[size=1x]{nbsp} If you installed Kiali with `view_only_mode: true`
 option, the `ClusterRole` will be named `kiali-viewer` instead of `kiali`.
 
-Alternatively, check in the Kiali Operator source code the
+Alternatively, check in the Kiali Operator source code. See either the
 link:https://github.com/kiali/kiali-operator/blob/master/roles/default/kiali-deploy/templates/kubernetes/role.yaml[Kubernetes
 role.yaml template file], or the
 link:https://github.com/kiali/kiali-operator/blob/master/roles/default/kiali-deploy/templates/openshift/role.yaml[OpenShift
 role.yaml template file].
 
 You can use this `ClusterRole` to assign privileges to users requiring access
-to Kiali. You can assign privileges either in one namespace, which will result
+to Kiali. You can assign privileges either in one namespace, which will result in
 users being able to see only resources in that namespace; or assign
-clustser-wide privileges.
+cluster-wide privileges.
 
 For example, to assign privileges to the `john` user and limiting access to the
 `myApp` namespace, you could run either:
@@ -126,7 +126,7 @@ $ kubectl create rolebinding john-binding --clusterrole=kiali --user="john" --na
 $ oc adm policy add-role-to-user kiali john -n myApp # For OpenShift clusters
 ----
 
-But if you ned to assign cluster-wide privileges, you could run either:
+But if you need to assign cluster-wide privileges, you could run either:
 
 [source,bash]
 ----
@@ -140,6 +140,6 @@ based off the privileges in Kiali's `ClusterRole` and remove the privileges you
 want to ban. You must understand that some Kiali features may not work properly
 because of the reduced privilege set.
 
-icon:bullhorn[size=1x]{nbsp} Do not edit the `kiali` nor the `kiali-viewer`
-`ClusterRoles` because they are binded to the Kiali ServiceAccount and editing
+icon:bullhorn[size=1x]{nbsp} Do not edit the `kiali` or the `kiali-viewer`
+`ClusterRoles` because they are bound to the Kiali ServiceAccount and editing
 them may lead to Kiali not working properly.

--- a/content/documentation/staging/configuration/rbac.adoc
+++ b/content/documentation/staging/configuration/rbac.adoc
@@ -1,0 +1,145 @@
+---
+title: "Role-based access control"
+date: 2020-08-25T00:00:00+02:00
+draft: false
+weight: 9
+---
+
+:toc: macro
+:toc-title: In this section:
+:keywords: Kiali RBAC privileges
+:icons: font
+:sectlinks:
+
+toc::[]
+
+== Introduction
+
+Kiali supports role-based access control (RBAC) when you are using either the
+`openid`, `openshift` or `token` authentication strategies.
+
+If you are using the `anonymous` strategy, RBAC isn't supported, but you still
+can limit privileges if your cluster is OpenShift. See the
+link:../authentication/anonymous#_access_control[access control section of the
+dedicated Anonymous strategy page].
+
+Kiali uses the RBAC capabilities of the underlying cluster. Thus, RBAC is
+accomplished by using the standard RBAC features of the cluster, which is
+through ClusterRoles, ClusterRoleBinding, Roles and RoleBindings resources.
+Read the
+link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/[Kubernetes
+RBAC documentation] for details. If you are using OpenShift, read the
+link:https://docs.openshift.com/container-platform/4.5/authentication/using-rbac.html[OpenShift
+RBAC documentation].
+
+In general, Kiali will give access to the resources granted to the account used
+to login. Specifically, depending on the authentication strategy, this
+translates to:
+
+[cols="25%,75%",options="header"]
+|===
+|Authentication strategy
+|Access to
+
+| `openid`
+| resources granted to the user of the third-party authentication system
+
+| `openshift`
+| resources granted to the OpenShift user
+
+| `token`
+| resources granted to the ServiceAccount whose token was used to login
+
+|===
+
+For example, if you are using the `token` strategy, you would grant
+cluster-wide privileges to a ServiceAccount with this command:
+
+[source,bash]
+----
+$ kubectl create clusterrolebinding john-binding --clusterrole=kiali --serviceaccount=mynamespace:john
+----
+
+and if you are using `openshift` or `openid` strategies, you could assign
+privileges with any of these commands:
+
+[source,bash]
+----
+$ kubectl create rolebinding john-openid-binding --clusterrole=kiali --user="john@example.com" --namespace=mynamespace
+$ oc adm policy add-role-to-user kiali john -n mynamespace # For OpenShift clusters
+----
+
+Please, read your cluster RBAC documentation to learn how to assign privileges.
+
+== Minimum required privileges to login
+
+The `get namespace` privilege in some namespace is the minimum privilege needed
+in order to be able to login to Kiali. This means you need the following
+minimal `Role` binded to the user requiring to login:
+
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs:
+  - get
+----
+
+This minimal `Role` will allow a user to login, but Kiali will be unusable. You
+will need a broader set of privileges so that Kiali works fine.
+
+== Privileges required for Kiali to work correctly
+
+The default installation of Kiali creates a `ClusterRole` with the needed
+privileges to take the most advantage of all Kiali features. Inspect the
+privileges with
+
+[source,bash]
+----
+kubectl describe clusterrole kiali
+----
+
+icon:bullhorn[size=1x]{nbsp} If you installed Kiali with `view_only_mode: true`
+option, the `ClusterRole` will be named `kiali-viewer` instead of `kiali`.
+
+Alternatively, check in the Kiali Operator source code the
+link:https://github.com/kiali/kiali-operator/blob/master/roles/default/kiali-deploy/templates/kubernetes/role.yaml[Kubernetes
+role.yaml template file], or the
+link:https://github.com/kiali/kiali-operator/blob/master/roles/default/kiali-deploy/templates/openshift/role.yaml[OpenShift
+role.yaml template file].
+
+You can use this `ClusterRole` to assign privileges to users requiring access
+to Kiali. You can assign privileges either in one namespace, which will result
+users being able to see only resources in that namespace; or assign
+clustser-wide privileges.
+
+For example, to assign privileges to the `john` user and limiting access to the
+`myApp` namespace, you could run either:
+
+[source,bash]
+----
+$ kubectl create rolebinding john-binding --clusterrole=kiali --user="john" --namespace=myApp
+$ oc adm policy add-role-to-user kiali john -n myApp # For OpenShift clusters
+----
+
+But if you ned to assign cluster-wide privileges, you could run either:
+
+[source,bash]
+----
+$ kubectl create clusterrolebinding john-admin-binding --clusterrole=kiali --user="john"
+$ oc adm policy add-cluster-role-to-user kiali john # For OpenShift clusters
+----
+
+In case you need to assign a more limited set of privileges than the ones
+present in the Kiali `ClusterRole`, create your own `ClusterRole` or `Role`
+based off the privileges in Kiali's `ClusterRole` and remove the privileges you
+want to ban. You must understand that some Kiali features may not work properly
+because of the reduced privilege set.
+
+icon:bullhorn[size=1x]{nbsp} Do not edit the `kiali` nor the `kiali-viewer`
+`ClusterRoles` because they are binded to the Kiali ServiceAccount and editing
+them may lead to Kiali not working properly.

--- a/content/documentation/staging/installation-guide/index.adoc
+++ b/content/documentation/staging/installation-guide/index.adoc
@@ -113,7 +113,7 @@ The version of Kiali packaged with Istio or Maistra may not contain the most rec
 
 Installing the latest version of Kiali is done using the Kiali Operator. The Kiali Operator is a link:https://coreos.com/operators/[Kubernetes Operator]. The Kiali Operator manages your Kiali installation. The Kiali Operator watches the Kiali Custom Resource (CR), a YAML file that holds the Kiali configuration. When you modify the Kiali CR, the operator installs, updates, or uninstalls Kiali as needed.
 
-The next few sections describe the different installation methods available for installing the Kiali Operator. Depending on the installation method you use, the operator may then install Kiali. Before you install Kiali, you will want to know which authentication strategy Kiali should use (this determines how users are to log into Kiali). See link:#_login_options[Login Options] for more on the `anonymous`, `openshift`, `token`, and `openid` authentication strategies.
+The next few sections describe the different installation methods available for installing the Kiali Operator. Depending on the installation method you use, the operator may then install Kiali. Before you install Kiali, you will want to know which authentication strategy Kiali should use (this determines how users are to log into Kiali). See the link:{{< ref "configuration/authentication" >}}[authentication configuration page].
 
 icon:bullhorn[size=1x]{nbsp} It is only necessary to install the Kiali Operator one time. After the operator is installed you need only create or edit the Kiali CR (see link:#_create_or_edit_the_kiali_cr[Create or Edit the Kiali CR]). The Kiali ConfigMap will be managed by the Kiali Operator and should *not* be manually edited.  As soon as the Kiali operator is installed and running, there is no need to again perform one of the installations below.
 
@@ -184,7 +184,7 @@ To update Kiali, edit and save the existing Kiali CR; for example:
 
 Once Istio, Maistra, or the Kiali Operator has installed Kiali, and the Kiali pod has successfully started, you can access the UI. Please, check the link:{{< ref "/documentation/staging/faq/general#how-do-i-access-kiai" >}}[FAQ: How do I access Kiali UI?]
 
-icon:bullhorn[size=1x]{nbsp} The credentials you use on the login screen depend on the authentication strategy that was configured for Kiali. See link:#_login_options[Login Options] for more details.
+icon:bullhorn[size=1x]{nbsp} The credentials you use on the login screen depend on the authentication strategy that was configured for Kiali. See the link:{{< ref "configuration/authentication" >}}[authentication configuration page] for more details.
 
 
 == Uninstall
@@ -249,110 +249,6 @@ server:
 ----
 
 The above is the default when Kiali is installed on Kubernetes - so to access the Kiali UI on Kubernetes you access it at the root context path of `/kiali`.
-
-=== Login Options
-
-Kiali supports several different login options.
-
-*anonymous*: This option removes any login requirement. A user will not be presented the login page and will automatically have access to Kiali without having to present any credentials.
-
-*openshift*: If you have deployed Kiali on OpenShift you can use this option (this is the default option if you're using OpenShift). With this option, users log in to Kiali with the OpenShift OAuth login. What users can access in Kiali will now be based on their user roles in OpenShift using the Kubernetes RBAC.
-
-*token*: This option allows a user to log in to Kiali using a Service Account token. This is similar to the link:https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/README.md#login-view[login view of Kubernetes Dashboard]. When using this option, the cluser RBAC will take effect and users can access only what is allowed to the Service Account.
-
-*openid*: This option allows a user to log in to Kiali using an external identity provider that implements link:https://openid.net/connect/[OpenID Connect]. When using this option, the cluser RBAC will take effect and users can access only what is allowed via the link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/[cluster's authorization mechanisms]. This strategy requires that your link:https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens[Kubernetes cluster is configured to accept tokens issued from your identity provider]. See the dedicated link:#_openid_connect[OpenID section of this page] for more information.
-
-icon:bullhorn[size=1x]{nbsp} Using the *anonymous* option will leave Kiali unsecured. Anyone who can access the console will have full access to Kiali. If you are using this option you will need to make sure that it is only available on a trusted network and that only trusted users can access it.
-
-For the `anonymous` login option, the content displayed in Kiali is based on the permissions of the Kiali service account. On Kubernetes, the Kiali service account has cluster wide access and will be able to display everything in the cluster. By default, in OpenShift the service account will also have access to everything in the cluster but this can be customized by following the link:#_reducing_permissions_in_openshift[instructions below].
-
-For the `openshift` login option, the content displayed in Kiali is based on the permissions of the user who logged in via the OpenShift OAuth login page. This means that individual users will be shown different content based on their roles within OpenShift. See the link:#openshift_user_permissions[section] below for how to grant or remove a user's access to specific namespaces.
-
-The login option can be specified in the Kiali CR when installing Kiali. For instance, to use the `openshift` login option, the Kiali CR should contain the following in the `auth` section:
-
-[source,yaml]
-----
-auth:
-  strategy: openshift
-----
-
-==== OpenID Connect
-
-The `openid` login strategy requires additional settings in the `auth.openid` section. The minimal required attributes are `client_id` and `issuer_uri`. For example:
-
-[source,yaml]
-----
-auth:
-  strategy: openid
-  openid:
-    client_id: "kiali-client"
-    issuer_uri: "https://openid.issuer.com"
-----
-
-Please, check the
-link:https://github.com/kiali/kiali-operator/blob/8f2329c17d67d9a22c9fc1a50b468a7e80df72e6/deploy/kiali/kiali_cr.yaml#L173-L206[kiali_cr.yaml]
-file of the Kiali operator repository to learn about all available options for
-configuring the `openid` strategy.
-
-The `openid` strategy requires that your
-link:https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens[Kubernetes
-cluster is configured to accept tokens generated by your identity provider]. If
-your cluster is not properly configured, authentication will fail and users
-won't be able to log in to Kiali. Because of this, the value of `client-id`,
-`issuer_uri` and `username_claim` configuration options in Kiali are required
-to match the `--oidc-client-id`, `--oidc-issuer-url` and
-`--oidc-username-claim` flags
-link:https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server[used
-to start the cluster API server]. If one or more of these values don't match,
-users might fail to log in to Kiali.
-
-Kiali uses the OpenID identity of the logged in user to make calls to the
-cluster API. Because of this, the `openid` strategy is RBAC-enabled and only
-users with privileges on the cluster will be able to log in to Kiali.
-Depending on the options you provided in the Kiali operator CR, there will be a
-ClusterRole named either `kiali` or `kiali-viewer` that you can use to assign
-privileges.  For example, to assign privileges to the `john@example.com` OpenId
-user in the `testing` namespace, you could run the following command:
-
-[source,bash]
-----
-kubectl create rolebinding john-openid-binding --clusterrole=kiali --user="john@example.com" --namespace=testing
-----
-
-By assigning privileges this way, the user will be able to use Kiali and
-inspect only the `testing` namespace. If you need to assign cluster-wide
-permissions, assign privileges using a ClusterRoleBinding:
-
-[source,bash]
-----
-kubectl create clusterrolebinding john-openid-clusterbinding --clusterrole=kiali --user="john@example.com"
-----
-
-icon:bullhorn[size=1x]{nbsp} If you need to assign a more limited set of
-privileges, it's possible to use the `kiali` or `kiali-viewer` ClusterRoles as
-a base for creating your own customized Roles or ClusterRoles. Then, bind the
-users these customized roles. Do not edit the `kiali` nor the `kiali-viewer`
-ClusterRoles becuase they are binded to the Kiali ServiceAccount and editing
-them may lead to Kiali not working properly.
-
-[#openshift_user_permissions]
-==== OpenShift User Permissions
-
-If you are running with the `openshift` login option you will need to grant a user the 'kiali' role for them to be able to properly access a namespace in Kiali.
-
-For instance, to grant the user 'developer' access to the 'myproject' namespace, you could run the following command:
-
-[source,bash]
-----
-  oc adm policy add-role-to-user kiali developer -n myproject
-----
-
-To remove the 'kiali' role from the user 'developer' in the 'myproject' namespace you can run the following command:
-
-[source,bash]
-----
-  oc adm policy remove-role-from-user kiali developer -n myproject
-----
 
 === Namespace Management
 

--- a/content/documentation/staging/quick-start/index.adoc
+++ b/content/documentation/staging/quick-start/index.adoc
@@ -86,7 +86,7 @@ istioctl dashboard kiali
 
 == Logging In
 
-The credentials you use to log into Kiali depend on the authentication strategy configured for Kiali. The install instructions mentioned above set the authentication strategy of `anonymous` which allows anyone to access the Kiali UI without having to provide any credentials. See link:{{< ref "/documentation/staging/installation-guide#_login_options" >}}[Login Options] for more details.
+The credentials you use to log into Kiali depend on the authentication strategy configured for Kiali. The install instructions mentioned above set the authentication strategy of `anonymous` which allows anyone to access the Kiali UI without having to provide any credentials. See the link:{{< ref "configuration/authentication" >}}[authentication configuration page] for more details.
 
 
 == More installation details


### PR DESCRIPTION
This is adding documentation for kiali/kiali#3142. However, since the authentication-related docs are now quite large, this is also re-organizing that content.

All authentication-related content was mostly placed in the installation guide, which is already quite large and somewhat confusing. So, authentication-related content was extracted from the installation guide and placed on it's own pages, hoping is clearer.

RBAC documentation is also extracted and unified to it's own pages. It is reworked because it was scattered and some parts of it were quite outdated.

Related to kiali/kiali#3042
Fixes kiali/kiali#2771