### PR TITLE
Add /documentation alias for /docs

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -2,6 +2,8 @@
 ---
 title: "Documentation"
 linkTitle: "Documentation"
+aliases:
+  - /documentation
 weight: 20
 menu:
   main:


### PR DESCRIPTION
Fixes  https://github.com/kiali/kiali/issues/4478

Use an alias on the website, as opposed to changing the code, so it works for all versions of Kiali in the wild.