### PR TITLE
remove the need for asciidoctor - use .md only now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,6 @@ ARG HUGO_VERSION
 VOLUME /site
 WORKDIR /site
 
-# Avoid startup errors about missing AsciiDoctor
-ARG ASCIIDOCTOR_VERSION=2.0.10
-RUN microdnf -y install ruby
-RUN gem install --no-document "asciidoctor:${ASCIIDOCTOR_VERSION}"
-
 # Download, untar, and install Hugo
 RUN microdnf -y install tar shadow-utils git nodejs \
  && microdnf clean all


### PR DESCRIPTION
With this PR, we now prohibit any .adoc files. If you try to introduce an .adoc file, hugo will refuse to start:

```
$ make serve
Will not rebuild the image [kiali/hugo:latest].
Start building sites … 

                   | EN   
-------------------+------
  Pages            | 101  
  Paginator pages  |   0  
  Non-page files   |   1  
  Static files     | 363  
  Processed images |   2  
  Aliases          |   9  
  Sitemaps         |   1  
  Cleaned          |   0  

Built in 876 ms
Watching for changes in /site/{assets,content,layouts,package.json,static,themes}
Watching for config changes in /site/config.toml, /site/themes/docsy/config.toml
Environment: "development"
Serving pages from memory
Web Server is available at http://localhost:1313/ (bind address 0.0.0.0)
Press Ctrl+C to stop
^C

$ ##### INTRODUCE A PROHIBITED .adoc FILE #########
$ touch content/en/docs/Installation/mazz.adoc
$ make serve
Will not rebuild the image [kiali/hugo:latest].
Start building sites … 
ERROR 2021/10/13 18:51:22 asciidoctor not found in $PATH: Please install.
                  Leaving AsciiDoc content unrendered.
Built in 856 ms
Error: Error building site: logged 1 error(s)
make: *** [Makefile:20: serve] Error 255
```