### PR TITLE
Automatic fetching sprint videos from youtube playilist

### DIFF
--- a/themes/kiali/layouts/index.html.html
+++ b/themes/kiali/layouts/index.html.html
@@ -9,7 +9,7 @@
   {{ partial "home/blog-latest-section.html" . }}
   {{ partial "home/video-getting-started-section.html" . }}
   {{ partial "home/video-latest-section.html" . }}
-  {{ partial "home/video-sprint-demo-section-auto.html" . }}
+  {{ partial "home/video-sprint-demo-section.html" . }}
   {{ partial "home/events-latest-section.html" . }}
   </main>
 {{ end }}

--- a/themes/kiali/layouts/index.html.html
+++ b/themes/kiali/layouts/index.html.html
@@ -9,7 +9,7 @@
   {{ partial "home/blog-latest-section.html" . }}
   {{ partial "home/video-getting-started-section.html" . }}
   {{ partial "home/video-latest-section.html" . }}
-  {{ partial "home/video-sprint-demo-section.html" . }}
+  {{ partial "home/video-sprint-demo-section-auto.html" . }}
   {{ partial "home/events-latest-section.html" . }}
   </main>
 {{ end }}

--- a/themes/kiali/layouts/partials/home/video-sprint-demo-section.html
+++ b/themes/kiali/layouts/partials/home/video-sprint-demo-section.html
@@ -1,5 +1,5 @@
 {{- $maxBlogPosts := .Site.Params.maxBlogPosts }}
-{{- $expTimestamp := div now.Unix 6000 }}
+{{- $expTimestamp := div now.Unix 60 }}
 {{- $sprintURL    := printf "https://api.rss2json.com/v1/api.json?timestamp=%d&rss_url=https://www.youtube.com/feeds/videos.xml?playlist_id=PLgwrCYrAkQYOHIeGukEZUmNRGbqI9uwpi" $expTimestamp }}
 {{- $json         := getJSON $sprintURL }}
 {{- $vids         := first $maxBlogPosts $json.items }}

--- a/themes/kiali/layouts/partials/home/video-sprint-demo-section.html
+++ b/themes/kiali/layouts/partials/home/video-sprint-demo-section.html
@@ -1,5 +1,5 @@
-{{- $maxBlogPosts := .Site.Params.maxBlogPosts }}
-{{- $expTimestamp := div now.Unix 60 }}
+{{- $maxBlogPosts := 5 }}
+{{- $expTimestamp := div now.Unix 6000 }}
 {{- $sprintURL    := printf "https://api.rss2json.com/v1/api.json?timestamp=%d&rss_url=https://www.youtube.com/feeds/videos.xml?playlist_id=PLgwrCYrAkQYOHIeGukEZUmNRGbqI9uwpi" $expTimestamp }}
 {{- $json         := getJSON $sprintURL }}
 {{- $vids         := first $maxBlogPosts $json.items }}
@@ -20,11 +20,9 @@
         {{ $link    := .link }}
         {{ $img     := .thumbnail }}
         {{ $title   := .title }}
-        {{ $author  := .author }}
         {{ $dateRaw := .pubDate }}
         {{ $vidId   := index (split .guid ":") 2 }}
         {{ $date    := dateFormat "January 2, 2006" $dateRaw }}
-        {{ $summary := .description | plainify | truncate 150 }}
 
         <div class="video-card">
             <header class="video-header">
@@ -33,7 +31,6 @@
             </header>
             <p class="video-text video-title">{{ $title }}</p>
             <iframe class="video-iframe-links" src="https://www.youtube.com/embed/{{ $vidId }}"></iframe>
-            <p class="video-text video-text-footer">{{ $author }}</p>
         </div>
       {{ end }}
     </div>

--- a/themes/kiali/layouts/partials/home/video-sprint-demo-section.html
+++ b/themes/kiali/layouts/partials/home/video-sprint-demo-section.html
@@ -1,8 +1,14 @@
+{{- $maxBlogPosts := .Site.Params.maxBlogPosts }}
+{{- $expTimestamp := div now.Unix 6000 }}
+{{- $sprintURL    := printf "https://api.rss2json.com/v1/api.json?timestamp=%d&rss_url=https://www.youtube.com/feeds/videos.xml?playlist_id=PLgwrCYrAkQYOHIeGukEZUmNRGbqI9uwpi" $expTimestamp }}
+{{- $json         := getJSON $sprintURL }}
+{{- $vids         := first $maxBlogPosts $json.items }}
+
 <section id="video-sprint-demo" class="video-section">
     <h1>
         Sprint demo videos
         <span class="go-to-videos-link">
-          <a href="https://www.youtube.com/channel/UCcm2NzDN_UCZKk2yYmOpc5w" target="_blank">
+          <a href="https://www.youtube.com/feeds/videos.xml?playlist_id=PLgwrCYrAkQYOHIeGukEZUmNRGbqI9uwpi" target="_blank">
             Go to videos
             <span class="fas fa-external-link-alt"/>
           </a>
@@ -10,46 +16,25 @@
     </h1>
 
     <div id="sprint-videos" class="new-embed-video-links">
