### PR TITLE
script to do the release.

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,8 +7,9 @@ if [ -z "${1:-}" ]; then
   exit 1
 fi
 
-# Because the version is used as part of the base image, the version should have dots converted to dashes
-CURRENT_VERSION="${1//./-}"
+# Because the version is used as part of the base image, the version for the base image URL should have dots converted to dashes
+CURRENT_VERSION="${1}"
+CURRENT_VERSION_WITH_DASHES="${CURRENT_VERSION//./-}"
 REMOTE_NAME="${REMOTE_NAME:-origin}"
 CURRENT_BRANCH="${CURRENT_BRANCH:-current}"
 STAGING_BRANCH="${STAGING_BRANCH:-staging}"
@@ -20,7 +21,7 @@ echo "===== Create a new version branch named [${CURRENT_VERSION}] based on bran
 git checkout -b ${CURRENT_VERSION} ${REMOTE_NAME}/${CURRENT_BRANCH}
 
 echo "===== Setting the base URL for the branch [${CURRENT_VERSION}]"
-sed -i "s/baseURL = .*/baseURL = \"https:\/\/${CURRENT_VERSION}.kiali.io\"/" config.toml
+sed -i "s/baseURL = .*/baseURL = \"https:\/\/${CURRENT_VERSION_WITH_DASHES}.kiali.io\"/" config.toml
 git commit -am "Set base URL for branch: ${CURRENT_VERSION}"
 
 echo "===== Push the new version branch [${CURRENT_VERSION}] to remote [${REMOTE_NAME}]"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,11 +3,11 @@
 set -eu
 
 if [ -z "${1:-}" ]; then
-  echo "ERROR! Pass in the new version string"
+  echo "ERROR! Pass in a version string"
   exit 1
 fi
 
-NEW_VERSION="${1}"
+CURRENT_VERSION="${1}"
 REMOTE_NAME="${REMOTE_NAME:-origin}"
 CURRENT_BRANCH="${CURRENT_BRANCH:-current}"
 STAGING_BRANCH="${STAGING_BRANCH:-staging}"
@@ -15,15 +15,15 @@ STAGING_BRANCH="${STAGING_BRANCH:-staging}"
 echo "===== Fetch the remote content"
 git fetch ${REMOTE_NAME}
 
-echo "===== Create a new version branch named [${NEW_VERSION}] based on branch [${CURRENT_BRANCH}]"
-git checkout -b ${NEW_VERSION} ${REMOTE_NAME}/${CURRENT_BRANCH}
+echo "===== Create a new version branch named [${CURRENT_VERSION}] based on branch [${CURRENT_BRANCH}]"
+git checkout -b ${CURRENT_VERSION} ${REMOTE_NAME}/${CURRENT_BRANCH}
 
-echo "===== Setting the base URL for the branch [${NEW_VERSION}]"
-sed -i "s/baseURL = .*/baseURL = \"https:\/\/${NEW_VERSION}.kiali.io\"/" config.toml
-git commit -am "Set base URL for branch: ${NEW_VERSION}"
+echo "===== Setting the base URL for the branch [${CURRENT_VERSION}]"
+sed -i "s/baseURL = .*/baseURL = \"https:\/\/${CURRENT_VERSION}.kiali.io\"/" config.toml
+git commit -am "Set base URL for branch: ${CURRENT_VERSION}"
 
-echo "===== Push the new version branch [${NEW_VERSION}] to remote [${REMOTE_NAME}]"
-git push ${REMOTE_NAME} ${NEW_VERSION}
+echo "===== Push the new version branch [${CURRENT_VERSION}] to remote [${REMOTE_NAME}]"
+git push ${REMOTE_NAME} ${CURRENT_VERSION}
 
 echo "===== Create a new branch named [${CURRENT_BRANCH}] (or switch to it if it already exists)"
 git checkout -b ${CURRENT_BRANCH} ${REMOTE_NAME}/${CURRENT_BRANCH} || git checkout ${CURRENT_BRANCH}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,7 +7,8 @@ if [ -z "${1:-}" ]; then
   exit 1
 fi
 
