### PR TITLE
Update compatibility chart.

### DIFF
--- a/content/documentation/staging/installation-guide/index.adoc
+++ b/content/documentation/staging/installation-guide/index.adoc
@@ -44,11 +44,11 @@ Kiali requires a supported version of Istio. link:https://istio.io/news/[The Ist
 | Istio 1.8 removes all support for mixer/telemetry V1, as does Kiali 1.26.0. Use earlier versions of Kiali for mixer support. Istio 1.8 is out of support.
 
 | 1.7
-| 1.22.1 or later
+| 1.22.1 to 1.34.x
 | Istio 1.7 istioctl will no longer install Kiali. Use the Istio samples/addons all-in-one yaml or the Kiali Helm Chart for quick demo installs. Istio 1.7 is out of support.
 
 | 1.6
-| 1.18.1 or later
+| 1.18.1 to 1.34.x
 | Istio 1.6 introduces CRD and Config changes, Kiali 1.17 is recommended for Istio < 1.6. Istio 1.6 is out of support.
 
 | <= 1.5

--- a/content/documentation/v1.36/installation-guide/index.adoc
+++ b/content/documentation/v1.36/installation-guide/index.adoc
@@ -44,11 +44,11 @@ Kiali requires a supported version of Istio. link:https://istio.io/news/[The Ist
 | Istio 1.8 removes all support for mixer/telemetry V1, as does Kiali 1.26.0. Use earlier versions of Kiali for mixer support. Istio 1.8 is out of support.
 
 | 1.7
-| 1.22.1 or later
+| 1.22.1 to 1.34.x
 | Istio 1.7 istioctl will no longer install Kiali. Use the Istio samples/addons all-in-one yaml or the Kiali Helm Chart for quick demo installs. Istio 1.7 is out of support.
 
 | 1.6
-| 1.18.1 or later
+| 1.18.1 to 1.34.x
 | Istio 1.6 introduces CRD and Config changes, Kiali 1.17 is recommended for Istio < 1.6. Istio 1.6 is out of support.
 
 | <= 1.5


### PR DESCRIPTION
Kiali 1.35 adds support for WorkloadGroup, which requires istio 1.8.

Fixes https://github.com/kiali/kiali/issues/4154