-        <div class="video-card">
-            <header class="video-header">
-                <span class="video-text">September 18, 2020</span>
-                <span class=" video-text video-icon"><span class="fas fa-video"/></span>
-            </header>
-            <p class="video-text video-title">Sprint 45 [Kiali v1.24]</p>
-            <iframe class="video-iframe-links" src="https://www.youtube.com/embed/XqliZJZMR84"></iframe>
-            <p class="video-text video-text-footer">Kiali Team</p>
-        </div>
+      {{ range $vids }}
+        {{ $link    := .link }}
+        {{ $img     := .thumbnail }}
+        {{ $title   := .title }}
+        {{ $author  := .author }}
+        {{ $dateRaw := .pubDate }}
+        {{ $vidId   := index (split .guid ":") 2 }}
+        {{ $date    := dateFormat "January 2, 2006" $dateRaw }}
+        {{ $summary := .description | plainify | truncate 150 }}
 
         <div class="video-card">
             <header class="video-header">
-                <span class="video-text">July 27, 2020</span>
+              <span class="video-text">{{ $date }}</span>
                 <span class=" video-text video-icon"><span class="fas fa-video"/></span>
             </header>
-            <p class="video-text video-title">Sprint 42 [Kiali v1.21]</p>
-            <iframe class="video-iframe-links" src="https://www.youtube.com/embed/wCVt8eRbtu8"></iframe>
-            <p class="video-text video-text-footer">Kiali Team</p>
+            <p class="video-text video-title">{{ $title }}</p>
+            <iframe class="video-iframe-links" src="https://www.youtube.com/embed/{{ $vidId }}"></iframe>
+            <p class="video-text video-text-footer">{{ $author }}</p>
         </div>
-
-        <div class="video-card">
-            <header class="video-header">
-                <span class="video-text">July 2, 2020</span>
-                <span class=" video-text video-icon"><span class="fas fa-video"/></span>
-            </header>
-            <p class="video-text video-title">Sprint 41 [Kiali v1.20]</p>
-            <iframe class="video-iframe-links" src="https://www.youtube.com/embed/i0cRua9v4CE"></iframe>
-            <p class="video-text video-text-footer">Kiali Team</p>
-        </div>
-
-        <div class="video-card">
-            <header class="video-header">
-                <span class="video-text">June 9, 2020</span>
-                <span class=" video-text video-icon"><span class="fas fa-video"/></span>
-            </header>
-            <p class="video-text video-title">Sprint 40 [Kiali v1.19]</p>
-            <iframe class="video-iframe-links" src="https://www.youtube.com/embed/9qvhfOkC-RM"></iframe>
-            <p class="video-text video-text-footer">Kiali Team</p>
-        </div>
-
+      {{ end }}
     </div>
-
 </section>

--- a/themes/kiali/layouts/partials/home/video-sprint-demo-section.html
+++ b/themes/kiali/layouts/partials/home/video-sprint-demo-section.html
@@ -37,4 +37,5 @@
         </div>
       {{ end }}
     </div>
+
 </section>

--- a/themes/kiali/layouts/partials/home/video-sprint-demo-section.html
+++ b/themes/kiali/layouts/partials/home/video-sprint-demo-section.html
@@ -8,7 +8,7 @@
     <h1>
         Sprint demo videos
         <span class="go-to-videos-link">
-          <a href="https://www.youtube.com/feeds/videos.xml?playlist_id=PLgwrCYrAkQYOHIeGukEZUmNRGbqI9uwpi" target="_blank">
+          <a href="https://www.youtube.com/playlist?list=PLgwrCYrAkQYOHIeGukEZUmNRGbqI9uwpi" target="_blank">
             Go to videos
             <span class="fas fa-external-link-alt"/>
           </a>

--- a/themes/kiali/static/css/kiali-home.css
+++ b/themes/kiali/static/css/kiali-home.css
@@ -67,6 +67,7 @@ section#hero p.buttons {
   border: 1px solid var(--kiali-card-border-color);
   border-radius: 5px;
   box-shadow: 2px 2px 2px 0 rgba(245,245,245,1);
+  max-width: 375px;
 }
 
 .video-header {
@@ -84,6 +85,8 @@ section#hero p.buttons {
 .video-title {
   font-weight: 400;
   font-size: 18px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .video-text-footer {
@@ -297,6 +300,10 @@ section#blog-latest div#blog-blocks > a > div p {
     padding: var(--kiali-orange-spacing) var(--kiali-yellow-spacing);
   }
 
+  .video-card {
+    max-width: 375px;
+  }
+
   section#blog-latest > h1 {
     float: left;
   }
@@ -326,5 +333,9 @@ section#blog-latest div#blog-blocks > a > div p {
   .video-section {
     padding-left: 15%;
     padding-right: 15%;
+  }
+
+  .video-card {
+    max-width: 375px;
   }
 }


### PR DESCRIPTION
Goal: Automatically update the sprint-videos section in kiali.io.

If we upload the sprint demo on youtube before the automatic release deploy is performed (Friday EOD), then Kiali.io will automatically fetch and build with that video.

As it is right now, we should have to manually change the page to add the video. This section is currently updated and shows some gaps between videos.

Pre-requisite before merge this video:
1) Add the latests sprint demo videos into the [Sprint demos playlist](https://www.youtube.com/playlist?list=PLgwrCYrAkQYOHIeGukEZUmNRGbqI9uwpi). The changes proposed here are displaying only videos in that playlist.
2) Have an agreement that we will add upcoming videos into that playlist.
3) Have an agreement to name the videos on Youtube in standardized way making sure the release version is in the title.

I do also volunteer to add the latest demo vids to the playlist. However, I'd need privileges to manage the kiali channel in YT.