### PR TITLE
Align FAQ link in docs menu

### DIFF
--- a/content/en/docs/FAQ/_index.md
+++ b/content/en/docs/FAQ/_index.md
@@ -4,6 +4,5 @@ description: Frequently Asked Questions about Kiali.
 weight: 6
 aliases:
   - /documentation/known-issues/
-icon: faq
 ---
 


### PR DESCRIPTION
Fix https://github.com/kiali/kiali/issues/4430

Remove the icon property to have the link aligned in the menu