### PR TITLE
Add upgrade section and install docs on kiali-server chart

### DIFF
--- a/content/documentation/staging/installation-guide/index.adoc
+++ b/content/documentation/staging/installation-guide/index.adoc
@@ -275,13 +275,17 @@ In general, Kiali tries to maintain compatability between at least the two most 
 
 For https://istio.io/latest/docs/setup/upgrade/canary/[Canary upgrades]:
 
-. Deploy the upgraded https://istio.io/latest/docs/setup/upgrade/canary/#control-plane[istio control-plane].
+. Deploy the upgraded https://istio.io/latest/docs/setup/upgrade/canary/#control-plane[Istio control-plane].
 . Update the Kiali Server configuration to point to the new Istio deployment. These fields need to be updated:
 - `spec.external_services.istio.config_map_name` to the new Istio configmap revision.
 - `spec.external_services.istio.istiod_deployment_name` to the new istio deployment revision.
 - `spec.external_services.istio.istio_sidecar_injector_config_map_name` to the new istio sidecar injector configmap revision.
 
-If you are using the *kiali-operator*, update the Kiali CR configuration:
+How you update these fields depends on how you have deployed Kiali.
+
+===== Operator
+
+If you are using the kiali-operator, update the Kiali CR configuration:
 
 [source,bash]
 ----
@@ -292,7 +296,9 @@ If you are using the *kiali-operator*, update the Kiali CR configuration:
 
 Wait until the operator restarts the Kiali Server and then verify everything is working correctly.
 
-If you are using the `kiali-server` *Helm Chart*, set the Helm Chart values: 
+===== Helm Chart - Kiali Server
+
+If you are using the `kiali-server` Helm Chart, set the Helm Chart values: 
 
 [source,bash]
 ----
@@ -305,7 +311,7 @@ If you are using the `kiali-server` *Helm Chart*, set the Helm Chart values:
     kiali-server kiali-server
 ----
 
-Restart the Kiali pod to pickup the new configmap changes.
+Then restart the Kiali pod to pickup the new configmap changes.
 
 [source,bash]
 ----
@@ -318,7 +324,7 @@ Restart the Kiali pod to pickup the new configmap changes.
 
 When upgrading Kiali using the operator, it's recommended to keep the operator version in sync with the Kiali version. The best way to do this is to ensure that your Kiali CR's `spec.deployment.image_version` field is set to `operator_version` (this is the default if this value is left unset) then upgrade the operator version. When the operator upgrade completes, the operator will upgrade the Kiali Server image version to match its own image version.
 
-==== Helm Chart - kiali-server
+==== Helm Chart - Kiali Server
 
 If you are managing the Kiali Server through the Helm Chart and not with the operator, you can upgrade Kiali by upgrading the version of the `kiali-server` Helm Chart.
 

