### PR TITLE
[current] Add /documentation alias for /docs

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -2,6 +2,8 @@
 ---
 title: "Documentation"
 linkTitle: "Documentation"
+aliases:
+  - /documentation
 weight: 20
 menu:
   main:


### PR DESCRIPTION
backport to current for kiali#4478, so bug is fixed immediately.