### PR TITLE
More documentation for configurations

### DIFF
--- a/content/en/docs/Configuration/p8s-jaeger-grafana.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana.md
@@ -1,6 +1,9 @@
 ---
-title: "Distributed Tracing / Jaeger"
-description: "Configuring Kiali's Jaeger integration."
+title: "Prometheus, Jaeger and Grafana"
+description: >
+  Prometheus and Grafana are primary data sources for Kiali. This page
+  describes how to configure Kiali to communicate with these dependencies. A
+  minimalistic Grafana integration is also available.
 ---
 
 
@@ -15,10 +18,11 @@ can't reach it, Kiali won't work properly.
 
 By default, Kiali assumes that Prometheus is available at the URL of the form
 `http://prometheus.<istio_namespace_name>:9090`, which is the usual case if you
-are using the Prometheus Istio add-on. If your Prometheus instance has a
-different service name or is installed to a different namespace, you must
-manually provide the endpoint where it is available, like in the following
-example:
+are using [the Prometheus Istio
+add-on](https://istio.io/latest/docs/ops/integrations/prometheus/#option-1-quick-start).
+If your Prometheus instance has a different service name or is installed to a
+different namespace, you must manually provide the endpoint where it is
+available, like in the following example:
 
 ```yaml
 spec:
@@ -53,8 +57,8 @@ spec:
 
 ### Compatibility with Prometheus-like servers
 
-Although Kiali assumes and is tested against Prometheus, there are <abbr
-title="Time series databases">TSDBs</abbr> that can be used as Prometheus
+Although Kiali assumes a Prometheus server and is tested against it, there are
+<abbr title="Time series databases">TSDBs</abbr> that can be used as Prometheus
 replacement despite not implementing the full Prometheus API. 
 
 Community users have faced two issues when using Prometheus-like TSDBs:
@@ -86,8 +90,10 @@ providing an enhanced experience.
 
 By default, Kiali will try to reach Jaeger at the GRPC-enabled URL of the form
 `http://tracing.<istio_namespace_name>:16685/jaeger`, which is the usual case
-if you are using the Jaeger Istio add-on. If this endpoint is unreachable,
-Kiali will disable features that use distributed tracing data.
+if you are using [the Jaeger Istio
+add-on](https://istio.io/latest/docs/ops/integrations/jaeger/#option-1-quick-start).
+If this endpoint is unreachable, Kiali will disable features that use
+distributed tracing data.
 
 If your Jaeger instance has a different service name or is installed to a
 different namespace, you must manually provide the endpoint where it is
@@ -118,4 +124,28 @@ expose Jaeger outside the cluster.
 
 ## Grafana configuration
 
-[TODO]
+Istio provides [preconfigured Grafana
+dashboards](https://istio.io/latest/docs/ops/integrations/grafana/) for the
+most relevant metrics of the mesh. Although Kiali offers similar views in its
+metrics dashboards, it is not in Kiali's goals to provide the advanced querying
+options nor the highly customizable settings that are available in Grafana.
+Thus, it is recommended that you use Grafana if you need those advanced
+options.
+
+Kiali can provide a direct link from its metric dashboards to the equivalent or
+most similar Grafana dashboard, which is convenient if you need the powerful
+Grafana options. For these links to appear in Kiali you need to manually
+configure what is the Grafana URL, like in the following example:
+
+
+```yaml
+spec:
+  external_services:
+    grafana:
+      enabled: true
+      # Grafana service name is "grafana" and is in the "telemetry" namespace.
+      in_cluster_url: 'http://grafana.telemetry:3000/'
+      # Public facing URL of Grafana
+      url: 'http://my-ingress-host/grafana'
+```
+

--- a/content/en/docs/Configuration/p8s-jaeger-grafana.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana.md
@@ -63,7 +63,7 @@ replacement despite not implementing the full Prometheus API.
 
 Community users have faced two issues when using Prometheus-like TSDBs:
 * Kiali may report that the TSDB is unreachable, and/or
-* Kiali may show empty metrics if the TSBD does no implement the `/api/v1/status/config`.
+* Kiali may show empty metrics if the TSBD does not implement the `/api/v1/status/config`.
 
 To fix these issues, you may need to provide a custom health check endpoint for
 the TSDB and/or manually provide the configurations that Kiali reads from the
@@ -118,7 +118,7 @@ spec:
 Minimally, you must provide `spec.external_services.tracing.in_cluster_url` to
 enable Kiali features that use distributed tracing data. However, Kiali can
 provide contextual links that users can use to jump to the Jaeger console to
-inspect tracing data more in deep. For these links to be available you need to
+inspect tracing data more in depth. For these links to be available you need to
 set the `spec.external_services.tracing.url` which may mean that you should
 expose Jaeger outside the cluster.
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana.md
@@ -1,7 +1,7 @@
 ---
 title: "Prometheus, Jaeger and Grafana"
 description: >
-  Prometheus and Grafana are primary data sources for Kiali. This page
+  Prometheus and Jaeger are primary data sources for Kiali. This page
   describes how to configure Kiali to communicate with these dependencies. A
   minimalistic Grafana integration is also available.
 ---

--- a/content/en/docs/Installation/deployment-configuration.md
+++ b/content/en/docs/Installation/deployment-configuration.md
@@ -255,3 +255,20 @@ in the Kubernetes
 documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/).
 
 
+## Adding host aliases to the Kiali pod
+
+If you need to provide some static hostname resolution in the Kiali pod, you
+can use [HostAliases to add entries to the `/etc/hosts`
+file](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/)
+of the Kiali pod, like in the following example:
+
+```yaml
+spec:
+  deployment:
+   host_aliases:
+   - ip: 192.168.1.100
+     hostnames:
+     - "foo.local"
+     - "bar.local"
+```
+

--- a/content/en/docs/Installation/deployment-configuration.md
+++ b/content/en/docs/Installation/deployment-configuration.md
@@ -76,7 +76,7 @@ spec:
 ```
 
 The `instance_name` will be used as a prefix for all created Kiali resources.
-The exception is the `kiali-signing-key` secret which will always have the same
+The exception is the `kiali-signing-key` secret which will always have the same name
 and will be shared on all deployments of the same namespace, unless you specify
 a custom secret name.
 
@@ -186,7 +186,7 @@ to learn more about the HPA.
 
 ### Allocating the Kiali pod to specific nodes of the cluster
 
-You can constraint the Kiali pod to run on a specific set of nodes by using
+You can constrain the Kiali pod to run on a specific set of nodes by using
 some of the standard Kubernetes scheduler configurations.
 
 The simplest option is to use [the
@@ -241,7 +241,7 @@ Read the following Kubernetes documentation to learn more about these configurat
 
 ### Priority class of the Kiali pod
 
-If you are using priority classess in your cluster, you can specify the
+If you are using priority classes in your cluster, you can specify the
 priority class that will be set on the Kiali pod. For example:
 
 ```yaml

--- a/content/en/docs/Installation/deployment-configuration.md
+++ b/content/en/docs/Installation/deployment-configuration.md
@@ -1,23 +1,25 @@
 ---
 title: "Deployment Configuration"
-description: "[TODO]"
+description: >
+  This page describes simple configuration options related to the deployment (not tied to features),
+  like configuring the installation namespace, logger settings, resource limits and 
+  scheduling options for the Kiali pod.
 weight: 30
 ---
 
-<!--
-* Namespace management: http://localhost:1313/docs/configuration/namespace-management/
-* Authentication: http://localhost:1313/docs/configuration/authentication/
-* Custom dashboards: http://localhost:1313/docs/configuration/custom-dashboard/
-* ingress: {}
-* service_type: ""
+There are other deployment-related settings, but are more complex and are described in dedicated pages:
+* [Authentication]({{< relref "../Configuration/authentication" >}})
+* [Customization of the Ingress resource]({{< relref
+  "installation-guide/accessing-kiali#ingress-access" >}})
+* [Customization of the service type service type (LoadBalancer or
+  NodePort)]({{< relref "installation-guide/accessing-kiali#accessing-kiali-through-a-loadbalancer-or-a-nodeport" >}})
+* [Namespace management (configuring namespaces accessible and visible to
+  Kiali)]({{< relref "../Configuration/namespace-management" >}})
 
-```yaml
-spec:
-  identity:
-    cert_file:
-    private_key_file:
-```
--->
+{{% alert title="Note" color="info" %}} All examples on this page are focused
+on the Kiali CR; i.e. when you use the Kiali operator to install Kiali. Rember
+that Helm charts mirror all these configurations.
+{{% /alert %}}
 
 ## Specifying Kiali installation namespace and Istio namespace
 
@@ -42,7 +44,8 @@ spec:
 ## Log level and log format configuration
 
 By default, Kiali will print up to `INFO`-level messages in simple text format.
-You can change the log level, output format, and time format as follows:
+You can change the log level, output format, and time format as in the
+following example:
 
 ```yaml
 spec:
@@ -74,8 +77,8 @@ spec:
 
 The `instance_name` will be used as a prefix for all created Kiali resources.
 The exception is the `kiali-signing-key` secret which will always have the same
-if you don't specify a custom secret name,  and will be shared on all
-deployments of the same namespace.
+and will be shared on all deployments of the same namespace, unless you specify
+a custom secret name.
 
 {{% alert title="Note" color="warning" %}}
 Since the `instance_name` will be used as a name prefix in resources, it must
@@ -91,7 +94,8 @@ uninstall Kiali and re-install with the desired `instance_name`.
 
 ## Configuring resource requests and limits
 
-You can set the amount of resources available to Kiali using the `spec.deployment.resources` attribute. For example:
+You can set the amount of resources available to Kiali using the
+`spec.deployment.resources` attribute, like in the following example:
 
 ```yaml
 spec:
@@ -112,11 +116,10 @@ for more details about possible configurations.
 ## Custom labels and annotations on the Kiali pod and service
 
 Although some labels and annotations are set on the Kiali pod and on its
-service (depending on configurations), you can add additional labels and
-annotations. For the pod, use the `spec.deployment.pod_labels` and
-`spec.deployment.pod_annotations` attributes. For the service, you can only add
-annotations using the `spec.deployment.service_annotations` attribute. For
-example:
+service (depending on configurations), you can add additional ones. For the
+pod, use the `spec.deployment.pod_labels` and `spec.deployment.pod_annotations`
+attributes. For the service, you can only add annotations using the
+`spec.deployment.service_annotations` attribute. For example:
 
 ```yaml
 spec:
@@ -147,8 +150,8 @@ The `installation_tag` is any human readable text of your desire.
 
 ### Configuring replicas and automatic scaling
 
-By default, only one replica of Kiali is deployed. I needed, you can change the
-replica count with the following configuration:
+By default, only one replica of Kiali is deployed. If needed, you can change the
+replica count like in the following example:
 
 ```yaml
 spec:
@@ -157,8 +160,8 @@ spec:
 ```
 
 If you prefer automatic scaling, creation of an `HorizontalPodAutoscaler`
-resource is supported. For example, set the following configuration to
-automatically scale Kiali based on CPU utilization:
+resource is supported. For example, the following configuration automatically
+scales Kiali based on CPU utilization:
 
 ```yaml
 spec:
@@ -174,8 +177,7 @@ spec:
 {{% alert title="Note" color="warning" %}}
 You must omit the `scaleTargetRef` field of the HPA spec, because this field
 will be populated by the Kiali operator (or by Helm) depending on other
-configuration. Also, the HPA spec you provide is not validated. Make sure you
-provide a valid HPA spec for installation to succeed.
+configuration.
 {{% /alert %}}
 
 Read the [Kubernetes Horizontal Pod Autoscaler
@@ -185,36 +187,11 @@ to learn more about the HPA.
 ### Allocating the Kiali pod to specific nodes of the cluster
 
 You can constraint the Kiali pod to run on a specific set of nodes by using
-[the
+some of the standard Kubernetes scheduler configurations.
+
+The simplest option is to use [the
 `nodeSelector`](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
-or the [affinity/anti-affinity
-native](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)
-Kubernetes features. In case you want to schedule Kiali to run on a node with
-taints, you can configure
-[tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
-
-The Kiali CR has the following attributes to configure the scheduling of the
-Kiali pod:
-
-```yaml
-spec:
-  deployment:
-    node_selector:
-      {...label set...}
-    affinity:
-      node:
-        {...your nodeAffinity spec...}
-      pod:
-        {...your podAffinity spec...}
-      pod_anti:
-        {...your podantiaffinity spec...}
-   tolerations:
-     {...your tolerations list...}
-      
-```
-
-For example, if you want to configure scheduing using `nodeSelector` labels,
-you can specify the following in the Kiali CR:
+configuration which you can configure like in the following example:
 
 ```yaml
 spec:
@@ -223,8 +200,10 @@ spec:
       worker-type: infra
 ```
 
-If you prefer to use _node affinity_, the following is a configuration example
-that has the same effec as the previous `nodeSelector` configuration:
+You can also use the [affinity/anti-affinity native Kubernetes
+feature](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)
+if you prefer its more expressive syntax, or if you need more complex matching
+rules. The following is an example for configuring node affinity:
 
 ```yaml
 spec:
@@ -240,6 +219,10 @@ spec:
               - infra
 ```
 
+Similarly, you can also configure pod affinity and pod anti-affinity using the
+`spec.deployment.affinity.pod` and `spec.deployment.affinity.pod_anti`
+attributes.
+
 Finally, if you want to run Kiali in a node with taints, the following is an
 example to configure tolerations:
 
@@ -251,13 +234,6 @@ spec:
       operator: "Exists"
       effect: "NoSchedule"
 ```
-
-{{% alert title="Note" color="warning" %}}
-Any scheduling configurations you set will be copied as is to the Kiali
-Deployment and are not validated. Thus, make sure you specify valid
-configurations. Invalid configurations may lead to installation failure, or to
-the inhability to start the Kiali pod.
-{{% /alert %}}
 
 Read the following Kubernetes documentation to learn more about these configurations:
 - [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)

--- a/content/en/docs/Installation/deployment-configuration.md
+++ b/content/en/docs/Installation/deployment-configuration.md
@@ -1,0 +1,281 @@
+---
+title: "Deployment Configuration"
+description: "[TODO]"
+weight: 30
+---
+
+<!--
+* Namespace management: http://localhost:1313/docs/configuration/namespace-management/
+* Authentication: http://localhost:1313/docs/configuration/authentication/
+* Custom dashboards: http://localhost:1313/docs/configuration/custom-dashboard/
+* ingress: {}
+* service_type: ""
+
+```yaml
+spec:
+  identity:
+    cert_file:
+    private_key_file:
+```
+-->
+
+## Specifying Kiali installation namespace and Istio namespace
+
+By default, the Kiali operator installs Kiali in the same namespace where the Kiali CR is created. However, it is possible to specify a different namespace for installation:
+
+```yaml
+spec:
+  deployment:
+    namespace: "custom-kiali-nameespace"
+```
+
+It is assumed that Kiali is installed to the same namespace as Istio. Kiali
+reads some Istio resources and may not work properly if those resources are not
+found. Thus, if you are installing Kiali and Istio on different namespaces, you
+must specify what is the Istio namespace:
+
+```yaml
+spec:
+  istio_namespace: "istio-system"
+```
+
+## Log level and log format configuration
+
+By default, Kiali will print up to `INFO`-level messages in simple text format.
+You can change the log level, output format, and time format as follows:
+
+```yaml
+spec:
+  deployment:
+    logger:
+      # Supported values are "trace", "debug", "info", "warn", "error" and "fatal"
+      log_level: error  
+      # Supported values are "text" and "json".
+      log_format: json  
+      time_field_format: "2006-01-02T15:04:05Z07:00"
+```
+
+The syntax for the `time_field_format` is the same as the [`Time.Format`
+function of the Go language](https://pkg.go.dev/time#pkg-constants). 
+
+The `json` format is useful if you are parsing logs of your applications for
+further processing.
+
+## Configuring an instance name (multiple Kialis on the same cluster)
+
+If you plan to install more than one Kiali instance on the same cluster, you
+may need to configure an instance name to avoid conflicts on created resources:
+
+```yaml
+spec:
+  deployment:
+    instance_name: "secondary"
+```
+
+The `instance_name` will be used as a prefix for all created Kiali resources.
+The exception is the `kiali-signing-key` secret which will always have the same
+if you don't specify a custom secret name,  and will be shared on all
+deployments of the same namespace.
+
+{{% alert title="Note" color="warning" %}}
+Since the `instance_name` will be used as a name prefix in resources, it must
+follow [Kubernetes naming
+constraints](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/).
+{{% /alert %}}
+
+{{% alert title="Note" color="warning" %}}
+Since Kubernetes resources cannot be renamed, you cannot change the
+`instance_name` of an existing Kiali installation. The workaround is to
+uninstall Kiali and re-install with the desired `instance_name`.
+{{% /alert %}}
+
+## Configuring resource requests and limits
+
+You can set the amount of resources available to Kiali using the `spec.deployment.resources` attribute. For example:
+
+```yaml
+spec:
+  deployment:
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+      limits:
+        memory: "1Gi"
+        cpu: "500m"
+```
+
+Please, read the [Managing Resources for Containers section in the Kubernetes
+documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+for more details about possible configurations.
+
+## Custom labels and annotations on the Kiali pod and service
+
+Although some labels and annotations are set on the Kiali pod and on its
+service (depending on configurations), you can add additional labels and
+annotations. For the pod, use the `spec.deployment.pod_labels` and
+`spec.deployment.pod_annotations` attributes. For the service, you can only add
+annotations using the `spec.deployment.service_annotations` attribute. For
+example:
+
+```yaml
+spec:
+  deployment:
+    pod_annotations:
+      a8r.io/repository: "https://github.com/kiali/kiali"
+    pod_labels:
+      sidecar.istio.io/inject: "true"
+    service_annotations:
+      a8r.io/documentation: "https://kiali.io/docs/installation/deployment-configuration"
+```
+
+## Customizing Kiali's page title (browser title bar)
+
+If you have several Kiali installations and you are using them at the same
+time, there are good chances that you will want to identify each Kiali by
+simply looking at the browser's title bar. You can set a custom text in the
+title bar with the following configuration:
+
+```yaml
+spec:
+  installation_tag: "Kiali West"
+```
+
+The `installation_tag` is any human readable text of your desire.
+
+## Configuring settings for the Kubernetes scheduler
+
+### Configuring replicas and automatic scaling
+
+By default, only one replica of Kiali is deployed. I needed, you can change the
+replica count with the following configuration:
+
+```yaml
+spec:
+  deployment:
+    replicas: 2
+```
+
+If you prefer automatic scaling, creation of an `HorizontalPodAutoscaler`
+resource is supported. For example, set the following configuration to
+automatically scale Kiali based on CPU utilization:
+
+```yaml
+spec:
+  deployment:
+    hpa:
+      api_version: "autoscaling/v1"
+      spec:
+        minReplicas: 1
+        maxReplicas: 2
+        targetCPUUtilizationPercentage: 80
+```
+
+{{% alert title="Note" color="warning" %}}
+You must omit the `scaleTargetRef` field of the HPA spec, because this field
+will be populated by the Kiali operator (or by Helm) depending on other
+configuration. Also, the HPA spec you provide is not validated. Make sure you
+provide a valid HPA spec for installation to succeed.
+{{% /alert %}}
+
+Read the [Kubernetes Horizontal Pod Autoscaler
+documentation](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+to learn more about the HPA.
+
+### Allocating the Kiali pod to specific nodes of the cluster
+
+You can constraint the Kiali pod to run on a specific set of nodes by using
+[the
+`nodeSelector`](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
+or the [affinity/anti-affinity
+native](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)
+Kubernetes features. In case you want to schedule Kiali to run on a node with
+taints, you can configure
+[tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
+
+The Kiali CR has the following attributes to configure the scheduling of the
+Kiali pod:
+
+```yaml
+spec:
+  deployment:
+    node_selector:
+      {...label set...}
+    affinity:
+      node:
+        {...your nodeAffinity spec...}
+      pod:
+        {...your podAffinity spec...}
+      pod_anti:
+        {...your podantiaffinity spec...}
+   tolerations:
+     {...your tolerations list...}
+      
+```
+
+For example, if you want to configure scheduing using `nodeSelector` labels,
+you can specify the following in the Kiali CR:
+
+```yaml
+spec:
+  deployment:
+    node_selector:
+      worker-type: infra
+```
+
+If you prefer to use _node affinity_, the following is a configuration example
+that has the same effec as the previous `nodeSelector` configuration:
+
+```yaml
+spec:
+  deployment:
+    affinity:
+      node:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: worker-type
+              operator: In
+              values:
+              - infra
+```
+
+Finally, if you want to run Kiali in a node with taints, the following is an
+example to configure tolerations:
+
+```yaml
+spec:
+  deployment:
+    tolerations: # Allow to run Kiali in a tainted master node
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+```
+
+{{% alert title="Note" color="warning" %}}
+Any scheduling configurations you set will be copied as is to the Kiali
+Deployment and are not validated. Thus, make sure you specify valid
+configurations. Invalid configurations may lead to installation failure, or to
+the inhability to start the Kiali pod.
+{{% /alert %}}
+
+Read the following Kubernetes documentation to learn more about these configurations:
+- [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)
+- [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
+
+### Priority class of the Kiali pod
+
+If you are using priority classess in your cluster, you can specify the
+priority class that will be set on the Kiali pod. For example:
+
+```yaml
+spec:
+  deployment:
+    priority_class_name: high-priority
+```
+
+For more information about priority classes, read [Pod Priority and Preemption
+in the Kubernetes
+documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/).
+
+

--- a/content/en/docs/Installation/installation-guide/_index.md
+++ b/content/en/docs/Installation/installation-guide/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Installation Guide"
 description: "Installing Kiali for production."
+weight: 20
 ---
 
 This section describes the production installation methods available for Kiali.


### PR DESCRIPTION
* Add configuration page for the Kiali deployment: 
  * Preview: https://deploy-preview-470--kiali.netlify.app/docs/installation/deployment-configuration/
* Replace the "Distributed tracing" configuration page with a page that describes configuration for P8s, Jaeger and Grafana, which are all very similar:
  * Old page: https://staging.kiali.io/docs/configuration/tracing/
  * New page preview: https://deploy-preview-470--kiali.netlify.app/docs/configuration/p8s-jaeger-grafana/

Partial work for kiali/kiali#3858