### PR TITLE
add double quote for authentication.md commend

### DIFF
--- a/content/en/docs/FAQ/authentication.md
+++ b/content/en/docs/FAQ/authentication.md
@@ -13,7 +13,7 @@ You can extract a service account's token from the secret that was created for y
 For example, if you want to log into Kiali using Kiali's own service account, you can get the token like this:
 
 ```
-kubectl get secret -n istio-system $(kubectl get sa kiali-service-account -n istio-system -o jsonpath={.secrets[0].name}) -o jsonpath={.data.token} | base64 -d
+kubectl get secret -n istio-system $(kubectl get sa kiali-service-account -n istio-system -o "jsonpath={.secrets[0].name}") -o jsonpath={.data.token} | base64 -d
 ```
 
 Note that this example assumes you installed Kiali in the `istio-system` namespace.


### PR DESCRIPTION
without double quote
```
ᐅ kubectl get secret -n istio-system $(kubectl get sa kiali -n istio-system -o jsonpath={.secrets[0].name}) -o jsonpath={.data.token} | base64 -d  

zsh: no matches found: jsonpath={.secrets[0].name}
```

with double quote
```
 kubectl get secret -n istio-system $(kubectl get sa kiali -n istio-system -o "jsonpath={.secrets[0].name}") -o jsonpath={.data.token} | base64 -d
eyJhbGciOiJSUzI1NiIsI......
```