### PR TITLE
Fix minimum privileges docs

### DIFF
--- a/content/documentation/staging/configuration/rbac.adoc
+++ b/content/documentation/staging/configuration/rbac.adoc
@@ -89,8 +89,10 @@ rules:
   - get
 ----
 
-This minimal `Role` will allow a user to login, but Kiali will be unusable. You
-will need a broader set of privileges so that Kiali works fine.
+This minimal `Role` will allow a user to login. Kiali may work partially, but
+some pages may be blank or show erroneous information, and errors will be
+logged constantly. You will need a broader set of privileges so that Kiali
+works fine.
 
 == Privileges required for Kiali to work correctly
 


### PR DESCRIPTION
Doc says that minimum privileges required to login will turn kiali
unusable. This is not totally true, as pages that work purely from
metrics will work OK. So, changing that paragraph to be more accurate.

Fixes kiali/kiali#3575