### PR TITLE
do not require npm locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN tar xzvf /hugo.tar.gz -C / \
 
 # Stuff for docsy
 RUN npm -g -D install postcss postcss-cli autoprefixer
-RUN npm prune
 
 # Install html-proofer
 RUN gem install html-proofer

--- a/Makefile
+++ b/Makefile
@@ -43,5 +43,5 @@ URL_IGNORE=\#$\
 ## validate-site: Builds the site and validates the pages. This is used for CI
 .PHONY: validate-site
 validate-site: build-hugo
-	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "hugo && htmlproofer --assume-extension --check-external-hash --empty_alt_ignore --url-ignore \"${URL_IGNORE}\" ./public"
+	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer --assume-extension --check-external-hash --empty_alt_ignore --url-ignore \"${URL_IGNORE}\" ./public"
 


### PR DESCRIPTION
We must do the npm prune inside the container but when /site is mounted to the container. Can't be done in the Dockerfile at build time.

To test this, remove `public/`, `resources/`, and especially `node_modules/` directories (there are in our `.gitignore`, they are not checked in and will be auto-generated). Then remove any existing image you already have, and run the `validate-site` target and it should now work.

```
rm -rf node_modules/ public/ resources/
podman rmi kiali/hugo:latest
make validate-site
```

Before it would only work if you ran `npm prune` locally - which created the `node_modules/` - but this requires the user to have npm installed and in PATH which we do not want to require.  Everything should run inside the container and via the make targets.