### PR TITLE
FAQ cleanup

### DIFF
--- a/content/en/docs/Configuration/_index.md
+++ b/content/en/docs/Configuration/_index.md
@@ -4,3 +4,43 @@ description: "How to configure Kiali to fit your needs."
 weight: 2
 ---
 
+The pages in this _Configuration_ section describes most available options for
+managing and customizing your Kiali installation.
+
+Unless noted, it is assumed that you are using the Kiali operator and that you
+are managing the Kiali installation through a Kiali CR. The provided YAML
+snippets for configuring Kiali should be placed in your Kiali CR. For example,
+the provided configuration snippet for [setting up the Anonymous authentication
+strategy]({{< relref "authentication/anonymous/#set-up" >}}) is the following:
+
+```yaml
+spec:
+  auth:
+    strategy: anonymous
+```
+
+You will need to take this YAML snippet and apply it to your Kiali CR. As an example, an almost minimal Kiali CR using the previous configuration snippet would be the following:
+
+```yaml
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  namespace: kiali-namespace
+  name: kiali
+spec:
+  istio_namespace: istio-system
+  deployment:
+    namespace: kiali-namespace
+  auth:
+    strategy: anonymous
+```
+
+Then, you can save the finished YAML file and apply it with `kubectl apply -f`.
+It is recommended that you read
+_[The Kiali CR]({{< relref "../Installation/installation-guide/creating-updating-kiali-cr" >}})_
+and the _[Example Install]({{< relref "../Installation/installation-guide/example-install" >}})_
+pages of the Installation Guide for more information about using the Kiali CR.
+Also, make sure to check the [Kiali CR YAML template
+file](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml)
+available in the Operator's GitHub repository which has a reference of all
+available options.

--- a/content/en/docs/Configuration/_index.md
+++ b/content/en/docs/Configuration/_index.md
@@ -4,7 +4,7 @@ description: "How to configure Kiali to fit your needs."
 weight: 2
 ---
 
-The pages in this _Configuration_ section describes most available options for
+The pages in this _Configuration_ section describe most available options for
 managing and customizing your Kiali installation.
 
 Unless noted, it is assumed that you are using the Kiali operator and that you
@@ -36,11 +36,10 @@ spec:
 ```
 
 Then, you can save the finished YAML file and apply it with `kubectl apply -f`.
+
 It is recommended that you read
 _[The Kiali CR]({{< relref "../Installation/installation-guide/creating-updating-kiali-cr" >}})_
 and the _[Example Install]({{< relref "../Installation/installation-guide/example-install" >}})_
 pages of the Installation Guide for more information about using the Kiali CR.
-Also, make sure to check the [Kiali CR YAML template
-file](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml)
-available in the Operator's GitHub repository which has a reference of all
-available options.
+
+Also, for reference, the [Kiali CR YAML template file](https://github.com/kiali/kiali operator/blob/master/deploy/kiali/kiali_cr.yaml) documents all available options.

--- a/content/en/docs/FAQ/distributed-tracing.md
+++ b/content/en/docs/FAQ/distributed-tracing.md
@@ -13,7 +13,7 @@ While on any Tracing page, error "Could not fetch traces" is displayed:
 
 ![Could not fetch traces](/images/documentation/faq/tracing/could-not-fetch-traces.png)
 
-Apparently, Kiali is unable to connect to Jaeger. Make sure tracing is correctly configured in the Kiali custom resource or ConfigMap ([View full CR description](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml)).
+Apparently, Kiali is unable to connect to Jaeger. Make sure [tracing is correctly configured in the Kiali CR]({{< relref "../Configuration/p8s-jaeger-grafana#jaeger-configuration" >}}).
 
 ```yaml
       tracing:
