### PR TITLE
Add script to figure out backports since the last release.

### DIFF
--- a/scripts/backports.py
+++ b/scripts/backports.py
@@ -1,12 +1,12 @@
-# Generates Simple Release Notes for Kiali given a release version and Sprint Project.
-# The output can then be clipped into kiali.io/content/news/release-notes.adoc as the
-# base for that version's release notes.
+#!/bin/python
+
+# Looks for backports since a previous patch release.
 #
 # Requires:
 # - a github oauth token with public_repo and read:org scopes for kiali
 # - python (tested with 3.8.7)
 #
-# usage: $ python relnotes <version: vX.Y.Z> <projectNumber: int> <githubOauthToken>
+# usage: > ./backports.py <releaseBranch: string (e.g. v1.36)> <sincePatch: int (e.g. 1)> <numProjects: int (e.g. 3 for PRs in last 3 projects)> <githubOauthToken>
 #
 
 import re
@@ -14,7 +14,7 @@ import requests
 import sys
 
 if len(sys.argv) != 5:
-    print( '\nUSAGE: $ python relnotes.py <releaseBranch: string (e.g. v1.36)> <sincePatch: int (e.g. 1)> <numProjects: int (e.g. 3 for PRs in last 3 projects)> <githubOauthToken>' )
+    print( '\nUSAGE: > ./backports.py <releaseBranch: string (e.g. v1.36)> <sincePatch: int (e.g. 1)> <numProjects: int (e.g. 3 for PRs in last 3 projects)> <githubOauthToken>' )
     sys.exit()
 
 releaseBranch = sys.argv[1]

--- a/scripts/backports.py
+++ b/scripts/backports.py
@@ -1,0 +1,112 @@
+# Generates Simple Release Notes for Kiali given a release version and Sprint Project.
+# The output can then be clipped into kiali.io/content/news/release-notes.adoc as the
+# base for that version's release notes.
+#
+# Requires:
+# - a github oauth token with public_repo and read:org scopes for kiali
+# - python (tested with 3.8.7)
+#
+# usage: $ python relnotes <version: vX.Y.Z> <projectNumber: int> <githubOauthToken>
+#
+
+import re
+import requests
+import sys
+
+if len(sys.argv) != 5:
+    print( '\nUSAGE: $ python relnotes.py <releaseBranch: string (e.g. v1.36)> <sincePatch: int (e.g. 1)> <numProjects: int (e.g. 3 for PRs in last 3 projects)> <githubOauthToken>' )
+    sys.exit()
+
+releaseBranch = sys.argv[1]
+sincePatch = sys.argv[2]
+numProjects = sys.argv[3]
+headers = {"Authorization": "bearer " + sys.argv[4]}
+sinceVersion = "{}.{}".format(releaseBranch, sincePatch)
+
+# GraphQL queries as a multi-line string.
+sinceQuery = """
+{
+  organization(login: "kiali") {
+    repository(name: "kiali") {
+      release(tagName: "$sinceVersion") {
+        createdAt
+      }
+    }
+  }
+}
+"""
+
+query = """
+{
+  organization(login: "kiali")
+  {
+    name
+    projects(last: $numProjects) {
+      nodes {
+        body
+        name
+        columns(last: 1) {
+          nodes {
+            cards {
+              nodes {
+                content {
+                  __typename
+                  ... on PullRequest {
+                    title
+                    url
+                    closedAt
+                    baseRef {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+def get_since_time(sinceQuery):
+    sinceQuery = sinceQuery.replace("$sinceVersion", sinceVersion)
+    request = requests.post('https://api.github.com/graphql', json={"query": sinceQuery}, headers=headers)
+    if request.status_code == 200:
+        return request.json()["data"]["organization"]["repository"]["release"]["createdAt"]
+    else:
+        raise Exception("SinceeQuery failed to run by returning code of {}. {}".format(request.status_code, query))
+
+def run_query(query):
+    query = query.replace("$numProjects", numProjects)
+    request = requests.post('https://api.github.com/graphql', json={"query": query}, headers=headers)
+    if request.status_code == 200:
+        return request.json()
+    else:
+        raise Exception("Query failed to run by returning code of {}. {}".format(request.status_code, query))
+        
+
+sinceTime = get_since_time(sinceQuery)
+result = run_query(query) # Execute the query
+projects = result["data"]["organization"]["projects"]
+backports = []
+
+print("\nBackports since {} ({}), looking in last {} projects:".format(sinceVersion, sinceTime, numProjects))
+print("-----------------------------------")
+
+for project in projects["nodes"]:
+    for card in project["columns"]["nodes"][0]["cards"]["nodes"]:
+        if card["content"]["__typename"] != "PullRequest":
+            continue
+        pr = card["content"]        
+        baseRef = pr["baseRef"]["name"]
+        closedAt = pr["closedAt"]
+        if baseRef == releaseBranch and closedAt > sinceTime:
+            title = pr["title"].replace("[", "(").replace("]", ")")
+            backports.append("{} [{}] {} ".format(pr["url"], title, closedAt))
+
+backports.sort()
+for backport in backports:
+    print("{}".format(backport))
+

--- a/scripts/relnotes.py
+++ b/scripts/relnotes.py
@@ -1,3 +1,5 @@
+#!/bin/python
+
 # Generates Simple Release Notes for Kiali given a release version and Sprint Project.
 # The output can then be clipped into kiali.io/content/news/release-notes.adoc as the
 # base for that version's release notes.
@@ -6,7 +8,7 @@
 # - a github oauth token with public_repo and read:org scopes for kiali
 # - python (tested with 3.8.7)
 #
-# usage: $ python relnotes <version: vX.Y.Z> <projectNumber: int> <githubOauthToken>
+# usage: $ ./relnotes <version: vX.Y.Z> <projectNumber: int> <githubOauthToken>
 #
 
 import re
@@ -14,7 +16,7 @@ import requests
 import sys
 
 if len(sys.argv) != 4:
-    print( 'usage: $ python relnotes.py <version: X.Y.Z> <projectNumber: int> <githubOauthToken>' )
+    print( 'usage: > ./relnotes.py <version: X.Y.Z> <projectNumber: int> <githubOauthToken>' )
     exit
 
 version = sys.argv[1]


### PR DESCRIPTION
For example, to list the backport PRs for v1.36 since patch release 1, searching the last 5 gihub projects:

`> python backports.py v1.36 1 5 <githubOauthToken>`
