### PR TITLE
[backport] docsy#731

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.fedoraproject.org/fedora-minimal:33
 
 ARG HUGO_VERSION
 

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ URL_IGNORE=\#$\
           ,/^https:\/\/github.com\/kiali\/kiali\.io\/edit\//$\
           ,/^https:\/\/github.com\/kiali\/kiali\.io\/new\//$\
           ,/^https:\/\/github.com\/kiali\/kiali\.io\/commit\//$\
-                    ,/^https:\/\/github.com\/kiali\/kiali\.io\/issues\/new/$\
+          ,/^https:\/\/github.com\/kiali\/kiali\.io\/issues\/new/$\
           ,/.*web.libera.chat.*/
 ## validate-site: Builds the site and validates the pages. This is used for CI
 .PHONY: validate-site

--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,13 @@ serve: build-hugo
 URL_IGNORE=\#$\
           ,/^https:\/\/github.com\/kiali\/kiali\/pull\/\d+/$\
           ,/^https:\/\/github.com\/kiali\/kiali\/issues\/\d+/$\
+          ,/^https:\/\/github.com\/kiali\/kiali\/issues\/new/$\
           ,/^https:\/\/github.com\/kiali\/kiali\/tree\/v\d+\.\d+(\.\d+)?\//$\
           ,/^https:\/\/github.com\/kiali\/kiali\/blob\/v\d+\.\d+(\.\d+)?\//$\
           ,/^https:\/\/github.com\/kiali\/kiali\.io\/edit\//$\
           ,/^https:\/\/github.com\/kiali\/kiali\.io\/new\//$\
-          ,/^https:\/\/github.com\/kiali\/kiali\/issues\/new/$\
           ,/^https:\/\/github.com\/kiali\/kiali\.io\/commit\//$\
+                    ,/^https:\/\/github.com\/kiali\/kiali\.io\/issues\/new/$\
           ,/.*web.libera.chat.*/
 ## validate-site: Builds the site and validates the pages. This is used for CI
 .PHONY: validate-site

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,0 +1,8 @@
+/*
+Hide the "create documentation issue" links and defer "create project issue".  Kiali puts all issues under the project.
+- The two lines below do the same thing, the top line is for our current version of Docsy.  The bottom
+  line is the newer, preferred way.  TODO: remove top line when we update Docsy.
+*/
+.td-page-meta > a:nth-child(3) { display: none !important; }
+.td-page-meta--issue { display: none !important; }
+


### PR DESCRIPTION
* related to: https://github.com/google/docsy/issues/731

Remove the 'Create Documentation Issue' link on the page RHS, we only
want "Project" issues.  (note, after merging we will disable Issues
for kiali/kiali.io.)

Also, unrelated, but fix our fedora-minimal image on something that works,
the most recent 'latest' failed to build the container.