### PR TITLE
Specify type for deletion

### DIFF
--- a/content/documentation/v1.24/installation-guide/index.adoc
+++ b/content/documentation/v1.24/installation-guide/index.adoc
@@ -211,8 +211,8 @@ After you have successfully deleted the Kiali CRs, then you can uninstall the Ki
 [source,bash]
 ----
   helm uninstall --namespace kiali-operator kiali-operator
-  kubectl delete monitoringdashboards.monitoring.kiali.io
-  kubectl delete kialis.kiali.io
+  kubectl delete crd monitoringdashboards.monitoring.kiali.io
+  kubectl delete crd kialis.kiali.io
 ----
 
 


### PR DESCRIPTION
```
➜ kubectl delete monitoringdashboards.monitoring.kiali.io
error: resource(s) were provided, but no name, label selector, or --all flag specified
➜ kubectl delete crd monitoringdashboards.monitoring.kiali.io
customresourcedefinition.apiextensions.k8s.io "monitoringdashboards.monitoring.kiali.io" deleted
➜ kubectl delete kialis.kiali.io
error: resource(s) were provided, but no name, label selector, or --all flag specified
➜ kubectl delete crd kialis.kiali.io
customresourcedefinition.apiextensions.k8s.io "kialis.kiali.io" deleted
```