@@ -25,7 +25,7 @@ Apparently, Kiali is unable to connect to Jaeger. Make sure tracing is correctly
         use_grpc: true
 ```
 
-You need especially to pay attention to the `in_cluster_url` field, which is how Kiali backend contacts the Jaeger service. In general, this URL is written using Kubernetes domain names in the form of `http://service.namespace`, plus eventually a path.
+You need especially to pay attention to the `in_cluster_url` field, which is how Kiali backend contacts the Jaeger service. In general, this URL is written using Kubernetes domain names in the form of `http://service.namespace`, plus a path.
 
 If you're not sure about this URL, try to find your Jaeger service and its exposed ports:
 
@@ -44,7 +44,7 @@ $ kubectl exec -n istio-system -it kiali-556fdb8ff5-p6l2n -- curl http://tracing
 {"data":null,"total":0,"limit":0,"offset":0,"errors":[{"code":400,"msg":"parameter 'service' is required"}]}
 ```
 
-If you see some returning JSON as in the above example, congrats, it should be well configured!
+If you see some returning JSON as in the above example, that should be the URL that you must configure.
 
 If instead of that you see some blocks of mixed HTML/Javascript mentioning JaegerUI, then probably the host+port are correct but the path isn't.
 
@@ -61,7 +61,7 @@ If for some reason the GRPC connection fails and you think it shouldn't (e.g. yo
 
 ### Why can't I see any external link to Jaeger?
 
-In addition to the embedded integration that Kiali provides with Jaeger, it is possible to show external links to the Jaeger UI. To do so, the external URL must be configured in the [Kiali CR](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml) or ConfigMap (field `url`).
+In addition to the embedded integration that Kiali provides with Jaeger, it is possible to show external links to the Jaeger UI. To do so, the external URL must be configured in the [Kiali CR](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml).
 
 ```yaml
     tracing:
@@ -82,7 +82,7 @@ When configured, this URL will be used to generate a couple of links to Jaeger w
 
 On the Application detail page, the Traces tab might redirect to Jaeger via an external link instead of showing the Kiali Tracing view. It happens when you have the `url` field configured, but not `in_cluster_url`, which means the Kiali backend will not be able to connect to Jaeger.
 
-To fix it, configure `in_cluster_url` in [Kiali CR](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml) or ConfigMap.
+To fix it, configure `in_cluster_url` in [Kiali CR](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml).
 
 
 ### Why do I see "Missing root span" for the root span of some span details on Traces tab?