-CURRENT_VERSION="${1}"
+# Because the version is used as part of the base image, the version should have dots converted to dashes
+CURRENT_VERSION="${1//./-}"
 REMOTE_NAME="${REMOTE_NAME:-origin}"
 CURRENT_BRANCH="${CURRENT_BRANCH:-current}"
 STAGING_BRANCH="${STAGING_BRANCH:-staging}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -26,7 +26,10 @@ Valid options:
       the versioned documentation (see --current-version).
       Default: "${DEFAULT_CURRENT_BRANCH}"
   -cv|--current-version
-      A new version branch will be created with the name of this version string ("vX.Y.Z").
+      A new version branch will be created with the name of this version string.
+      Note that it is expected that this be in the form of "vX.Y.Z" but only the "vX.Y" portion
+      will be used by this script. However, if the "Z" number is anything other than "0" this script will abort.
+      In other words, this script will not release patch-level documentation.
       This new version branch will be a copy of the "current" branch.
       Default: <undefined>
   -rn|--remote-name
@@ -58,7 +61,15 @@ if [ -z "${REMOTE_NAME:-}" ]; then
   exit 1
 fi
 
+# Require vX.Y.Z with Z == 0.
+if ! [[ ${CURRENT_VERSION} =~ ^v[0-9]+\.[0-9]+\.0$ ]]; then
+  echo "ERROR! You must specify --current-version in the form of vX.Y.Z where X and Y are numbers and Z is 0: ${CURRENT_VERSION}"
+  exit 1
+fi
+
+# Only use the vX.Y portion of the version string (strip the patch number).
 # Because the version is used as part of the base image, the version for the base image URL should have dots converted to dashes
+CURRENT_VERSION=$(echo ${CURRENT_VERSION} | sed -E 's/(v[0-9]+\.[0-9]+)\.[0-9]+/\1/')
 CURRENT_VERSION_WITH_DASHES="${CURRENT_VERSION//./-}"
 
 echo "===== SETTINGS"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -eu
+
+if [ -z "${1:-}" ]; then
+  echo "ERROR! Pass in the new version string"
+  exit 1
+fi
+
+NEW_VERSION="${1}"
+REMOTE_NAME="${REMOTE_NAME:-origin}"
+CURRENT_BRANCH="${CURRENT_BRANCH:-current}"
+STAGING_BRANCH="${STAGING_BRANCH:-staging}"
+
+echo "===== Fetch the remote content"
+git fetch ${REMOTE_NAME}
+
+echo "===== Create a new version branch named [${NEW_VERSION}] based on branch [${CURRENT_BRANCH}]"
+git checkout -b ${NEW_VERSION} ${REMOTE_NAME}/${CURRENT_BRANCH}
+
+echo "===== Setting the base URL for the branch [${NEW_VERSION}]"
+sed -i "s/baseURL = .*/baseURL = \"https:\/\/${NEW_VERSION}.kiali.io\"/" config.toml
+git commit -am "Set base URL for branch: ${NEW_VERSION}"
+
+echo "===== Push the new version branch [${NEW_VERSION}] to remote [${REMOTE_NAME}]"
+git push ${REMOTE_NAME} ${NEW_VERSION}
+
+echo "===== Create a new branch named [${CURRENT_BRANCH}] (or switch to it if it already exists)"
+git checkout -b ${CURRENT_BRANCH} ${REMOTE_NAME}/${CURRENT_BRANCH} || git checkout ${CURRENT_BRANCH}
+
+echo "===== Reset branch [${CURRENT_BRANCH}] to the content of branch [${STAGING_BRANCH}] from remote [${REMOTE_NAME}]"
+git reset --hard ${REMOTE_NAME}/${STAGING_BRANCH}
+
+echo "===== Setting the base URL for the branch [${CURRENT_BRANCH}]"
+sed -i "s/baseURL = .*/baseURL = \"https:\/\/kiali.io\"/" config.toml
+git commit -am "Set base URL for branch: ${CURRENT_BRANCH}"
+
+echo "===== Push the branch [${CURRENT_BRANCH}] to remote [${REMOTE_NAME}]"
+git push --force ${REMOTE_NAME} ${CURRENT_BRANCH}


### PR DESCRIPTION
be careful when testing. You must set the --remote-name (or just edit the script locally) so it matches your fork name - do not use `origin`.

REPEAT! DO NOT USE `origin` 

When testing, you might even want to remove or rename your `origin` remote so you don't accidentally push up changes when testing this script. Test against your fork.