--- a/content/documentation/staging/installation-guide/index.adoc
+++ b/content/documentation/staging/installation-guide/index.adoc
@@ -144,9 +144,9 @@ For production environments that have OperatorHub installed (OpenShift comes wit
 
 ==== Helm Chart
 
-For production environments that do not have OperatorHub, it is recommended that you use the Kiali Operator Helm Chart located on the Kiali Helm Chart Repository at link:https://kiali.org/helm-charts[https://kiali.org/helm-charts].
+For production environments that do not have OperatorHub, it is recommended that you use the Kiali Operator Helm Chart located on the Kiali Helm Chart Repository at link:https://kiali.org/helm-charts[https://kiali.org/helm-charts]. There are two separate Helm Charts: `kiali-operator` and `kiali-server`. The `kiali-operator` Helm Chart installs the operator and the operator in turn installs Kiali when you create a Kiali CR whereas the `kiali-server` Helm Chart installs a standalone Kiali Server that can be used to manage Kiali without the operator. 
 
-icon:bullhorn[size=1x]{nbsp} The Kiali Operator Helm Chart requires Helm v3
+icon:bullhorn[size=1x]{nbsp} The Kiali Helm Charts require Helm v3
 
 The Kiali Operator Helm Chart is configurable. You can see the link:https://github.com/kiali/helm-charts/tree/master/kiali-operator/values.yaml[default values.yaml here].
 
@@ -174,6 +174,18 @@ To install only the Kiali Operator and not a Kiali CR, simply pass `--set cr.cre
 
 After the Kiali Operator is installed and running, go to link:#_create_or_edit_the_kiali_cr[Create or Edit the Kiali CR] for the customized Kiali installation.
 
+==== Kiali-Only Install
+
+To install the Kiali Server without the operator, use the `kiali-server` Helm Chart:
+
+[source,bash]
+----
+  helm install \
+    --namespace istio-system \
+    --repo https://kiali.org/helm-charts \
+    kiali-server \
+    kiali-server
+----
 
 === Create or Edit the Kiali CR
 
@@ -252,6 +264,63 @@ icon:lightbulb[size=1x]{nbsp} If you installed the Kiali CR in a different names
 ----
 
 Note that even if this fixes the hang problem, you may still have remnants of the Kiali Server in your cluster. You will manually need to delete those resources.
+
+== Upgrade
+
+=== Upgrading Istio
+
+In general, Kiali tries to maintain compatability between at least the two most recent minor versions of Istio e.g. Kiali 1.26.0 is compatible with both Istio 1.7 and 1.8. If you are upgrading one minor version of Istio, before upgrading Istio, upgrade Kiali to the most recent version that supports that version of Istio. See the link:#_version_compatibility[version compatability] section for more details on which versions are supported. 
+
+==== Canary
+
+For https://istio.io/latest/docs/setup/upgrade/canary/[Canary upgrades]:
+
+. Deploy the upgraded https://istio.io/latest/docs/setup/upgrade/canary/#control-plane[istio control-plane].
+. Update the Kiali Server configuration to point to the new Istio deployment. These fields need to be updated:
+- `spec.external_services.istio.config_map_name` to the new Istio configmap revision.
+- `spec.external_services.istio.istiod_deployment_name` to the new istio deployment revision.
+- `spec.external_services.istio.istio_sidecar_injector_config_map_name` to the new istio sidecar injector configmap revision.
+
+If you are using the *kiali-operator*, update the Kiali CR configuration:
+
+[source,bash]
+----
+  kubectl patch kialis kiali -n kiali-operator \
+    -p '{"spec": {"external_services": {"istio": {"config_map_name": "istio-canary", "istiod_deployment_name": "istiod-canary", "istio_sidecar_injector_config_map_name": "istio-sidecar-injector-canary"}}}}' \
+    --type=merge
+----
+
+Wait until the operator restarts the Kiali Server and then verify everything is working correctly.
+
+If you are using the `kiali-server` *Helm Chart*, set the Helm Chart values: 
+
+[source,bash]
+----
+  helm upgrade \
+    --set external_services.istio.config_map_name=istio-canary \
+    --set external_services.istio.istio_sidecar_injector_config_map_name=istio-sidecar-injector-canary \
+    --set external_services.istio.istiod_deployment_name=istiod-canary \
+    --repo https://kiali.org/helm-charts \
+    --namespace istio-system \
+    kiali-server kiali-server
+----
+
+Restart the Kiali pod to pickup the new configmap changes.
+
+[source,bash]
+----
+  kubectl rollout restart deployments kiali -n istio-system
+----
+
+=== Upgrading Kiali
+
+==== Operator
+
+When upgrading Kiali using the operator, it's recommended to keep the operator version in sync with the Kiali version. The best way to do this is to ensure that your Kiali CR's `spec.deployment.image_version` field is set to `operator_version` (the default if it is unset) then upgrade the operator version. When the operator upgrade completes, the operator will upgrade the Kiali Server image version to match its own image version.
+
+==== Helm Chart - kiali-server
+
+If you are managing the Kiali Server through the Helm Chart and not with the operator, you can upgrade Kiali by upgrading the version of the `kiali-server` Helm Chart.
 
 == Additional Notes
 

--- a/content/documentation/staging/installation-guide/index.adoc
+++ b/content/documentation/staging/installation-guide/index.adoc
@@ -316,7 +316,7 @@ Restart the Kiali pod to pickup the new configmap changes.
 
 ==== Operator
 
-When upgrading Kiali using the operator, it's recommended to keep the operator version in sync with the Kiali version. The best way to do this is to ensure that your Kiali CR's `spec.deployment.image_version` field is set to `operator_version` (the default if it is unset) then upgrade the operator version. When the operator upgrade completes, the operator will upgrade the Kiali Server image version to match its own image version.
+When upgrading Kiali using the operator, it's recommended to keep the operator version in sync with the Kiali version. The best way to do this is to ensure that your Kiali CR's `spec.deployment.image_version` field is set to `operator_version` (this is the default if this value is left unset) then upgrade the operator version. When the operator upgrade completes, the operator will upgrade the Kiali Server image version to match its own image version.
 
 ==== Helm Chart - kiali-server
 


### PR DESCRIPTION
Adds an `Upgrade` section to the install guide that gives instructions for updating Kiali during an Istio canary upgrade and for upgrading Kiali itself. Also adds information in the install section for using the `kiali-server` helm chart to install Kiali without the operator.

Relates to https://github.com/kiali/kiali/issues/2884