@@ -90,3 +90,4 @@ To fix it, configure `in_cluster_url` in [Kiali CR](https://github.com/kiali/kia
 ![Missing root span](/images/documentation/faq/tracing/missing-root-span.png)
 
 In Traces tab, while clicking on a trace, it shows the details of that trace and information about spans. These details also include the root span information. But for the traces for traffic that is not comming from ingress-gateway, the root span information is not available in Jaeger, thus Kiali is displaying "Missing root span" for those traces' details and tooltips in Traces tab and in Graph pages.
+

--- a/content/en/docs/FAQ/graph.md
+++ b/content/en/docs/FAQ/graph.md
@@ -40,21 +40,7 @@ From the Graph page, you can filter them out by typing `node = unknown` in the _
 
 ![Graph Hide](/images/documentation/faq/graph/graph-hide.png)
 
-For a more definitive solution, there are several ways to prevent Istio from gathering this kind of telemetry.
-
-The first is to have these endpoints (like `/health` or `/metrics`) exposed on a different port and server than your main application, and to _not_ declare this port in your _Pod_'s container definition as _containerPort_. This way, the requests will be completely ignored by the Istio proxy, as mentioned in [Istio documentation](https://istio.io/v1.9/docs/ops/configuration/mesh/app-health-check/#liveness-and-readiness-probes-using-the-http-request-approach) (at the bottom of that page).
-
-The second way is to modify Istio's Prometheus rule to explicitly exclude some requests based on the User Agent. This is the `Rule` resource named `promhttp` located in `istio-system`. To edit it:
-
-```
-kubectl edit rule promhttp -n istio-system
-```
-
-Then locate the `match` field under `spec` section. Change it to filter out, for instance, the Kubernetes probes:
-
-```yaml
-match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false)
-```
+For a more definitive solution, you could have these endpoints (like `/health` or `/metrics`) exposed on a different port and server than your main application, and to _not_ declare this port in your _Pod_'s container definition as _containerPort_. This way, the requests will be completely ignored by the Istio proxy, as mentioned in [Istio documentation](https://istio.io/v1.6/docs/ops/configuration/mesh/app-health-check/#liveness-and-readiness-probes-with-http-request-option) (at the bottom of that page).
 
 ### Why do I have missing edges? {#missing-edges}
 

--- a/content/en/docs/FAQ/installation.md
+++ b/content/en/docs/FAQ/installation.md
@@ -32,11 +32,13 @@ and RoleBindings (not the "Cluster" kinds) and assign them to the Kiali Server.
 A Kiali CR is used to tell the Kiali Operator how and where to install a Kiali Server in your cluster. You can install one or more Kiali Servers by creating
 one Kiali CR for each Kiali Server you want the Operator to install and manage. Deleting a Kiali CR will uninstall its associted Kiali Server.
 
-All the settings that you can define in a Kiali CR are [fully documented here](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml).
+Most options are described in the pages of the [Installation]({{< relref "../Installation" >}}) and [Configuration]({{< relref "../Configuration" >}}) sections of the documentation.
+
+If you cannot find some configuration, check the [template of the Kiali CR](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml) available in Kiali's GitHub repository, which briefly describes all available options.
 If you are using a specific version of the Operator, the Kiali CR that is valid for that version can be found in the version tag within the github repository
 (e.g. Operator v1.25.0 supported [these Kiali CR settings](https://github.com/kiali/kiali-operator/blob/v1.25.0/deploy/kiali/kiali_cr.yaml)).
 
-Note that that example Kiali CR is formatted in such a way that if you uncomment a line (by deleting the line's leading `#` character), that line's setting
+Note that that Kiali CR template is formatted in such a way that if you uncomment a line (by deleting the line's leading `#` character), that line's setting
 will be at the appropriate indentation level. This allows you to create an initial Kiali CR by simply uncommenting lines of the settings you want to define.
 The comments are also specifically laid out in such a way that each major top-level group of settings are in their own major comment section, and each value
 in each commented setting is the default value (so if you do not define that setting yourself, you will know what its default value is). 

--- a/content/en/docs/Installation/installation-guide/creating-updating-kiali-cr.md
+++ b/content/en/docs/Installation/installation-guide/creating-updating-kiali-cr.md
@@ -67,10 +67,19 @@ Events:        <none>
 *Never* manually edit resources created by the Kiali Operator, only the Kiali CR.
 {{% /alert %}}
 
-We recommended to download the [example Kiali CR YAML file](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml)
-that is available in the Operator's GitHub repository. This
-example file contains and describes all available settings. Then, edit the
-downloaded file being *very careful* to maintain proper formatting.  Incorrect indentation is a common problem!
+You may want to check the [example install page]({{< relref "example-install"
+>}}) to see some examples where the Kiali CR has a `spec` and to better
+understand its structre. Most available attributes of the Kiali CR are
+described in the pages of the [Installation]({{< relref "../" >}}) and
+[Configuration]({{< relref "../../Configuration" >}}) sections of the
+documentation.
+
+Alternatively, a [Kiali CR YAML template
+file](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml)
+is available in the Operator's GitHub repository. This template file contains
+and describes all available settings. You can download it and edit it being
+*very careful* to maintain proper formatting. Incorrect indentation is a common
+problem!
 
 {{% alert color="warning" %}}
 The link in the previous paragraph is for the example Kiali CR hosted in


### PR DESCRIPTION
De-duplicate some doc, remove some obsolete information and remove some references to the Kiali CR in GitHub in favor of cross-referencing docs

This is the last PR for kiali/kiali#3858.

Some configs are still missing. I found some of them are not really meant to be user configurable, but are more for easiness to change in case Istio uses different names/strings. Some others are rarely used configurations and I think we can add them to docs on demand. Finally, there are a few configs that I don't understand, thus I'm not describing under the scope of kiali/kiali#3858.

Fixes kiali/kiali#3858