### PR TITLE
Doc updates for 1.26

### DIFF
--- a/content/documentation/staging/glossary/concepts/index.adoc
+++ b/content/documentation/staging/glossary/concepts/index.adoc
@@ -64,10 +64,6 @@ Namespaces are a way to divide cluster resources between multiple users.
 
 A limited or fixed number or amount of resources.
 
-== QuotaSpecBinding
-
-Quota spec binding is used to bind link:https://istio.io/help/faq/mixer/[mixer] quota resource name to a proxy.
-
 == ReplicaSet
 
 Ensures that a specified number of pod replicas are running at any one time.

--- a/content/documentation/staging/glossary/observability/index.adoc
+++ b/content/documentation/staging/glossary/observability/index.adoc
@@ -28,10 +28,6 @@ For more information see the Envoy definition in link:https://istio.io/docs/ops/
 
 A health check performed by Envoy proxies, for inbound and outbound traffic: see membership_healthy and membership_total from link:https://www.envoyproxy.io/docs/envoy/v1.7.1/configuration/cluster_manager/cluster_stats#general[Envoy documentation].
 
-== Mixer
-
-The deprecated entity used for Istio telemetry.
-
 == Pilot
 
 For more information see the Pilot definition in link:https://istio.io/docs/ops/deployment/architecture/#pilot[Istio Pilot Documentation].

--- a/content/documentation/staging/installation-guide/index.adoc
+++ b/content/documentation/staging/installation-guide/index.adoc
@@ -30,12 +30,16 @@ Kiali requires a supported version of Istio. link:https://istio.io/news/[The Ist
 |Kiali
 |Notes
 
-| 1.7.0+
-| 1.22.1+
+| 1.8.0 or later
+| 1.26.0 or later
+| Istio 1.8 removes all support for mixer/telemetry V1, as does Kiali 1.26.0. Use earlier versions of Kiali for mixer support.
+
+| 1.7.0 or later
+| 1.22.1 or later
 | Istio 1.7 istioctl will no longer install Kiali. Use the Istio samples/addons all-in-one yaml or the Kiali Helm Chart for quick demo installs.
 
-| 1.6.0+
-| 1.18.1+
+| 1.6.0 or later
+| 1.18.1 or later
 | Istio 1.6 introduces CRD and Config changes, Kiali 1.17 is recommended for Istio < 1.6.
 
 | <= 1.5

--- a/content/documentation/v1.26/glossary/concepts/index.adoc
+++ b/content/documentation/v1.26/glossary/concepts/index.adoc
@@ -64,10 +64,6 @@ Namespaces are a way to divide cluster resources between multiple users.
 
 A limited or fixed number or amount of resources.
 
-== QuotaSpecBinding
-
-Quota spec binding is used to bind link:https://istio.io/help/faq/mixer/[mixer] quota resource name to a proxy.
-
 == ReplicaSet
 
 Ensures that a specified number of pod replicas are running at any one time.

--- a/content/documentation/v1.26/glossary/observability/index.adoc
+++ b/content/documentation/v1.26/glossary/observability/index.adoc
@@ -28,10 +28,6 @@ For more information see the Envoy definition in link:https://istio.io/docs/ops/
 
 A health check performed by Envoy proxies, for inbound and outbound traffic: see membership_healthy and membership_total from link:https://www.envoyproxy.io/docs/envoy/v1.7.1/configuration/cluster_manager/cluster_stats#general[Envoy documentation].
 
-== Mixer
-
-The deprecated entity used for Istio telemetry.
-
 == Pilot
 
 For more information see the Pilot definition in link:https://istio.io/docs/ops/deployment/architecture/#pilot[Istio Pilot Documentation].

--- a/content/documentation/v1.26/installation-guide/index.adoc
+++ b/content/documentation/v1.26/installation-guide/index.adoc
@@ -30,12 +30,16 @@ Kiali requires a supported version of Istio. link:https://istio.io/news/[The Ist
 |Kiali
 |Notes
 
-| 1.7.0+
-| 1.22.1+
+| 1.8.0 or later
+| 1.26.0 or later
+| Istio 1.8 removes all support for mixer/telemetry V1, as does Kiali 1.26.0. Use earlier versions of Kiali for mixer support.
+
+| 1.7.0 or later
+| 1.22.1 or later
 | Istio 1.7 istioctl will no longer install Kiali. Use the Istio samples/addons all-in-one yaml or the Kiali Helm Chart for quick demo installs.
 
-| 1.6.0+
-| 1.18.1+
+| 1.6.0 or later
+| 1.18.1 or later
 | Istio 1.6 introduces CRD and Config changes, Kiali 1.17 is recommended for Istio < 1.6.
 
 | <= 1.5

--- a/content/news/release-notes.adoc
+++ b/content/news/release-notes.adoc
@@ -32,6 +32,7 @@ Features:
 * https://github.com/kiali/kiali/issues/2235[Improve health check of Istio subcomponents]
 * https://github.com/kiali/kiali/issues/3324[(operator) provide a hidden setting in Kiali CR to turn off operator reconciliation]
 * https://github.com/kiali/kiali/issues/3291[add molecule tests to test as much of the API as possible]
+* https://github.com/kiali/kiali/issues/3084[support external OIDC providers]
 
 Fixes:
 


### PR DESCRIPTION
- remove mixer references
- add feature that was missed from the 1.26 relnotes
- update compatibility chart