### PR TITLE
Documentation for OpenID with RBAC disabled

### DIFF
--- a/content/documentation/staging/configuration/authentication/openid.adoc
+++ b/content/documentation/staging/configuration/authentication/openid.adoc
@@ -20,15 +20,33 @@ identity provider that implements link:https://openid.net/connect/[OpenID
 Connect], and allows users to login to Kiali using their existing accounts of a
 third-party system.
 
-The `openid` strategy takes advantage of the cluster's RBAC. See the link:{{<
-relref "../rbac" >}}[Role-based access control documentation] for more details.
+If your
+link:https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens[Kubernetes
+cluster is also integrated with your OpenId provider], then Kiali's `openid`
+strategy can offer role-based access control (RBAC) through the
+link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/[Kubernetes
+authorization mechanisms]. See the link:{{< relref "../rbac" >}}[RBAC
+documentation] for more details.
 
 Currently, Kiali supports the _authorization code flow_ (preferred) and the
 _implicit flow_ of the link:https://openid.net/connect/[OpenId Connect spec].
 
 == Requirements
 
-You need either:
+If you want to enable usage of the OpenId's _authorization code flow_, make
+sure that the
+link:https://github.com/kiali/kiali-operator/blob/7dafc469c95d4307ebd03c515a87c7f84eb64da7/deploy/kiali/kiali_cr.yaml#L746-L754[Kiali's
+signing key] is 16, 24 or 32 byte long. If you setup a signing key of a
+different size, Kiali will only be capable of using the _implicit flow_. If you
+install Kiali via the operator and don't set a custom signing key, the operator
+should create a 16 byte long signing key.  
+
+icon:bullhorn[size=1x]{nbsp} We recommend using the _authorization code flow_.
+
+If you *_don't need_* RBAC support, the only requirement is to have a
+working OpenId Server where Kiali can be configured as a client application.
+
+If you *_do need_* RBAC support, you need either:
 
 * A link:https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens[Kubernetes cluster configured with OpenID connect integration], which results in the API server accepting tokens issued by your identity provider; or
 * A replacement or reverse proxy for the Kubernetes cluster API capable of handling the OIDC authentication.
@@ -46,17 +64,16 @@ link:https://github.com/jetstack/kube-oidc-proxy[`kube-oidc-proxy`] which is a
 reverse proxy that handles the OpenID authentication and forwards the
 authenticated requests to the Kubernetes API.
 
-== Set-up
+icon:bullhorn[size=1x]{nbsp} Several Azure users have reported that OpenId
+authentication is not working correctly even after enabling Azure AD
+integration in AKS clusters. As of now, if you need RBAC, you will need to
+fallback to using
+link:https://github.com/jetstack/kube-oidc-proxy[`kube-oidc-proxy`] or a
+similar alternative. If you don't need RBAC, just configure Kiali accordingly.
+As nobody in the Kiali team has access to Azure, contributions for improved
+Azure support will be appreciated.
 
-If you want to enable usage of the OpenId's _authorization code flow_, make
-sure that the
-link:https://github.com/kiali/kiali-operator/blob/7dafc469c95d4307ebd03c515a87c7f84eb64da7/deploy/kiali/kiali_cr.yaml#L746-L754[Kiali's
-signing key] is 16, 24 or 32 byte long. If you setup a signing key of a
-different size, Kiali will only be capable of using the _implicit flow_. If you
-install Kiali via the operator and don't set a custom signing key, the operator
-should create a 16 byte long signing key.  
-
-icon:bullhorn[size=1x]{nbsp} We recommend using the _authorization code flow_.
+== Set-up with RBAC support
 
 Assuming you already have a working Kubernetes cluster with OpenId integration
 (or a working alternative like `kube-oidc-proxy`), you should already had
@@ -128,6 +145,46 @@ attribute is the URI of the reverse proxy or cluster API replacement (only
 HTTPS is allowed). The `api_proxy_ca_data` is the public certificate authority
 file encoded in a base64 string, to trust the secure connection.
 
+== Set-up with no RBAC support
+
+Register Kiali as a client application in your OpenId Server. Use the root path
+of your Kiali instance as the callback URL. If the OpenId Server provides you a
+_client secret_, or if you manually set a _client secret_, issue the following
+command to create a Kubernetes secret holding the OpenId client secret:
+
+[source,yaml]
+----
+kubectl create secret generic kiali --from-literal="oidc-secret=$CLIENT_SECRET" -n $NAMESPACE
+----
+
+where `$NAMESPACE` is the namespace where you installed Kiali and
+`$CLIENT_SECRET` is the secret you configured or provided by your OpenId
+Server. If Kiali is already running, you may need to restart the Kiali pod so
+that the secret is mounted in Kiali.
+
+icon:bullhorn[size=1x]{nbsp} This secret is only needed if you want Kiali to
+use the _authorization code flow_ (i.e. if your Kiali's signing key is neither
+16, 24 or 32 byte long).
+
+Then, to enable the OpenID Connect strategy, the minimal configuration you need
+to set in the Kiali CR is like the following:
+
+[source,yaml]
+----
+spec:
+  auth:
+    strategy: openid
+    openid:
+      client_id: "kiali-client"
+      disable_rbac: true
+      issuer_uri: "https://openid.issuer.com"
+----
+
+icon:bullhorn[size=1x]{nbsp} As RBAC is disabled, all users logging into Kiali
+will share the same cluster-wide privileges.
+
+== Additional configurations
+
 === Configuring the displayed user name
 
 The Kiali front-end will, by default, retrieve the string of the `sub` claim of
@@ -143,10 +200,10 @@ spec:
       username_claim: "email"
 ----
 
-Usually, you will want the `username_claim` attribute to match the
+If you enabled RBAC, you will want the `username_claim` attribute to match the
 `--oidc-username-claim` flag used to start the Kubernetes API server, or the
 equivalent option if you are using a replacement or reverse proxy of the API
-server.
+server. Else, any user-friendly claim will be OK as it is purely informational.
 
 === Configuring requested scopes
 


### PR DESCRIPTION
Adding documentation to configure Kiali with OpenID authentication and
RBAC disabled.

Related kiali/kiali#3084