### PR TITLE
generate the CRD schema doc from the information in the kiali-operator repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 public
 resources
-
+tmp-crd-docs

--- a/content/en/docs/Configuration/_index.md
+++ b/content/en/docs/Configuration/_index.md
@@ -42,4 +42,4 @@ _[The Kiali CR]({{< relref "../Installation/installation-guide/creating-updating
 and the _[Example Install]({{< relref "../Installation/installation-guide/example-install" >}})_
 pages of the Installation Guide for more information about using the Kiali CR.
 
-Also, for reference, the [Kiali CR YAML template file](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml) documents all available options.
+Also, for reference, see [Kiali CR Reference](/docs/configuration/kialis.kiali.io) which documents all available options.

--- a/content/en/docs/Configuration/authentication/openid.md
+++ b/content/en/docs/Configuration/authentication/openid.md
@@ -465,8 +465,7 @@ Create a web application for Kiali in your Azure AD panel:
    Kubernetes secret in your cluster as mentioned in the [Set-up
    with RBAC support](#setup-with-rbac) section. Please, note that the suggested name for the
    Kubernetes Secret is `kiali`. If you want to customize the secret name, you
-   will have to specify your custom name in the Kiali CR. See the
-   [comments for the `secret_name` configuration in the sample Kiali CR](https://github.com/kiali/kiali-operator/blob/5e364ee48c08a1bdd200172b47f08b2ed0369c25/deploy/kiali/kiali_cr.yaml#L342-L347).
+   will have to specify your custom name in the Kiali CR. See: [secret_name in Kial CR Reference](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.deployment.secret_name).
 3. Go to _API Permissions_ and press the _Add a permission_ button. In the new page that appears, switch to the
   _APIs my organization uses_ tab.
   1. Type the following ID in the search field:

--- a/content/en/docs/Configuration/authentication/openid.md
+++ b/content/en/docs/Configuration/authentication/openid.md
@@ -465,7 +465,7 @@ Create a web application for Kiali in your Azure AD panel:
    Kubernetes secret in your cluster as mentioned in the [Set-up
    with RBAC support](#setup-with-rbac) section. Please, note that the suggested name for the
    Kubernetes Secret is `kiali`. If you want to customize the secret name, you
-   will have to specify your custom name in the Kiali CR. See: [secret_name in Kial CR Reference](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.deployment.secret_name).
+   will have to specify your custom name in the Kiali CR. See: [secret_name in Kial CR Reference](/docs/configuration/kialis.kiali.io/#.spec.deployment.secret_name).
 3. Go to _API Permissions_ and press the _Add a permission_ button. In the new page that appears, switch to the
   _APIs my organization uses_ tab.
   1. Type the following ID in the search field:

--- a/content/en/docs/Configuration/custom-dashboard.md
+++ b/content/en/docs/Configuration/custom-dashboard.md
@@ -197,7 +197,7 @@ external_services:
 # ...
 ```
 
-For more details on this configuration, such as Prometheus authentication options, [check the Kiali CR Reference page](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.external_services.custom_dashboards).
+For more details on this configuration, such as Prometheus authentication options, [check the Kiali CR Reference page](/docs/configuration/kialis.kiali.io/#.spec.external_services.custom_dashboards).
 
 You must make sure that this Prometheus instance is correctly configured to scrape your application pods and generates labels that Kiali will understand. Please refer to
 [this documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config) to setup the `kubernetes_sd_config` section. As a reference,

--- a/content/en/docs/Configuration/custom-dashboard.md
+++ b/content/en/docs/Configuration/custom-dashboard.md
@@ -197,7 +197,7 @@ external_services:
 # ...
 ```
 
-For more details on this configuration, such as Prometheus authentication options, [check this page](https://github.com/kiali/kiali-operator/blob/76242369299c35db350119516c6db6fd87f47822/deploy/kiali/kiali_cr.yaml#L452-L470).
+For more details on this configuration, such as Prometheus authentication options, [check the Kiali CR Reference page](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.external_services.custom_dashboards).
 
 You must make sure that this Prometheus instance is correctly configured to scrape your application pods and generates labels that Kiali will understand. Please refer to
 [this documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config) to setup the `kubernetes_sd_config` section. As a reference,

--- a/content/en/docs/Configuration/health.md
+++ b/content/en/docs/Configuration/health.md
@@ -43,7 +43,7 @@ So, for example, if the rate of application errors is >= 0.1% Kiali will show `D
 
 ## Custom Configuration
 
-Custom health configuration is specified in the Kiali CR. To see the supported configuration syntax for `health_config` visit [Kiali CR](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml).
+Custom health configuration is specified in the Kiali CR. To see the supported configuration syntax for `health_config` see the [Kiali CR Reference](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.health_config).
 
 Kiali applies *the first matching rate configuration (namespace, kind, etc)* and calculates the status for each tolerance. The reported health will be the status with highest priority (see below).
 

--- a/content/en/docs/Configuration/health.md
+++ b/content/en/docs/Configuration/health.md
@@ -43,7 +43,7 @@ So, for example, if the rate of application errors is >= 0.1% Kiali will show `D
 
 ## Custom Configuration
 
-Custom health configuration is specified in the Kiali CR. To see the supported configuration syntax for `health_config` see the [Kiali CR Reference](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.health_config).
+Custom health configuration is specified in the Kiali CR. To see the supported configuration syntax for `health_config` see the [Kiali CR Reference](/docs/configuration/kialis.kiali.io/#.spec.health_config).
 
 Kiali applies *the first matching rate configuration (namespace, kind, etc)* and calculates the status for each tolerance. The reported health will be the status with highest priority (see below).
 

--- a/content/en/docs/Configuration/kialis.kiali.io.md
+++ b/content/en/docs/Configuration/kialis.kiali.io.md
@@ -466,6 +466,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 
 <div class="property depth-0">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec">.spec</h3>
 </div>
 <div class="property-body">
@@ -484,6 +485,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 
 <div class="property depth-1">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.additional_display_details">.spec.additional_display_details</h3>
 </div>
 <div class="property-body">
@@ -509,6 +511,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.additional_display_details[*]">.spec.additional_display_details[*]</h3>
 </div>
 <div class="property-body">
@@ -522,6 +525,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.additional_display_details[*].annotation">.spec.additional_display_details[*].annotation</h3>
 </div>
 <div class="property-body">
@@ -540,6 +544,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.additional_display_details[*].icon_annotation">.spec.additional_display_details[*].icon_annotation</h3>
 </div>
 <div class="property-body">
@@ -558,6 +563,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.additional_display_details[*].title">.spec.additional_display_details[*].title</h3>
 </div>
 <div class="property-body">
@@ -576,6 +582,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 
 <div class="property depth-1">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.api">.spec.api</h3>
 </div>
 <div class="property-body">
@@ -589,6 +596,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.api.namespaces">.spec.api.namespaces</h3>
 </div>
 <div class="property-body">
@@ -607,6 +615,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.api.namespaces.exclude">.spec.api.namespaces.exclude</h3>
 </div>
 <div class="property-body">
@@ -625,6 +634,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.api.namespaces.exclude[*]">.spec.api.namespaces.exclude[*]</h3>
 </div>
 <div class="property-body">
@@ -638,6 +648,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.api.namespaces.label_selector">.spec.api.namespaces.label_selector</h3>
 </div>
 <div class="property-body">
@@ -668,6 +679,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-1">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth">.spec.auth</h3>
 </div>
 <div class="property-body">
@@ -681,6 +693,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid">.spec.auth.openid</h3>
 </div>
 <div class="property-body">
@@ -699,6 +712,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.additional_request_params">.spec.auth.openid.additional_request_params</h3>
 </div>
 <div class="property-body">
@@ -712,6 +726,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.allowed_domains">.spec.auth.openid.allowed_domains</h3>
 </div>
 <div class="property-body">
@@ -725,6 +740,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.allowed_domains[*]">.spec.auth.openid.allowed_domains[*]</h3>
 </div>
 <div class="property-body">
@@ -738,6 +754,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.api_proxy">.spec.auth.openid.api_proxy</h3>
 </div>
 <div class="property-body">
@@ -751,6 +768,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.api_proxy_ca_data">.spec.auth.openid.api_proxy_ca_data</h3>
 </div>
 <div class="property-body">
@@ -764,6 +782,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.api_token">.spec.auth.openid.api_token</h3>
 </div>
 <div class="property-body">
@@ -777,6 +796,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.authentication_timeout">.spec.auth.openid.authentication_timeout</h3>
 </div>
 <div class="property-body">
@@ -790,6 +810,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.authorization_endpoint">.spec.auth.openid.authorization_endpoint</h3>
 </div>
 <div class="property-body">
@@ -803,6 +824,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.client_id">.spec.auth.openid.client_id</h3>
 </div>
 <div class="property-body">
@@ -816,6 +838,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.disable_rbac">.spec.auth.openid.disable_rbac</h3>
 </div>
 <div class="property-body">
@@ -829,6 +852,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.http_proxy">.spec.auth.openid.http_proxy</h3>
 </div>
 <div class="property-body">
@@ -842,6 +866,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.https_proxy">.spec.auth.openid.https_proxy</h3>
 </div>
 <div class="property-body">
@@ -855,6 +880,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.insecure_skip_verify_tls">.spec.auth.openid.insecure_skip_verify_tls</h3>
 </div>
 <div class="property-body">
@@ -868,6 +894,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.issuer_uri">.spec.auth.openid.issuer_uri</h3>
 </div>
 <div class="property-body">
@@ -881,6 +908,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.scopes">.spec.auth.openid.scopes</h3>
 </div>
 <div class="property-body">
@@ -894,6 +922,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.scopes[*]">.spec.auth.openid.scopes[*]</h3>
 </div>
 <div class="property-body">
@@ -907,6 +936,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openid.username_claim">.spec.auth.openid.username_claim</h3>
 </div>
 <div class="property-body">
@@ -920,6 +950,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openshift">.spec.auth.openshift</h3>
 </div>
 <div class="property-body">
@@ -938,6 +969,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.openshift.client_id_prefix">.spec.auth.openshift.client_id_prefix</h3>
 </div>
 <div class="property-body">
@@ -956,6 +988,7 @@ is the namespace where Kiali is to be installed.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.auth.strategy">.spec.auth.strategy</h3>
 </div>
 <div class="property-body">
@@ -990,6 +1023,7 @@ Authorization header and potentially impersonation headers.</li>
 
 <div class="property depth-1">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.custom_dashboards">.spec.custom_dashboards</h3>
 </div>
 <div class="property-body">
@@ -1031,6 +1065,7 @@ empty dashboard.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.custom_dashboards[*]">.spec.custom_dashboards[*]</h3>
 </div>
 <div class="property-body">
@@ -1044,6 +1079,7 @@ empty dashboard.</p>
 
 <div class="property depth-1">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment">.spec.deployment</h3>
 </div>
 <div class="property-body">
@@ -1057,6 +1093,7 @@ empty dashboard.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.accessible_namespaces">.spec.deployment.accessible_namespaces</h3>
 </div>
 <div class="property-body">
@@ -1075,6 +1112,7 @@ empty dashboard.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.accessible_namespaces[*]">.spec.deployment.accessible_namespaces[*]</h3>
 </div>
 <div class="property-body">
@@ -1088,6 +1126,7 @@ empty dashboard.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.additional_service_yaml">.spec.deployment.additional_service_yaml</h3>
 </div>
 <div class="property-body">
@@ -1106,6 +1145,7 @@ empty dashboard.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.affinity">.spec.deployment.affinity</h3>
 </div>
 <div class="property-body">
@@ -1124,6 +1164,7 @@ empty dashboard.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.affinity.node">.spec.deployment.affinity.node</h3>
 </div>
 <div class="property-body">
@@ -1137,6 +1178,7 @@ empty dashboard.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.affinity.pod">.spec.deployment.affinity.pod</h3>
 </div>
 <div class="property-body">
@@ -1150,6 +1192,7 @@ empty dashboard.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.affinity.pod_anti">.spec.deployment.affinity.pod_anti</h3>
 </div>
 <div class="property-body">
@@ -1163,6 +1206,7 @@ empty dashboard.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.custom_secrets">.spec.deployment.custom_secrets</h3>
 </div>
 <div class="property-body">
@@ -1196,6 +1240,7 @@ An example configuration is,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.custom_secrets[*]">.spec.deployment.custom_secrets[*]</h3>
 </div>
 <div class="property-body">
@@ -1209,6 +1254,7 @@ An example configuration is,</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.custom_secrets[*].mount">.spec.deployment.custom_secrets[*].mount</h3>
 </div>
 <div class="property-body">
@@ -1227,6 +1273,7 @@ An example configuration is,</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.custom_secrets[*].name">.spec.deployment.custom_secrets[*].name</h3>
 </div>
 <div class="property-body">
@@ -1245,6 +1292,7 @@ An example configuration is,</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.custom_secrets[*].optional">.spec.deployment.custom_secrets[*].optional</h3>
 </div>
 <div class="property-body">
@@ -1263,6 +1311,7 @@ An example configuration is,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.host_aliases">.spec.deployment.host_aliases</h3>
 </div>
 <div class="property-body">
@@ -1292,6 +1341,7 @@ A typical way to configure this setting is,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.host_aliases[*]">.spec.deployment.host_aliases[*]</h3>
 </div>
 <div class="property-body">
@@ -1305,6 +1355,7 @@ A typical way to configure this setting is,</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.host_aliases[*].hostnames">.spec.deployment.host_aliases[*].hostnames</h3>
 </div>
 <div class="property-body">
@@ -1318,6 +1369,7 @@ A typical way to configure this setting is,</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.host_aliases[*].hostnames[*]">.spec.deployment.host_aliases[*].hostnames[*]</h3>
 </div>
 <div class="property-body">
@@ -1331,6 +1383,7 @@ A typical way to configure this setting is,</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.host_aliases[*].ip">.spec.deployment.host_aliases[*].ip</h3>
 </div>
 <div class="property-body">
@@ -1344,6 +1397,7 @@ A typical way to configure this setting is,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.hpa">.spec.deployment.hpa</h3>
 </div>
 <div class="property-body">
@@ -1371,6 +1425,7 @@ A typical way to configure HPA for Kiali is,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.hpa.api_version">.spec.deployment.hpa.api_version</h3>
 </div>
 <div class="property-body">
@@ -1389,6 +1444,7 @@ A typical way to configure HPA for Kiali is,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.hpa.spec">.spec.deployment.hpa.spec</h3>
 </div>
 <div class="property-body">
@@ -1407,6 +1463,7 @@ A typical way to configure HPA for Kiali is,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.image_digest">.spec.deployment.image_digest</h3>
 </div>
 <div class="property-body">
@@ -1425,6 +1482,7 @@ A typical way to configure HPA for Kiali is,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.image_name">.spec.deployment.image_name</h3>
 </div>
 <div class="property-body">
@@ -1443,6 +1501,7 @@ A typical way to configure HPA for Kiali is,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.image_pull_policy">.spec.deployment.image_pull_policy</h3>
 </div>
 <div class="property-body">
@@ -1461,6 +1520,7 @@ A typical way to configure HPA for Kiali is,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.image_pull_secrets">.spec.deployment.image_pull_secrets</h3>
 </div>
 <div class="property-body">
@@ -1479,6 +1539,7 @@ A typical way to configure HPA for Kiali is,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.image_pull_secrets[*]">.spec.deployment.image_pull_secrets[*]</h3>
 </div>
 <div class="property-body">
@@ -1492,6 +1553,7 @@ A typical way to configure HPA for Kiali is,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.image_version">.spec.deployment.image_version</h3>
 </div>
 <div class="property-body">
@@ -1526,6 +1588,7 @@ operator itself was configured.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.ingress">.spec.deployment.ingress</h3>
 </div>
 <div class="property-body">
@@ -1544,6 +1607,7 @@ operator itself was configured.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.additional_labels">.spec.deployment.ingress.additional_labels</h3>
 </div>
 <div class="property-body">
@@ -1562,6 +1626,7 @@ operator itself was configured.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.class_name">.spec.deployment.ingress.class_name</h3>
 </div>
 <div class="property-body">
@@ -1580,6 +1645,7 @@ operator itself was configured.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.enabled">.spec.deployment.ingress.enabled</h3>
 </div>
 <div class="property-body">
@@ -1598,6 +1664,7 @@ operator itself was configured.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.override_yaml">.spec.deployment.ingress.override_yaml</h3>
 </div>
 <div class="property-body">
@@ -1645,6 +1712,7 @@ Example,</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.override_yaml.metadata">.spec.deployment.ingress.override_yaml.metadata</h3>
 </div>
 <div class="property-body">
@@ -1658,6 +1726,7 @@ Example,</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.override_yaml.metadata.annotations">.spec.deployment.ingress.override_yaml.metadata.annotations</h3>
 </div>
 <div class="property-body">
@@ -1671,6 +1740,7 @@ Example,</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.override_yaml.spec">.spec.deployment.ingress.override_yaml.spec</h3>
 </div>
 <div class="property-body">
@@ -1684,6 +1754,7 @@ Example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.instance_name">.spec.deployment.instance_name</h3>
 </div>
 <div class="property-body">
@@ -1702,6 +1773,7 @@ Example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.logger">.spec.deployment.logger</h3>
 </div>
 <div class="property-body">
@@ -1720,6 +1792,7 @@ Example,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.logger.log_format">.spec.deployment.logger.log_format</h3>
 </div>
 <div class="property-body">
@@ -1738,6 +1811,7 @@ Example,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.logger.log_level">.spec.deployment.logger.log_level</h3>
 </div>
 <div class="property-body">
@@ -1756,6 +1830,7 @@ Example,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.logger.sampler_rate">.spec.deployment.logger.sampler_rate</h3>
 </div>
 <div class="property-body">
@@ -1774,6 +1849,7 @@ Example,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.logger.time_field_format">.spec.deployment.logger.time_field_format</h3>
 </div>
 <div class="property-body">
@@ -1792,6 +1868,7 @@ Example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.namespace">.spec.deployment.namespace</h3>
 </div>
 <div class="property-body">
@@ -1810,6 +1887,7 @@ Example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.node_selector">.spec.deployment.node_selector</h3>
 </div>
 <div class="property-body">
@@ -1828,6 +1906,7 @@ Example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.pod_annotations">.spec.deployment.pod_annotations</h3>
 </div>
 <div class="property-body">
@@ -1846,6 +1925,7 @@ Example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.pod_labels">.spec.deployment.pod_labels</h3>
 </div>
 <div class="property-body">
@@ -1868,6 +1948,7 @@ An example use for this setting is to inject an Istio sidecar such as,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.priority_class_name">.spec.deployment.priority_class_name</h3>
 </div>
 <div class="property-body">
@@ -1886,6 +1967,7 @@ An example use for this setting is to inject an Istio sidecar such as,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.replicas">.spec.deployment.replicas</h3>
 </div>
 <div class="property-body">
@@ -1904,6 +1986,7 @@ An example use for this setting is to inject an Istio sidecar such as,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.resources">.spec.deployment.resources</h3>
 </div>
 <div class="property-body">
@@ -1931,6 +2014,7 @@ limits:
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.secret_name">.spec.deployment.secret_name</h3>
 </div>
 <div class="property-body">
@@ -1949,6 +2033,7 @@ limits:
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.service_annotations">.spec.deployment.service_annotations</h3>
 </div>
 <div class="property-body">
@@ -1967,6 +2052,7 @@ limits:
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.service_type">.spec.deployment.service_type</h3>
 </div>
 <div class="property-body">
@@ -1985,6 +2071,7 @@ limits:
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.tolerations">.spec.deployment.tolerations</h3>
 </div>
 <div class="property-body">
@@ -2003,6 +2090,7 @@ limits:
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.tolerations[*]">.spec.deployment.tolerations[*]</h3>
 </div>
 <div class="property-body">
@@ -2016,6 +2104,7 @@ limits:
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.verbose_mode">.spec.deployment.verbose_mode</h3>
 </div>
 <div class="property-body">
@@ -2034,6 +2123,7 @@ limits:
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.version_label">.spec.deployment.version_label</h3>
 </div>
 <div class="property-body">
@@ -2060,6 +2150,7 @@ When empty, its default will be determined as follows,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.deployment.view_only_mode">.spec.deployment.view_only_mode</h3>
 </div>
 <div class="property-body">
@@ -2078,6 +2169,7 @@ When empty, its default will be determined as follows,</p>
 
 <div class="property depth-1">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services">.spec.external_services</h3>
 </div>
 <div class="property-body">
@@ -2111,6 +2203,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards">.spec.external_services.custom_dashboards</h3>
 </div>
 <div class="property-body">
@@ -2129,6 +2222,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.discovery_auto_threshold">.spec.external_services.custom_dashboards.discovery_auto_threshold</h3>
 </div>
 <div class="property-body">
@@ -2147,6 +2241,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.discovery_enabled">.spec.external_services.custom_dashboards.discovery_enabled</h3>
 </div>
 <div class="property-body">
@@ -2165,6 +2260,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.enabled">.spec.external_services.custom_dashboards.enabled</h3>
 </div>
 <div class="property-body">
@@ -2183,6 +2279,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.is_core">.spec.external_services.custom_dashboards.is_core</h3>
 </div>
 <div class="property-body">
@@ -2201,6 +2298,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.namespace_label">.spec.external_services.custom_dashboards.namespace_label</h3>
 </div>
 <div class="property-body">
@@ -2219,6 +2317,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus">.spec.external_services.custom_dashboards.prometheus</h3>
 </div>
 <div class="property-body">
@@ -2237,6 +2336,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth">.spec.external_services.custom_dashboards.prometheus.auth</h3>
 </div>
 <div class="property-body">
@@ -2255,6 +2355,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.ca_file">.spec.external_services.custom_dashboards.prometheus.auth.ca_file</h3>
 </div>
 <div class="property-body">
@@ -2273,6 +2374,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.insecure_skip_verify">.spec.external_services.custom_dashboards.prometheus.auth.insecure_skip_verify</h3>
 </div>
 <div class="property-body">
@@ -2291,6 +2393,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.password">.spec.external_services.custom_dashboards.prometheus.auth.password</h3>
 </div>
 <div class="property-body">
@@ -2309,6 +2412,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.token">.spec.external_services.custom_dashboards.prometheus.auth.token</h3>
 </div>
 <div class="property-body">
@@ -2327,6 +2431,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.type">.spec.external_services.custom_dashboards.prometheus.auth.type</h3>
 </div>
 <div class="property-body">
@@ -2345,6 +2450,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.use_kiali_token">.spec.external_services.custom_dashboards.prometheus.auth.use_kiali_token</h3>
 </div>
 <div class="property-body">
@@ -2363,6 +2469,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.username">.spec.external_services.custom_dashboards.prometheus.auth.username</h3>
 </div>
 <div class="property-body">
@@ -2381,6 +2488,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.cache_duration">.spec.external_services.custom_dashboards.prometheus.cache_duration</h3>
 </div>
 <div class="property-body">
@@ -2399,6 +2507,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.cache_enabled">.spec.external_services.custom_dashboards.prometheus.cache_enabled</h3>
 </div>
 <div class="property-body">
@@ -2417,6 +2526,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.cache_expiration">.spec.external_services.custom_dashboards.prometheus.cache_expiration</h3>
 </div>
 <div class="property-body">
@@ -2435,6 +2545,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.custom_headers">.spec.external_services.custom_dashboards.prometheus.custom_headers</h3>
 </div>
 <div class="property-body">
@@ -2453,6 +2564,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.health_check_url">.spec.external_services.custom_dashboards.prometheus.health_check_url</h3>
 </div>
 <div class="property-body">
@@ -2471,6 +2583,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.is_core">.spec.external_services.custom_dashboards.prometheus.is_core</h3>
 </div>
 <div class="property-body">
@@ -2489,6 +2602,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.thanos_proxy">.spec.external_services.custom_dashboards.prometheus.thanos_proxy</h3>
 </div>
 <div class="property-body">
@@ -2507,6 +2621,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.thanos_proxy.enabled">.spec.external_services.custom_dashboards.prometheus.thanos_proxy.enabled</h3>
 </div>
 <div class="property-body">
@@ -2525,6 +2640,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.thanos_proxy.retention_period">.spec.external_services.custom_dashboards.prometheus.thanos_proxy.retention_period</h3>
 </div>
 <div class="property-body">
@@ -2543,6 +2659,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.thanos_proxy.scrape_interval">.spec.external_services.custom_dashboards.prometheus.thanos_proxy.scrape_interval</h3>
 </div>
 <div class="property-body">
@@ -2561,6 +2678,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.url">.spec.external_services.custom_dashboards.prometheus.url</h3>
 </div>
 <div class="property-body">
@@ -2579,6 +2697,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana">.spec.external_services.grafana</h3>
 </div>
 <div class="property-body">
@@ -2597,6 +2716,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth">.spec.external_services.grafana.auth</h3>
 </div>
 <div class="property-body">
@@ -2615,6 +2735,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.ca_file">.spec.external_services.grafana.auth.ca_file</h3>
 </div>
 <div class="property-body">
@@ -2633,6 +2754,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.insecure_skip_verify">.spec.external_services.grafana.auth.insecure_skip_verify</h3>
 </div>
 <div class="property-body">
@@ -2651,6 +2773,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.password">.spec.external_services.grafana.auth.password</h3>
 </div>
 <div class="property-body">
@@ -2669,6 +2792,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.token">.spec.external_services.grafana.auth.token</h3>
 </div>
 <div class="property-body">
@@ -2687,6 +2811,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.type">.spec.external_services.grafana.auth.type</h3>
 </div>
 <div class="property-body">
@@ -2705,6 +2830,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.use_kiali_token">.spec.external_services.grafana.auth.use_kiali_token</h3>
 </div>
 <div class="property-body">
@@ -2723,6 +2849,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.username">.spec.external_services.grafana.auth.username</h3>
 </div>
 <div class="property-body">
@@ -2741,6 +2868,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards">.spec.external_services.grafana.dashboards</h3>
 </div>
 <div class="property-body">
@@ -2759,6 +2887,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*]">.spec.external_services.grafana.dashboards[*]</h3>
 </div>
 <div class="property-body">
@@ -2772,6 +2901,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].name">.spec.external_services.grafana.dashboards[*].name</h3>
 </div>
 <div class="property-body">
@@ -2790,6 +2920,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].variables">.spec.external_services.grafana.dashboards[*].variables</h3>
 </div>
 <div class="property-body">
@@ -2803,6 +2934,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].variables.app">.spec.external_services.grafana.dashboards[*].variables.app</h3>
 </div>
 <div class="property-body">
@@ -2821,6 +2953,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].variables.namespace">.spec.external_services.grafana.dashboards[*].variables.namespace</h3>
 </div>
 <div class="property-body">
@@ -2839,6 +2972,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].variables.service">.spec.external_services.grafana.dashboards[*].variables.service</h3>
 </div>
 <div class="property-body">
@@ -2857,6 +2991,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].variables.workload">.spec.external_services.grafana.dashboards[*].variables.workload</h3>
 </div>
 <div class="property-body">
@@ -2875,6 +3010,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.enabled">.spec.external_services.grafana.enabled</h3>
 </div>
 <div class="property-body">
@@ -2893,6 +3029,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.health_check_url">.spec.external_services.grafana.health_check_url</h3>
 </div>
 <div class="property-body">
@@ -2911,6 +3048,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.in_cluster_url">.spec.external_services.grafana.in_cluster_url</h3>
 </div>
 <div class="property-body">
@@ -2929,6 +3067,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.is_core">.spec.external_services.grafana.is_core</h3>
 </div>
 <div class="property-body">
@@ -2947,6 +3086,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.url">.spec.external_services.grafana.url</h3>
 </div>
 <div class="property-body">
@@ -2965,6 +3105,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio">.spec.external_services.istio</h3>
 </div>
 <div class="property-body">
@@ -2983,6 +3124,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status">.spec.external_services.istio.component_status</h3>
 </div>
 <div class="property-body">
@@ -3001,6 +3143,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components">.spec.external_services.istio.component_status.components</h3>
 </div>
 <div class="property-body">
@@ -3019,6 +3162,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components[*]">.spec.external_services.istio.component_status.components[*]</h3>
 </div>
 <div class="property-body">
@@ -3032,6 +3176,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components[*].app_label">.spec.external_services.istio.component_status.components[*].app_label</h3>
 </div>
 <div class="property-body">
@@ -3050,6 +3195,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components[*].is_core">.spec.external_services.istio.component_status.components[*].is_core</h3>
 </div>
 <div class="property-body">
@@ -3068,6 +3214,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components[*].is_proxy">.spec.external_services.istio.component_status.components[*].is_proxy</h3>
 </div>
 <div class="property-body">
@@ -3086,6 +3233,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components[*].namespace">.spec.external_services.istio.component_status.components[*].namespace</h3>
 </div>
 <div class="property-body">
@@ -3104,6 +3252,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.enabled">.spec.external_services.istio.component_status.enabled</h3>
 </div>
 <div class="property-body">
@@ -3122,6 +3271,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.config_map_name">.spec.external_services.istio.config_map_name</h3>
 </div>
 <div class="property-body">
@@ -3140,6 +3290,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.envoy_admin_local_port">.spec.external_services.istio.envoy_admin_local_port</h3>
 </div>
 <div class="property-body">
@@ -3158,6 +3309,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_canary_revision">.spec.external_services.istio.istio_canary_revision</h3>
 </div>
 <div class="property-body">
@@ -3176,6 +3328,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_canary_revision.current">.spec.external_services.istio.istio_canary_revision.current</h3>
 </div>
 <div class="property-body">
@@ -3194,6 +3347,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_canary_revision.upgrade">.spec.external_services.istio.istio_canary_revision.upgrade</h3>
 </div>
 <div class="property-body">
@@ -3212,6 +3366,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_identity_domain">.spec.external_services.istio.istio_identity_domain</h3>
 </div>
 <div class="property-body">
@@ -3230,6 +3385,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_injection_annotation">.spec.external_services.istio.istio_injection_annotation</h3>
 </div>
 <div class="property-body">
@@ -3248,6 +3404,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_sidecar_annotation">.spec.external_services.istio.istio_sidecar_annotation</h3>
 </div>
 <div class="property-body">
@@ -3266,6 +3423,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_sidecar_injector_config_map_name">.spec.external_services.istio.istio_sidecar_injector_config_map_name</h3>
 </div>
 <div class="property-body">
@@ -3284,6 +3442,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istiod_deployment_name">.spec.external_services.istio.istiod_deployment_name</h3>
 </div>
 <div class="property-body">
@@ -3302,6 +3461,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istiod_pod_monitoring_port">.spec.external_services.istio.istiod_pod_monitoring_port</h3>
 </div>
 <div class="property-body">
@@ -3320,6 +3480,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.root_namespace">.spec.external_services.istio.root_namespace</h3>
 </div>
 <div class="property-body">
@@ -3338,6 +3499,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.istio.url_service_version">.spec.external_services.istio.url_service_version</h3>
 </div>
 <div class="property-body">
@@ -3356,6 +3518,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus">.spec.external_services.prometheus</h3>
 </div>
 <div class="property-body">
@@ -3374,6 +3537,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth">.spec.external_services.prometheus.auth</h3>
 </div>
 <div class="property-body">
@@ -3392,6 +3556,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.ca_file">.spec.external_services.prometheus.auth.ca_file</h3>
 </div>
 <div class="property-body">
@@ -3410,6 +3575,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.insecure_skip_verify">.spec.external_services.prometheus.auth.insecure_skip_verify</h3>
 </div>
 <div class="property-body">
@@ -3428,6 +3594,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.password">.spec.external_services.prometheus.auth.password</h3>
 </div>
 <div class="property-body">
@@ -3446,6 +3613,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.token">.spec.external_services.prometheus.auth.token</h3>
 </div>
 <div class="property-body">
@@ -3464,6 +3632,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.type">.spec.external_services.prometheus.auth.type</h3>
 </div>
 <div class="property-body">
@@ -3482,6 +3651,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.use_kiali_token">.spec.external_services.prometheus.auth.use_kiali_token</h3>
 </div>
 <div class="property-body">
@@ -3500,6 +3670,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.username">.spec.external_services.prometheus.auth.username</h3>
 </div>
 <div class="property-body">
@@ -3518,6 +3689,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.cache_duration">.spec.external_services.prometheus.cache_duration</h3>
 </div>
 <div class="property-body">
@@ -3536,6 +3708,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.cache_enabled">.spec.external_services.prometheus.cache_enabled</h3>
 </div>
 <div class="property-body">
@@ -3554,6 +3727,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.cache_expiration">.spec.external_services.prometheus.cache_expiration</h3>
 </div>
 <div class="property-body">
@@ -3572,6 +3746,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.custom_headers">.spec.external_services.prometheus.custom_headers</h3>
 </div>
 <div class="property-body">
@@ -3590,6 +3765,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.health_check_url">.spec.external_services.prometheus.health_check_url</h3>
 </div>
 <div class="property-body">
@@ -3608,6 +3784,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.is_core">.spec.external_services.prometheus.is_core</h3>
 </div>
 <div class="property-body">
@@ -3626,6 +3803,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.thanos_proxy">.spec.external_services.prometheus.thanos_proxy</h3>
 </div>
 <div class="property-body">
@@ -3644,6 +3822,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.thanos_proxy.enabled">.spec.external_services.prometheus.thanos_proxy.enabled</h3>
 </div>
 <div class="property-body">
@@ -3662,6 +3841,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.thanos_proxy.retention_period">.spec.external_services.prometheus.thanos_proxy.retention_period</h3>
 </div>
 <div class="property-body">
@@ -3680,6 +3860,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.thanos_proxy.scrape_interval">.spec.external_services.prometheus.thanos_proxy.scrape_interval</h3>
 </div>
 <div class="property-body">
@@ -3698,6 +3879,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.url">.spec.external_services.prometheus.url</h3>
 </div>
 <div class="property-body">
@@ -3716,6 +3898,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing">.spec.external_services.tracing</h3>
 </div>
 <div class="property-body">
@@ -3734,6 +3917,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth">.spec.external_services.tracing.auth</h3>
 </div>
 <div class="property-body">
@@ -3752,6 +3936,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.ca_file">.spec.external_services.tracing.auth.ca_file</h3>
 </div>
 <div class="property-body">
@@ -3770,6 +3955,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.insecure_skip_verify">.spec.external_services.tracing.auth.insecure_skip_verify</h3>
 </div>
 <div class="property-body">
@@ -3788,6 +3974,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.password">.spec.external_services.tracing.auth.password</h3>
 </div>
 <div class="property-body">
@@ -3806,6 +3993,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.token">.spec.external_services.tracing.auth.token</h3>
 </div>
 <div class="property-body">
@@ -3824,6 +4012,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.type">.spec.external_services.tracing.auth.type</h3>
 </div>
 <div class="property-body">
@@ -3842,6 +4031,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.use_kiali_token">.spec.external_services.tracing.auth.use_kiali_token</h3>
 </div>
 <div class="property-body">
@@ -3860,6 +4050,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.username">.spec.external_services.tracing.auth.username</h3>
 </div>
 <div class="property-body">
@@ -3878,6 +4069,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.enabled">.spec.external_services.tracing.enabled</h3>
 </div>
 <div class="property-body">
@@ -3896,6 +4088,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.in_cluster_url">.spec.external_services.tracing.in_cluster_url</h3>
 </div>
 <div class="property-body">
@@ -3914,6 +4107,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.is_core">.spec.external_services.tracing.is_core</h3>
 </div>
 <div class="property-body">
@@ -3932,6 +4126,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.namespace_selector">.spec.external_services.tracing.namespace_selector</h3>
 </div>
 <div class="property-body">
@@ -3950,6 +4145,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.url">.spec.external_services.tracing.url</h3>
 </div>
 <div class="property-body">
@@ -3968,6 +4164,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.use_grpc">.spec.external_services.tracing.use_grpc</h3>
 </div>
 <div class="property-body">
@@ -3986,6 +4183,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.whitelist_istio_system">.spec.external_services.tracing.whitelist_istio_system</h3>
 </div>
 <div class="property-body">
@@ -4004,6 +4202,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.whitelist_istio_system[*]">.spec.external_services.tracing.whitelist_istio_system[*]</h3>
 </div>
 <div class="property-body">
@@ -4022,6 +4221,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-1">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.health_config">.spec.health_config</h3>
 </div>
 <div class="property-body">
@@ -4040,6 +4240,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.health_config.rate">.spec.health_config.rate</h3>
 </div>
 <div class="property-body">
@@ -4053,6 +4254,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*]">.spec.health_config.rate[*]</h3>
 </div>
 <div class="property-body">
@@ -4066,6 +4268,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].kind">.spec.health_config.rate[*].kind</h3>
 </div>
 <div class="property-body">
@@ -4084,6 +4287,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].name">.spec.health_config.rate[*].name</h3>
 </div>
 <div class="property-body">
@@ -4102,6 +4306,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].namespace">.spec.health_config.rate[*].namespace</h3>
 </div>
 <div class="property-body">
@@ -4120,6 +4325,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance">.spec.health_config.rate[*].tolerance</h3>
 </div>
 <div class="property-body">
@@ -4138,6 +4344,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*]">.spec.health_config.rate[*].tolerance[*]</h3>
 </div>
 <div class="property-body">
@@ -4151,6 +4358,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*].code">.spec.health_config.rate[*].tolerance[*].code</h3>
 </div>
 <div class="property-body">
@@ -4169,6 +4377,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*].degraded">.spec.health_config.rate[*].tolerance[*].degraded</h3>
 </div>
 <div class="property-body">
@@ -4187,6 +4396,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*].direction">.spec.health_config.rate[*].tolerance[*].direction</h3>
 </div>
 <div class="property-body">
@@ -4205,6 +4415,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*].failure">.spec.health_config.rate[*].tolerance[*].failure</h3>
 </div>
 <div class="property-body">
@@ -4223,6 +4434,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*].protocol">.spec.health_config.rate[*].tolerance[*].protocol</h3>
 </div>
 <div class="property-body">
@@ -4241,6 +4453,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-1">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.identity">.spec.identity</h3>
 </div>
 <div class="property-body">
@@ -4259,6 +4472,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.identity.cert_file">.spec.identity.cert_file</h3>
 </div>
 <div class="property-body">
@@ -4277,6 +4491,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.identity.private_key_file">.spec.identity.private_key_file</h3>
 </div>
 <div class="property-body">
@@ -4295,6 +4510,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-1">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.installation_tag">.spec.installation_tag</h3>
 </div>
 <div class="property-body">
@@ -4313,6 +4529,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-1">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.istio_labels">.spec.istio_labels</h3>
 </div>
 <div class="property-body">
@@ -4331,6 +4548,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.istio_labels.app_label_name">.spec.istio_labels.app_label_name</h3>
 </div>
 <div class="property-body">
@@ -4349,6 +4567,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.istio_labels.injection_label_name">.spec.istio_labels.injection_label_name</h3>
 </div>
 <div class="property-body">
@@ -4367,6 +4586,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.istio_labels.injection_label_rev">.spec.istio_labels.injection_label_rev</h3>
 </div>
 <div class="property-body">
@@ -4385,6 +4605,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.istio_labels.version_label_name">.spec.istio_labels.version_label_name</h3>
 </div>
 <div class="property-body">
@@ -4403,6 +4624,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-1">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.istio_namespace">.spec.istio_namespace</h3>
 </div>
 <div class="property-body">
@@ -4421,6 +4643,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-1">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags">.spec.kiali_feature_flags</h3>
 </div>
 <div class="property-body">
@@ -4439,6 +4662,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.certificates_information_indicators">.spec.kiali_feature_flags.certificates_information_indicators</h3>
 </div>
 <div class="property-body">
@@ -4457,6 +4681,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.certificates_information_indicators.enabled">.spec.kiali_feature_flags.certificates_information_indicators.enabled</h3>
 </div>
 <div class="property-body">
@@ -4470,6 +4695,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.certificates_information_indicators.secrets">.spec.kiali_feature_flags.certificates_information_indicators.secrets</h3>
 </div>
 <div class="property-body">
@@ -4483,6 +4709,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.certificates_information_indicators.secrets[*]">.spec.kiali_feature_flags.certificates_information_indicators.secrets[*]</h3>
 </div>
 <div class="property-body">
@@ -4496,6 +4723,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.clustering">.spec.kiali_feature_flags.clustering</h3>
 </div>
 <div class="property-body">
@@ -4514,6 +4742,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.clustering.enabled">.spec.kiali_feature_flags.clustering.enabled</h3>
 </div>
 <div class="property-body">
@@ -4532,6 +4761,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.istio_injection_action">.spec.kiali_feature_flags.istio_injection_action</h3>
 </div>
 <div class="property-body">
@@ -4550,6 +4780,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.istio_upgrade_action">.spec.kiali_feature_flags.istio_upgrade_action</h3>
 </div>
 <div class="property-body">
@@ -4568,6 +4799,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults">.spec.kiali_feature_flags.ui_defaults</h3>
 </div>
 <div class="property-body">
@@ -4586,6 +4818,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph">.spec.kiali_feature_flags.ui_defaults.graph</h3>
 </div>
 <div class="property-body">
@@ -4604,6 +4837,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.find_options">.spec.kiali_feature_flags.ui_defaults.graph.find_options</h3>
 </div>
 <div class="property-body">
@@ -4622,6 +4856,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.find_options[*]">.spec.kiali_feature_flags.ui_defaults.graph.find_options[*]</h3>
 </div>
 <div class="property-body">
@@ -4635,6 +4870,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.find_options[*].description">.spec.kiali_feature_flags.ui_defaults.graph.find_options[*].description</h3>
 </div>
 <div class="property-body">
@@ -4653,6 +4889,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.find_options[*].expression">.spec.kiali_feature_flags.ui_defaults.graph.find_options[*].expression</h3>
 </div>
 <div class="property-body">
@@ -4671,6 +4908,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.hide_options">.spec.kiali_feature_flags.ui_defaults.graph.hide_options</h3>
 </div>
 <div class="property-body">
@@ -4689,6 +4927,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*]">.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*]</h3>
 </div>
 <div class="property-body">
@@ -4702,6 +4941,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*].description">.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*].description</h3>
 </div>
 <div class="property-body">
@@ -4720,6 +4960,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*].expression">.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*].expression</h3>
 </div>
 <div class="property-body">
@@ -4738,6 +4979,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.traffic">.spec.kiali_feature_flags.ui_defaults.graph.traffic</h3>
 </div>
 <div class="property-body">
@@ -4756,6 +4998,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.traffic.grpc">.spec.kiali_feature_flags.ui_defaults.graph.traffic.grpc</h3>
 </div>
 <div class="property-body">
@@ -4774,6 +5017,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.traffic.http">.spec.kiali_feature_flags.ui_defaults.graph.traffic.http</h3>
 </div>
 <div class="property-body">
@@ -4792,6 +5036,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.traffic.tcp">.spec.kiali_feature_flags.ui_defaults.graph.traffic.tcp</h3>
 </div>
 <div class="property-body">
@@ -4810,6 +5055,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_inbound">.spec.kiali_feature_flags.ui_defaults.metrics_inbound</h3>
 </div>
 <div class="property-body">
@@ -4838,6 +5084,7 @@ An example,</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations">.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations</h3>
 </div>
 <div class="property-body">
@@ -4851,6 +5098,7 @@ An example,</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*]">.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*]</h3>
 </div>
 <div class="property-body">
@@ -4864,6 +5112,7 @@ An example,</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*].display_name">.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*].display_name</h3>
 </div>
 <div class="property-body">
@@ -4877,6 +5126,7 @@ An example,</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*].label">.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*].label</h3>
 </div>
 <div class="property-body">
@@ -4890,6 +5140,7 @@ An example,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_outbound">.spec.kiali_feature_flags.ui_defaults.metrics_outbound</h3>
 </div>
 <div class="property-body">
@@ -4918,6 +5169,7 @@ An example,</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations">.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations</h3>
 </div>
 <div class="property-body">
@@ -4931,6 +5183,7 @@ An example,</p>
 
 <div class="property depth-5">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*]">.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*]</h3>
 </div>
 <div class="property-body">
@@ -4944,6 +5197,7 @@ An example,</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*].display_name">.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*].display_name</h3>
 </div>
 <div class="property-body">
@@ -4957,6 +5211,7 @@ An example,</p>
 
 <div class="property depth-6">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*].label">.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*].label</h3>
 </div>
 <div class="property-body">
@@ -4970,6 +5225,7 @@ An example,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_per_refresh">.spec.kiali_feature_flags.ui_defaults.metrics_per_refresh</h3>
 </div>
 <div class="property-body">
@@ -4988,6 +5244,7 @@ An example,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.namespaces">.spec.kiali_feature_flags.ui_defaults.namespaces</h3>
 </div>
 <div class="property-body">
@@ -5006,6 +5263,7 @@ An example,</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.namespaces[*]">.spec.kiali_feature_flags.ui_defaults.namespaces[*]</h3>
 </div>
 <div class="property-body">
@@ -5019,6 +5277,7 @@ An example,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.refresh_interval">.spec.kiali_feature_flags.ui_defaults.refresh_interval</h3>
 </div>
 <div class="property-body">
@@ -5037,6 +5296,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.validations">.spec.kiali_feature_flags.validations</h3>
 </div>
 <div class="property-body">
@@ -5055,6 +5315,7 @@ An example,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.validations.ignore">.spec.kiali_feature_flags.validations.ignore</h3>
 </div>
 <div class="property-body">
@@ -5073,6 +5334,7 @@ An example,</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.validations.ignore[*]">.spec.kiali_feature_flags.validations.ignore[*]</h3>
 </div>
 <div class="property-body">
@@ -5091,6 +5353,7 @@ An example,</p>
 
 <div class="property depth-1">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kubernetes_config">.spec.kubernetes_config</h3>
 </div>
 <div class="property-body">
@@ -5109,6 +5372,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.burst">.spec.kubernetes_config.burst</h3>
 </div>
 <div class="property-body">
@@ -5127,6 +5391,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_duration">.spec.kubernetes_config.cache_duration</h3>
 </div>
 <div class="property-body">
@@ -5145,6 +5410,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_enabled">.spec.kubernetes_config.cache_enabled</h3>
 </div>
 <div class="property-body">
@@ -5163,6 +5429,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_istio_types">.spec.kubernetes_config.cache_istio_types</h3>
 </div>
 <div class="property-body">
@@ -5181,6 +5448,7 @@ An example,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_istio_types[*]">.spec.kubernetes_config.cache_istio_types[*]</h3>
 </div>
 <div class="property-body">
@@ -5194,6 +5462,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_namespaces">.spec.kubernetes_config.cache_namespaces</h3>
 </div>
 <div class="property-body">
@@ -5212,6 +5481,7 @@ An example,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_namespaces[*]">.spec.kubernetes_config.cache_namespaces[*]</h3>
 </div>
 <div class="property-body">
@@ -5225,6 +5495,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_token_namespace_duration">.spec.kubernetes_config.cache_token_namespace_duration</h3>
 </div>
 <div class="property-body">
@@ -5243,6 +5514,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.excluded_workloads">.spec.kubernetes_config.excluded_workloads</h3>
 </div>
 <div class="property-body">
@@ -5261,6 +5533,7 @@ An example,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.excluded_workloads[*]">.spec.kubernetes_config.excluded_workloads[*]</h3>
 </div>
 <div class="property-body">
@@ -5274,6 +5547,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.qps">.spec.kubernetes_config.qps</h3>
 </div>
 <div class="property-body">
@@ -5292,6 +5566,7 @@ An example,</p>
 
 <div class="property depth-1">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.login_token">.spec.login_token</h3>
 </div>
 <div class="property-body">
@@ -5305,6 +5580,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.login_token.expiration_seconds">.spec.login_token.expiration_seconds</h3>
 </div>
 <div class="property-body">
@@ -5323,6 +5599,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.login_token.signing_key">.spec.login_token.signing_key</h3>
 </div>
 <div class="property-body">
@@ -5341,6 +5618,7 @@ An example,</p>
 
 <div class="property depth-1">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server">.spec.server</h3>
 </div>
 <div class="property-body">
@@ -5359,6 +5637,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.address">.spec.server.address</h3>
 </div>
 <div class="property-body">
@@ -5377,6 +5656,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.audit_log">.spec.server.audit_log</h3>
 </div>
 <div class="property-body">
@@ -5395,6 +5675,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.cors_allow_all">.spec.server.cors_allow_all</h3>
 </div>
 <div class="property-body">
@@ -5413,6 +5694,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.gzip_enabled">.spec.server.gzip_enabled</h3>
 </div>
 <div class="property-body">
@@ -5431,6 +5713,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.observability">.spec.server.observability</h3>
 </div>
 <div class="property-body">
@@ -5449,6 +5732,7 @@ An example,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.observability.metrics">.spec.server.observability.metrics</h3>
 </div>
 <div class="property-body">
@@ -5467,6 +5751,7 @@ An example,</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.observability.metrics.enabled">.spec.server.observability.metrics.enabled</h3>
 </div>
 <div class="property-body">
@@ -5485,6 +5770,7 @@ An example,</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.observability.metrics.port">.spec.server.observability.metrics.port</h3>
 </div>
 <div class="property-body">
@@ -5503,6 +5789,7 @@ An example,</p>
 
 <div class="property depth-3">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.observability.tracing">.spec.server.observability.tracing</h3>
 </div>
 <div class="property-body">
@@ -5521,6 +5808,7 @@ An example,</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.observability.tracing.collector_url">.spec.server.observability.tracing.collector_url</h3>
 </div>
 <div class="property-body">
@@ -5539,6 +5827,7 @@ An example,</p>
 
 <div class="property depth-4">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.observability.tracing.enabled">.spec.server.observability.tracing.enabled</h3>
 </div>
 <div class="property-body">
@@ -5557,6 +5846,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.port">.spec.server.port</h3>
 </div>
 <div class="property-body">
@@ -5575,6 +5865,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.web_fqdn">.spec.server.web_fqdn</h3>
 </div>
 <div class="property-body">
@@ -5593,6 +5884,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.web_history_mode">.spec.server.web_history_mode</h3>
 </div>
 <div class="property-body">
@@ -5611,6 +5903,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.web_port">.spec.server.web_port</h3>
 </div>
 <div class="property-body">
@@ -5629,6 +5922,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.web_root">.spec.server.web_root</h3>
 </div>
 <div class="property-body">
@@ -5647,6 +5941,7 @@ An example,</p>
 
 <div class="property depth-2">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.server.web_schema">.spec.server.web_schema</h3>
 </div>
 <div class="property-body">
@@ -5665,6 +5960,7 @@ An example,</p>
 
 <div class="property depth-1">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.spec.version">.spec.version</h3>
 </div>
 <div class="property-body">
@@ -5698,6 +5994,7 @@ with the rest of the configuration and resources the operator will install).</p>
 
 <div class="property depth-0">
 <div class="property-header">
+<hr/>
 <h3 class="property-path" id="v1alpha1-.status">.status</h3>
 </div>
 <div class="property-body">

--- a/content/en/docs/Configuration/kialis.kiali.io.md
+++ b/content/en/docs/Configuration/kialis.kiali.io.md
@@ -1,0 +1,5727 @@
+---
+title: Kiali CRD Schema Reference
+linkTitle: Kiali CRD Schema Reference
+description: |
+  Custom resource definition (CRD) schema reference page for the Kiali CR (kind: kialis.kiali.io).
+  The Kiali Operator will watch for resources of this type and install Kiali according to those resources' configurations.
+weight: 100
+crd:
+  name_camelcase: Kiali
+  name_plural: kialis
+  name_singular: kiali
+  group: kiali.io
+  technical_name: kialis.kiali.io
+  scope: Namespaced
+  source_repository: https://github.com/kiali/kiali-operator
+  source_repository_ref: master
+  versions:
+    - v1alpha1
+  topics:
+layout: crd
+owner:
+  - https://github.com/orgs/kiali/teams/maintainers
+aliases:
+  - /reference/cp-k8s-api/kialis.kiali.io/
+technical_name: kialis.kiali.io
+source_repository: https://github.com/kiali/kiali-operator
+source_repository_ref: master
+---
+
+# Kiali
+
+<dl class="crd-meta">
+<dt class="fullname">Full name:</dt>
+<dd class="fullname">kialis.kiali.io</dd>
+<dt class="groupname">Group:</dt>
+<dd class="groupname">kiali.io</dd>
+<dt class="singularname">Singular name:</dt>
+<dd class="singularname">kiali</dd>
+<dt class="pluralname">Plural name:</dt>
+<dd class="pluralname">kialis</dd>
+<dt class="scope">Scope:</dt>
+<dd class="scope">Namespaced</dd>
+<dt class="versions">Versions:</dt>
+<dd class="versions"><a class="version" href="#v1alpha1" title="Show schema for version v1alpha1">v1alpha1</a></dd>
+</dl>
+
+
+
+<div class="crd-schema-version">
+<h2 id="v1alpha1">Version v1alpha1</h2>
+
+
+<h3 id="crd-example-v1alpha1">Example CR (all values shown here are the defaults unless otherwise noted)</h3>
+
+```yaml
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+  annotations:
+    ansible.sdk.operatorframework.io/verbosity: "1"
+spec:
+  additional_display_details:
+  - title: "API Documentation"
+    annotation: "kiali.io/api-spec"
+    icon_annotation: "kiali.io/api-type"
+
+  installation_tag: ""
+
+  istio_namespace: ""
+
+  version: "default"
+
+  api:
+    namespaces:
+      exclude:
+      - "istio-operator"
+      - "kube-.*"
+      - "openshift.*"
+      - "ibm.*"
+      - "kiali-operator"
+      # default: label_selector is undefined
+      label_selector: "kiali.io/member-of=istio-system"
+
+  auth:
+    strategy: ""
+    openid:
+      # default: additional_request_params is empty
+      additional_request_params:
+        openIdReqParam: "openIdReqParamValue"
+      # default: allowed_domains is an empty list
+      allowed_domains: ["allowed.domain"]
+      api_proxy: ""
+      api_proxy_ca_data: ""
+      api_token: "id_token"
+      authentication_timeout: 300
+      authorization_endpoint: ""
+      client_id: ""
+      disable_rbac: false
+      http_proxy: ""
+      https_proxy: ""
+      insecure_skip_verify_tls: false
+      issuer_uri: ""
+      scopes: ["openid", "profile", "email"]
+      username_claim: "sub"
+    openshift:
+      client_id_prefix: "kiali"
+
+  # default: custom_dashboards is an empty list
+  custom_dashboards:
+  - name: "envoy"
+
+  deployment:
+    accessible_namespaces: ["^((?!(istio-operator|kube-.*|openshift.*|ibm.*|kiali-operator)).)*$"]
+    # default: additional_service_yaml is empty
+    additional_service_yaml:
+      externalName: "kiali.example.com"
+    affinity:
+      # default: node is empty
+      node:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: kubernetes.io/e2e-az-name
+              operator: In
+              values:
+              - e2e-az1
+              - e2e-az2
+      # default: pod is empty
+      pod:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: security
+              operator: In
+              values:
+              - S1
+          topologyKey: topology.kubernetes.io/zone
+      # default: pod_anti is empty
+      pod_anti:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: security
+                operator: In
+                values:
+                - S2
+            topologyKey: topology.kubernetes.io/zone
+    # default: custom_secrets is an empty list
+    custom_secrets:
+    - name: "a-custom-secret"
+      mount: "/a-custom-secret-path"
+      optional: true
+    hpa:
+      api_version: "autoscaling/v2beta2"
+      # default: spec is empty
+      spec:
+        maxReplicas: 2
+        minReplicas: 1
+        targetCPUUtilizationPercentage: 80
+    # default: host_aliases is an empty list
+    host_aliases:
+    - ip: "192.168.1.100"
+      hostnames:
+      - "foo.local"
+      - "bar.local"
+    image_digest: ""
+    image_name: ""
+    image_pull_policy: "IfNotPresent"
+    # default: image_pull_secrets is an empty list
+    image_pull_secrets: ["image.pull.secret"]
+    image_version: ""
+    ingress:
+      # default: additional_labels is empty
+      additional_labels:
+        ingressAdditionalLabel: "ingressAdditionalLabelValue"
+      class_name: "nginx"
+      # default: enabled is undefined
+      enabled: false
+      # default: override_yaml is undefined
+      override_yaml:
+        metadata:
+          annotations:
+            nginx.ingress.kubernetes.io/secure-backends: "true"
+            nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+        spec:
+          rules:
+          - http:
+              paths:
+              - path: "/kiali"
+                backend:
+                  serviceName: "kiali"
+                  servicePort: 20001
+    instance_name: "kiali"
+    logger:
+      log_level: "info"
+      log_format: "text"
+      sampler_rate: "1"
+      time_field_format: "2006-01-02T15:04:05Z07:00"
+    namespace: "istio-system"
+    # default: node_selector is empty
+    node_selector:
+      nodeSelector: "nodeSelectorValue"
+    # default: pod_annotations is empty
+    pod_annotations:
+      podAnnotation: "podAnnotationValue"
+    # default: pod_labels is empty
+    pod_labels:
+      sidecar.istio.io/inject: "true"
+    priority_class_name: ""
+    replicas: 1
+    # default: resources is undefined
+    resources:
+      requests:
+        cpu: "10m"
+        memory: "64Mi"
+      limits:
+        memory: "1Gi"
+    secret_name: "kiali"
+    # default: service_annotations is empty
+    service_annotations:
+      svcAnnotation: "svcAnnotationValue"
+    # default: service_type is undefined
+    service_type: "NodePort"
+    # default: tolerations is an empty list
+    tolerations:
+    - key: "example-key"
+      operator: "Exists"
+      effect: "NoSchedule"
+    verbose_mode: "3"
+    version_label: ""
+    view_only_mode: false
+
+  external_services:
+    custom_dashboards:
+      discovery_auto_threshold: 10
+      discovery_enabled: "auto"
+      enabled: true
+      is_core: false
+      namespace_label: "kubernetes_namespace"
+      prometheus:
+        auth:
+          ca_file: ""
+          insecure_skip_verify: false
+          password: ""
+          token: ""
+          type: "none"
+          use_kiali_token: false
+          username: ""
+        cache_duration: 10
+        cache_enabled: true
+        cache_expiration: 300
+        # default: custom_headers is empty
+        custom_headers:
+          customHeader1: "customHeader1Value"
+        health_check_url: ""
+        is_core: true
+        thanos_proxy:
+          enabled: false
+          retention_period: "7d"
+          scrape_interval: "30s"
+        url: ""
+    grafana:
+      auth:
+        ca_file: ""
+        insecure_skip_verify: false
+        password: ""
+        token: ""
+        type: "none"
+        use_kiali_token: false
+        username: ""
+      dashboards:
+      - name: "Istio Service Dashboard"
+        variables:
+          namespace: "var-namespace"
+          service: "var-service"
+      - name: "Istio Workload Dashboard"
+        variables:
+          namespace: "var-namespace"
+          workload: "var-workload"
+      - name: "Istio Mesh Dashboard"
+      - name: "Istio Control Plane Dashboard"
+      - name: "Istio Performance Dashboard"
+      - name: "Istio Wasm Extension Dashboard"
+      enabled: true
+      health_check_url: ""
+      # default: in_cluster_url is undefined
+      in_cluster_url: ""
+      is_core: false
+      url: ""
+    istio:
+      component_status:
+        components:
+        - app_label: "istiod"
+          is_core: true
+          is_proxy: false
+        - app_label: "istio-ingressgateway"
+          is_core: true
+          is_proxy: true
+        - app_label: "istio-egressgateway"
+          is_core: false
+          is_proxy: true
+        enabled: true
+      config_map_name: "istio"
+      envoy_admin_local_port: 15000
+      # default: istio_canary_revision is undefined
+      istio_canary_revision:
+        current: "1-9-9"
+        upgrade: "1-10-2"
+      istio_identity_domain: "svc.cluster.local"
+      istio_injection_annotation: "sidecar.istio.io/inject"
+      istio_sidecar_annotation: "sidecar.istio.io/status"
+      istio_sidecar_injector_config_map_name: "istio-sidecar-injector"
+      istiod_deployment_name: "istiod"
+      istiod_pod_monitoring_port: 15014
+      root_namespace: ""
+      url_service_version: ""
+    prometheus:
+      auth:
+        ca_file: ""
+        insecure_skip_verify: false
+        password: ""
+        token: ""
+        type: "none"
+        use_kiali_token: false
+        username: ""
+      cache_duration: 10
+      cache_enabled: true
+      cache_expiration: 300
+      # default: custom_headers is empty
+      custom_headers:
+        customHeader1: "customHeader1Value"
+      health_check_url: ""
+      is_core: true
+      thanos_proxy:
+        enabled: false
+        retention_period: "7d"
+        scrape_interval: "30s"
+      url: ""
+    tracing:
+      auth:
+        ca_file: ""
+        insecure_skip_verify: false
+        password: ""
+        token: ""
+        type: "none"
+        use_kiali_token: false
+        username: ""
+      enabled: true
+      in_cluster_url: ""
+      is_core: false
+      namespace_selector: true
+      url: ""
+      use_grpc: true
+      whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]
+
+  health_config:
+    # default: rate is an empty list
+    rate:
+    - namespace: ".*"
+      kind: ".*"
+      name: ".*"
+      tolerance:
+      - protocol: "http"
+        direction: ".*"
+        code: "[1234]00"
+        degraded: 5
+        failure: 10
+
+  identity:
+    # default: cert_file is undefined
+    cert_file: ""
+    # default: private_key_file is undefined
+    private_key_file: ""
+
+  istio_labels:
+    app_label_name: "app"
+    injection_label_name: "istio-injection"
+    injection_label_rev:  "istio.io/rev"
+    version_label_name: "version"
+
+  kiali_feature_flags:
+    certificates_information_indicators:
+      enabled: true
+      secrets:
+      - "cacerts"
+      - "istio-ca-secret"
+    clustering:
+      enabled: true
+    istio_injection_action: true
+    istio_upgrade_action: false
+    ui_defaults:
+      graph:
+        find_options:
+        - description: "Find: slow edges (> 1s)"
+          expression: "rt > 1000"
+        - description: "Find: unhealthy nodes"
+          expression:  "! healthy"
+        - description: "Find: unknown nodes"
+          expression:  "name = unknown"
+        hide_options:
+        - description: "Hide: healthy nodes"
+          expression: "healthy"
+        - description: "Hide: unknown nodes"
+          expression:  "name = unknown"
+        traffic:
+          grpc: "requests"
+          http: "requests"
+          tcp:  "sent"
+      metrics_per_refresh: "1m"
+      # default: metrics_inbound is undefined
+      metrics_inbound:
+        aggregations:
+        - display_name: "Istio Network"
+          label: "topology_istio_io_network"
+        - display_name: "Istio Revision"
+          label: "istio_io_rev"
+      # default: metrics_outbound is undefined
+      metrics_outbound:
+        aggregations:
+        - display_name: "Istio Network"
+          label: "topology_istio_io_network"
+        - display_name: "Istio Revision"
+          label: "istio_io_rev"
+      # default: namespaces is an empty list
+      namespaces: ["istio-system"]
+      refresh_interval: "15s"
+    validations:
+      # default: ignore is an empty list
+      ignore: ["KIA0101"]
+
+  kubernetes_config:
+    burst: 200
+    cache_duration: 300
+    cache_enabled: true
+    cache_istio_types:
+    - "AuthorizationPolicy"
+    - "DestinationRule"
+    - "EnvoyFilter"
+    - "Gateway"
+    - "PeerAuthentication"
+    - "RequestAuthentication"
+    - "ServiceEntry"
+    - "Sidecar"
+    - "VirtualService"
+    - "WorkloadEntry"
+    - "WorkloadGroup"
+    cache_namespaces:
+    - ".*"
+    cache_token_namespace_duration: 10
+    excluded_workloads:
+    - "CronJob"
+    - "DeploymentConfig"
+    - "Job"
+    - "ReplicationController"
+    qps: 175
+
+  login_token:
+    expiration_seconds: 86400
+    signing_key: ""
+
+  server:
+    address: ""
+    audit_log: true
+    cors_allow_all: false
+    gzip_enabled: true
+    observability:
+      metrics:
+        enabled: true
+        port: 9090
+      tracing:
+        collector_url: "http://jaeger-collector.istio-system:14268/api/traces"
+        enabled: false
+    port: 20001
+    web_fqdn: ""
+    web_history_mode: ""
+    web_port: ""
+    web_root: ""
+    web_schema: ""
+```
+
+
+<h3 id="property-details-v1alpha1">Properties</h3>
+
+
+<div class="property depth-0">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec">.spec</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>This is the CRD for the resources called Kiali CRs. The Kiali Operator will watch for resources of this type and when it detects a Kiali CR has been added, deleted, or modified, it will install, uninstall, and update the associated Kiali Server installation. The settings here will configure the Kiali Server as well as the Kiali Operator. All of these settings will be stored in the Kiali ConfigMap. Do not modify the ConfigMap; it will be managed by the Kiali Operator. Only modify the Kiali CR when you want to change a configuration setting.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.additional_display_details">.spec.additional_display_details</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>A list of additional details that Kiali will look for in annotations. When found on any workload or service, Kiali will display the additional details in the respective workload or service details page. This is typically used to inject some CI metadata or documentation links into Kiali views. For example, by default, Kiali will recognize these annotations on a service or workload (e.g. a Deployment, StatefulSet, etc.):</p>
+
+<pre><code>annotations:
+  kiali.io/api-spec: http://list/to/my/api/doc
+  kiali.io/api-type: rest
+</code></pre>
+
+<p>Note that if you change this setting for your own custom annotations, keep in mind that it would override the current default. So you would have to add the default setting as shown in the example CR if you want to preserve the default links.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.additional_display_details[*]">.spec.additional_display_details[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.additional_display_details[*].annotation">.spec.additional_display_details[*].annotation</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+<span class="property-required">*Required*</span>
+</div>
+
+<div class="property-description">
+<p>The name of the annotation whose value is a URL to additional documentation useful to the user.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.additional_display_details[*].icon_annotation">.spec.additional_display_details[*].icon_annotation</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The name of the annotation whose value is used to determine what icon to display. The annotation name itself can be anything, but note that the value of that annotation must be one of: <code>rest</code>, <code>grpc</code>, and <code>graphql</code> - any other value is ignored.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.additional_display_details[*].title">.spec.additional_display_details[*].title</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+<span class="property-required">*Required*</span>
+</div>
+
+<div class="property-description">
+<p>The title of the link that Kiali will display. The link will go to the URL specified in the value of the configured <code>annotation</code>.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.api">.spec.api</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.api.namespaces">.spec.api.namespaces</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Settings that control what namespaces are returned by Kiali.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.api.namespaces.exclude">.spec.api.namespaces.exclude</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>A list of namespaces to be excluded from the list of namespaces provided by the Kiali API and Kiali UI. Regex is supported. This does not affect explicit namespace access.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.api.namespaces.exclude[*]">.spec.api.namespaces.exclude[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.api.namespaces.label_selector">.spec.api.namespaces.label_selector</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>A Kubernetes label selector (e.g. <code>myLabel=myValue</code>) which is used when fetching the list of
+available namespaces. This does not affect explicit namespace access.</p>
+
+<p>If <code>deployment.accessible_namespaces</code> does not have the special value of <code>'**'</code>
+then the Kiali operator will add a new label to all accessible namespaces - that new
+label will be this <code>label_selector</code>.</p>
+
+<p>Note that if you do not set this <code>label_selector</code> setting but <code>deployment.accessible_namespaces</code>
+does not have the special &ldquo;all namespaces&rdquo; entry of <code>'**'</code> then this <code>label_selector</code> will be set
+to a default value of <code>kiali.io/[&lt;deployment.instance_name&gt;.]member-of=&lt;deployment.namespace&gt;</code>
+where <code>[&lt;deployment.instance_name&gt;.]</code> is the instance name assigned to the Kiali installation
+if it is not the default &lsquo;kiali&rsquo; (otherwise, this is omitted) and <code>&lt;deployment.namespace&gt;</code>
+is the namespace where Kiali is to be installed.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth">.spec.auth</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid">.spec.auth.openid</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>To learn more about these settings and how to configure the OpenId authentication strategy, read the documentation at <a href="https://kiali.io/docs/configuration/authentication/openid/">https://kiali.io/docs/configuration/authentication/openid/</a></p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.additional_request_params">.spec.auth.openid.additional_request_params</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.allowed_domains">.spec.auth.openid.allowed_domains</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.allowed_domains[*]">.spec.auth.openid.allowed_domains[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.api_proxy">.spec.auth.openid.api_proxy</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.api_proxy_ca_data">.spec.auth.openid.api_proxy_ca_data</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.api_token">.spec.auth.openid.api_token</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.authentication_timeout">.spec.auth.openid.authentication_timeout</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.authorization_endpoint">.spec.auth.openid.authorization_endpoint</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.client_id">.spec.auth.openid.client_id</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.disable_rbac">.spec.auth.openid.disable_rbac</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.http_proxy">.spec.auth.openid.http_proxy</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.https_proxy">.spec.auth.openid.https_proxy</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.insecure_skip_verify_tls">.spec.auth.openid.insecure_skip_verify_tls</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.issuer_uri">.spec.auth.openid.issuer_uri</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.scopes">.spec.auth.openid.scopes</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.scopes[*]">.spec.auth.openid.scopes[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openid.username_claim">.spec.auth.openid.username_claim</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openshift">.spec.auth.openshift</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>To learn more about these settings and how to configure the OpenShift authentication strategy, read the documentation at <a href="https://kiali.io/docs/configuration/authentication/openshift/">https://kiali.io/docs/configuration/authentication/openshift/</a></p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.openshift.client_id_prefix">.spec.auth.openshift.client_id_prefix</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The Route resource name and OAuthClient resource name will have this value as its prefix. This value normally should never change. The installer will ensure this value is set correctly.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.auth.strategy">.spec.auth.strategy</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Determines what authentication strategy to use when users log into Kiali.
+Options are <code>anonymous</code>, <code>token</code>, <code>openshift</code>, <code>openid</code>, or <code>header</code>.</p>
+
+<ul>
+<li>Choose <code>anonymous</code> to allow full access to Kiali without requiring any credentials.</li>
+<li>Choose <code>token</code> to allow access to Kiali using service account tokens, which controls
+access based on RBAC roles assigned to the service account.</li>
+<li>Choose <code>openshift</code> to use the OpenShift OAuth login which controls access based on
+the individual&rsquo;s RBAC roles in OpenShift. Not valid for non-OpenShift environments.</li>
+<li>Choose <code>openid</code> to enable OpenID Connect-based authentication. Your cluster is required to
+be configured to accept the tokens issued by your IdP. There are additional required
+configurations for this strategy. See below for the additional OpenID configuration section.</li>
+<li>Choose <code>header</code> when Kiali is running behind a reverse proxy that will inject an
+Authorization header and potentially impersonation headers.</li>
+</ul>
+
+<p>When empty, this value will default to <code>openshift</code> on OpenShift and <code>token</code> on other Kubernetes environments.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.custom_dashboards">.spec.custom_dashboards</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>A list of user-defined custom monitoring dashboards that you can use to generate metrics charts
+for your applications. The server has some built-in dashboards; if you define a custom dashboard here
+with the same name as a built-in dashboard, your custom dashboard takes precedence and will overwrite
+the built-in dashboard. You can disable one or more of the built-in dashboards by simply defining an
+empty dashboard.</p>
+
+<p>An example of an additional user-defined dashboard,</p>
+
+<pre><code>- name: myapp
+  title: My App Metrics
+  items:
+  - chart:
+      name: &quot;Thread Count&quot;
+      spans: 4
+      metricName: &quot;thread-count&quot;
+      dataType: &quot;raw&quot;
+</code></pre>
+
+<p>An example of disabling a built-in dashboard (in this case, disabling the Envoy dashboard),</p>
+
+<pre><code>- name: envoy
+</code></pre>
+
+<p>To learn more about custom monitoring dashboards, see the documentation at <a href="https://kiali.io/docs/configuration/custom-dashboard/">https://kiali.io/docs/configuration/custom-dashboard/</a></p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.custom_dashboards[*]">.spec.custom_dashboards[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment">.spec.deployment</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.accessible_namespaces">.spec.deployment.accessible_namespaces</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>A list of namespaces Kiali is to be given access to. These namespaces have service mesh components that are to be observed by Kiali. You can provide names using regex expressions matched against all namespaces the operator can see. The default makes all namespaces accessible except for some internal namespaces that typically should be ignored. NOTE! If this has an entry with the special value of <code>'**'</code> (two asterisks), that will denote you want Kiali to be given access to all namespaces via a single cluster role (if using this special value of <code>'**'</code>, you are required to have already granted the operator permissions to create cluster roles and cluster role bindings).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.accessible_namespaces[*]">.spec.deployment.accessible_namespaces[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.additional_service_yaml">.spec.deployment.additional_service_yaml</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Additional custom yaml to add to the service definition. This is used mainly to customize the service type. For example, if the <code>deployment.service_type</code> is set to &lsquo;LoadBalancer&rsquo; and you want to set the loadBalancerIP, you can do so here with: <code>additional_service_yaml: { 'loadBalancerIP': '78.11.24.19' }</code>. Another example would be if the <code>deployment.service_type</code> is set to &lsquo;ExternalName&rsquo; you will need to configure the name via: <code>additional_service_yaml: { 'externalName': 'my.kiali.example.com' }</code>. A final example would be if external IPs need to be set: <code>additional_service_yaml: { 'externalIPs': ['80.11.12.10'] }</code></p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.affinity">.spec.deployment.affinity</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Affinity definitions that are to be used to define the nodes where the Kiali pod should be constrained. See the Kubernetes documentation on Assigning Pods to Nodes for the proper syntax for these three different affinity types.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.affinity.node">.spec.deployment.affinity.node</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.affinity.pod">.spec.deployment.affinity.pod</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.affinity.pod_anti">.spec.deployment.affinity.pod_anti</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.custom_secrets">.spec.deployment.custom_secrets</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>Defines additional secrets that are to be mounted in the Kiali pod.</p>
+
+<p>These are useful to contain certs that are used by Kiali to securely connect to third party systems
+(for example, see <code>external_services.tracing.auth.ca_file</code>).</p>
+
+<p>These secrets must be created by an external mechanism. Kiali will not generate these secrets; it
+is assumed these secrets are externally managed. You can define 0, 1, or more secrets.
+An example configuration is,</p>
+
+<pre><code>custom_secrets:
+- name: mysecret
+  mount: /mysecret-path
+- name: my-other-secret
+  mount: /my-other-secret-location
+  optional: true
+</code></pre>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.custom_secrets[*]">.spec.deployment.custom_secrets[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.custom_secrets[*].mount">.spec.deployment.custom_secrets[*].mount</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+<span class="property-required">*Required*</span>
+</div>
+
+<div class="property-description">
+<p>The file path location where the secret content will be mounted.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.custom_secrets[*].name">.spec.deployment.custom_secrets[*].name</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+<span class="property-required">*Required*</span>
+</div>
+
+<div class="property-description">
+<p>The name of the secret that is to be mounted to the Kiali pod&rsquo;s file system.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.custom_secrets[*].optional">.spec.deployment.custom_secrets[*].optional</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Indicates if the secret may or may not exist at the time the Kiali pod starts. This will default to &lsquo;false&rsquo; if not specified.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.host_aliases">.spec.deployment.host_aliases</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>This is content for the Kubernetes &lsquo;hostAliases&rsquo; setting for the Kiali server.
+This allows you to modify the Kiali server pod &lsquo;/etc/hosts&rsquo; file.
+A typical way to configure this setting is,</p>
+
+<pre><code>host_aliases:
+- ip: 192.168.1.100
+  hostnames:
+  - &quot;foo.local&quot;
+  - &quot;bar.local&quot;
+</code></pre>
+
+<p>For details on the content of this setting, see <a href="https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/#adding-additional-entries-with-hostaliases">https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/#adding-additional-entries-with-hostaliases</a></p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.host_aliases[*]">.spec.deployment.host_aliases[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.host_aliases[*].hostnames">.spec.deployment.host_aliases[*].hostnames</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.host_aliases[*].hostnames[*]">.spec.deployment.host_aliases[*].hostnames[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.host_aliases[*].ip">.spec.deployment.host_aliases[*].ip</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.hpa">.spec.deployment.hpa</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Determines what (if any) HorizontalPodAutoscaler should be created to autoscale the Kiali pod.
+A typical way to configure HPA for Kiali is,</p>
+
+<pre><code>hpa:
+  api_version: &quot;autoscaling/v2beta2&quot;
+  spec:
+    maxReplicas: 2
+    minReplicas: 1
+    targetCPUUtilizationPercentage: 80
+</code></pre>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.hpa.api_version">.spec.deployment.hpa.api_version</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>A specific HPA API version that can be specified in case there is some HPA feature you want to use that is only supported in that specific version.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.hpa.spec">.spec.deployment.hpa.spec</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>The <code>spec</code> specified here will be placed in the created HPA resource&rsquo;s &lsquo;spec&rsquo; section. If <code>spec</code> is left empty, no HPA resource will be created. Note that you must not specify the &lsquo;scaleTargetRef&rsquo; section in <code>spec</code>; the Kiali Operator will populate that for you.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.image_digest">.spec.deployment.image_digest</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>If <code>deployment.image_version</code> is a digest hash, this value indicates what type of digest it is. A typical value would be &lsquo;sha256&rsquo;. Note: do NOT prefix this value with a &lsquo;@&rsquo;.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.image_name">.spec.deployment.image_name</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Determines which Kiali image to download and install. If you set this to a specific name (i.e. you do not leave it as the default empty string), you must make sure that image is supported by the operator. If empty, the operator will use a known supported image name based on which <code>version</code> was defined. Note that, as a security measure, a cluster admin may have configured the Kiali operator to ignore this setting. A cluster admin may do this to ensure the Kiali operator only installs a single, specific Kiali version, thus this setting may have no effect depending on how the operator itself was configured.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.image_pull_policy">.spec.deployment.image_pull_policy</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The Kubernetes pull policy for the Kiali deployment. This is overridden to be &lsquo;Always&rsquo; if <code>deployment.image_version</code> is set to &lsquo;latest&rsquo;.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.image_pull_secrets">.spec.deployment.image_pull_secrets</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>The names of the secrets to be used when container images are to be pulled.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.image_pull_secrets[*]">.spec.deployment.image_pull_secrets[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.image_version">.spec.deployment.image_version</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Determines which version of Kiali to install.
+Choose &lsquo;lastrelease&rsquo; to use the last Kiali release.
+Choose &lsquo;latest&rsquo; to use the latest image (which may or may not be a released version of Kiali).
+Choose &lsquo;operator_version&rsquo; to use the image whose version is the same as the operator version.
+Otherwise, you can set this to any valid Kiali version (such as &lsquo;v1.0&rsquo;) or any valid Kiali
+digest hash (if you set this to a digest hash, you must indicate the digest in <code>deployment.image_digest</code>).</p>
+
+<p>Note that if this is set to &lsquo;latest&rsquo; then the <code>deployment.image_pull_policy</code> will be set to &lsquo;Always&rsquo;.</p>
+
+<p>If you set this to a specific version (i.e. you do not leave it as the default empty string),
+you must make sure that image is supported by the operator.</p>
+
+<p>If empty, the operator will use a known supported image version based on which &lsquo;version&rsquo; was defined.
+Note that, as a security measure, a cluster admin may have configured the Kiali operator to
+ignore this setting. A cluster admin may do this to ensure the Kiali operator only installs
+a single, specific Kiali version, thus this setting may have no effect depending on how the
+operator itself was configured.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.ingress">.spec.deployment.ingress</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Configures if/how the Kiali endpoint should be exposed externally.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.additional_labels">.spec.deployment.ingress.additional_labels</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Additional labels to add to the Ingress (or Route if on OpenShift). These are added to the labels that are created by default; these do not override the default labels.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.class_name">.spec.deployment.ingress.class_name</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>If <code>class_name</code> is a non-empty string, it will be used as the &lsquo;spec.ingressClassName&rsquo; in the created Kubernetes Ingress resource. This setting is ignored if on OpenShift. This is also ignored if <code>override_yaml.spec</code> is defined (i.e. you must define the &lsquo;ingressClassName&rsquo; directly in your override yaml).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.enabled">.spec.deployment.ingress.enabled</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Determines if the Kiali endpoint should be exposed externally. If &lsquo;true&rsquo;, an Ingress will be created if on Kubernetes or a Route if on OpenShift. If left undefined, this will be &lsquo;false&rsquo; on Kubernetes and &lsquo;true&rsquo; on OpenShift.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.override_yaml">.spec.deployment.ingress.override_yaml</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Because an Ingress into a cluster can vary wildly in its desired configuration,
+this setting provides a way to override complete portions of the Ingress resource
+configuration (Ingress on Kubernetes and Route on OpenShift). It is up to the user
+to ensure this override YAML configuration is valid and supports the cluster environment
+since the operator will blindly copy this custom configuration into the resource it
+creates.</p>
+
+<p>This setting is not used if <code>deployment.ingress.enabled</code> is set to &lsquo;false&rsquo;.
+Note that only &lsquo;metadata.annotations&rsquo; and &lsquo;spec&rsquo; is valid and only they will
+be used to override those same sections in the created resource. You can define
+either one or both.</p>
+
+<p>Note that <code>override_yaml.metadata.labels</code> is not allowed - you cannot override the labels; to add
+labels to the default set of labels, use the <code>deployment.ingress.additional_labels</code> setting.
+Example,</p>
+
+<pre><code>override_yaml:
+  metadata:
+    annotations:
+      nginx.ingress.kubernetes.io/secure-backends: &quot;true&quot;
+      nginx.ingress.kubernetes.io/backend-protocol: &quot;HTTPS&quot;
+  spec:
+    rules:
+    - http:
+        paths:
+        - path: /kiali
+          backend:
+            serviceName: kiali
+            servicePort: 20001
+</code></pre>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.override_yaml.metadata">.spec.deployment.ingress.override_yaml.metadata</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.override_yaml.metadata.annotations">.spec.deployment.ingress.override_yaml.metadata.annotations</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.override_yaml.spec">.spec.deployment.ingress.override_yaml.spec</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.instance_name">.spec.deployment.instance_name</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The instance name of this Kiali installation. This instance name will be the prefix prepended to the names of all Kiali resources created by the operator and will be used to label those resources as belonging to this Kiali installation instance. You cannot change this instance name after a Kiali CR is created. If you attempt to change it, the operator will abort with an error. If you want to change it, you must first delete the original Kiali CR and create a new one. Note that this does not affect the name of the auto-generated signing key secret. If you do not supply a signing key, the operator will create one for you in a secret, but that secret will always be named &lsquo;kiali-signing-key&rsquo; and shared across all Kiali instances in the same deployment namespace. If you want a different signing key secret, you are free to create your own and tell the operator about it via <code>login_token.signing_key</code>. See the docs on that setting for more details. Note also that if you are setting this value, you may also want to change the <code>installation_tag</code> setting, but this is not required.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.logger">.spec.deployment.logger</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Configures the logger that emits messages to the Kiali server pod logs.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.logger.log_format">.spec.deployment.logger.log_format</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Indicates if the logs should be written with one log message per line or using a JSON format. Must be one of: <code>text</code> or <code>json</code>.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.logger.log_level">.spec.deployment.logger.log_level</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The lowest priority of messages to log. Must be one of: <code>trace</code>, <code>debug</code>, <code>info</code>, <code>warn</code>, <code>error</code>, or <code>fatal</code>.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.logger.sampler_rate">.spec.deployment.logger.sampler_rate</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>With this setting every sampler_rate-th message will be logged. By default, every message is logged. As an example, setting this to <code>'2'</code> means every other message will be logged. The value of this setting is a string but must be parsable as an integer.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.logger.time_field_format">.spec.deployment.logger.time_field_format</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The log message timestamp format. This supports a golang time format (see <a href="https://golang.org/pkg/time/">https://golang.org/pkg/time/</a>)</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.namespace">.spec.deployment.namespace</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The namespace into which Kiali is to be installed. If this is empty or not defined, the default will be the namespace where the Kiali CR is located.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.node_selector">.spec.deployment.node_selector</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>A set of node labels that dictate onto which node the Kiali pod will be deployed.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.pod_annotations">.spec.deployment.pod_annotations</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Custom annotations to be created on the Kiali pod.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.pod_labels">.spec.deployment.pod_labels</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Custom labels to be created on the Kiali pod.
+An example use for this setting is to inject an Istio sidecar such as,</p>
+
+<pre><code>sidecar.istio.io/inject: &quot;true&quot;
+</code></pre>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.priority_class_name">.spec.deployment.priority_class_name</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The priorityClassName used to assign the priority of the Kiali pod.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.replicas">.spec.deployment.replicas</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>The replica count for the Kiail deployment.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.resources">.spec.deployment.resources</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Defines compute resources that are to be given to the Kiali pod&rsquo;s container. The value is a dict as defined by Kubernetes. See the Kubernetes documentation (<a href="https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container">https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container</a>).
+If you set this to an empty dict (<code>{}</code>) then no resources will be defined in the Deployment.
+If you do not set this at all, the default is,</p>
+
+<pre><code>requests:
+  cpu: &quot;10m&quot;
+  memory: &quot;64Mi&quot;
+limits:
+  memory: &quot;1Gi&quot;
+</code></pre>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.secret_name">.spec.deployment.secret_name</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The name of a secret used by the Kiali. This secret is optionally used when configuring the OpenID authentication strategy. Consult the OpenID docs for more information at <a href="https://kiali.io/docs/configuration/authentication/openid/">https://kiali.io/docs/configuration/authentication/openid/</a></p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.service_annotations">.spec.deployment.service_annotations</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Custom annotations to be created on the Kiali Service resource.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.service_type">.spec.deployment.service_type</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The Kiali service type. Kubernetes determines what values are valid. Common values are &lsquo;NodePort&rsquo;, &lsquo;ClusterIP&rsquo;, and &lsquo;LoadBalancer&rsquo;.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.tolerations">.spec.deployment.tolerations</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>A list of tolerations which declare which node taints Kiali can tolerate. See the Kubernetes documentation on Taints and Tolerations for more details.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.tolerations[*]">.spec.deployment.tolerations[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.verbose_mode">.spec.deployment.verbose_mode</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>DEPRECATED! Determines which priority levels of log messages Kiali will output. Use <code>deployment.logger</code> settings instead.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.version_label">.spec.deployment.version_label</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Kiali resources will be assigned a &lsquo;version&rsquo; label when they are deployed.
+This setting determines what value those &lsquo;version&rsquo; labels will have.
+When empty, its default will be determined as follows,</p>
+
+<ul>
+<li>If <code>deployment.image_version</code> is &lsquo;latest&rsquo;, <code>version_label</code> will be fixed to &lsquo;master&rsquo;.</li>
+<li>If <code>deployment.image_version</code> is &lsquo;lastrelease&rsquo;, <code>version_label</code> will be fixed to the last Kiali release version string.</li>
+<li>If <code>deployment.image_version</code> is anything else, <code>version_label</code> will be that value, too.</li>
+</ul>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.deployment.view_only_mode">.spec.deployment.view_only_mode</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>When true, Kiali will be in &lsquo;view only&rsquo; mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services">.spec.external_services</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>These external service configuration settings define how to connect to the external services
+like Prometheus, Grafana, and Jaoeger.</p>
+
+<p>Regarding sensitive values in the external_services &lsquo;auth&rsquo; sections:
+Some external services configured below support an &lsquo;auth&rsquo; sub-section in order to tell Kiali
+how it should authenticate with the external services. Credentials used to authenticate Kiali
+to those external services can be defined in the <code>auth.password</code> and <code>auth.token</code> values
+within the <code>auth</code> sub-section. Because these are sensitive values, you may not want to declare
+the actual credentials here in the Kiali CR. In this case, you may store the actual password
+or token string in a Kubernetes secret. If you do, you need to set the <code>auth.password</code> or
+<code>auth.token</code> to a value in the format <code>secret:&lt;secretName&gt;:&lt;secretKey&gt;</code> where <code>&lt;secretName&gt;</code>
+is the name of the secret object that Kiali can access, and <code>&lt;secretKey&gt;</code> is the name of the
+key within the named secret that contains the actual password or token string. For example,
+if Grafana requires a password, you can store that password in a secret named &lsquo;myGrafanaCredentials&rsquo;
+in a key named &lsquo;myGrafanaPw&rsquo;. In this case, you would set <code>external_services.grafana.auth.password</code>
+to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards">.spec.external_services.custom_dashboards</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Settings for enabling and discovering custom dashboards.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.discovery_auto_threshold">.spec.external_services.custom_dashboards.discovery_auto_threshold</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>Threshold of the number of pods, for a given Application or Workload, above which dashboards discovery will be skipped. This setting only takes effect when <code>discovery_enabled</code> is set to &lsquo;auto&rsquo;.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.discovery_enabled">.spec.external_services.custom_dashboards.discovery_enabled</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Enable, disable or set &lsquo;auto&rsquo; mode to the dashboards discovery process. If set to &lsquo;true&rsquo;, Kiali will always try to discover dashboards based on metrics. Note that this can generate performance penalties while discovering dashboards for workloads having many pods (thus many metrics). When set to &lsquo;auto&rsquo;, Kiali will skip dashboards discovery for workloads with more than a configured threshold of pods (see <code>discovery_auto_threshold</code>). When discovery is disabled or auto/skipped, it is still possible to tie workloads with dashboards through annotations on pods (refer to the doc <a href="https://kiali.io/docs/configuration/custom-dashboard/#pod-annotations">https://kiali.io/docs/configuration/custom-dashboard/#pod-annotations</a>). Value must be one of: <code>true</code>, <code>false</code>, <code>auto</code>.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.enabled">.spec.external_services.custom_dashboards.enabled</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Enable or disable custom dashboards, including the dashboards discovery process.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.is_core">.spec.external_services.custom_dashboards.is_core</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.namespace_label">.spec.external_services.custom_dashboards.namespace_label</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The Prometheus label name used for identifying namespaces in metrics for custom dashboards. The default is <code>kubernetes_namespace</code> but it is quite common to use just <code>namespace</code> depending on your Prometheus configuration.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus">.spec.external_services.custom_dashboards.prometheus</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>The Prometheus configuration defined here refers to the Prometheus instance that is dedicated to fetching metrics for custom dashboards. This means you can obtain these metrics for the custom dashboards from a Prometheus instance that is different from the one that Istio uses. If this section is omitted, the same Prometheus that is used to obtain the Istio metrics will also be used for retrieving custom dashboard metrics.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth">.spec.external_services.custom_dashboards.prometheus.auth</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Settings used to authenticate with the Prometheus instance.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.ca_file">.spec.external_services.custom_dashboards.prometheus.auth.ca_file</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The certificate authority file to use when accessing Prometheus using https. An empty string means no extra certificate authority file is used.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.insecure_skip_verify">.spec.external_services.custom_dashboards.prometheus.auth.insecure_skip_verify</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Set true to skip verifying certificate validity when Kiali contacts Prometheus over https.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.password">.spec.external_services.custom_dashboards.prometheus.auth.password</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Password to be used when making requests to Prometheus, for basic authentication. May refer to a secret.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.token">.spec.external_services.custom_dashboards.prometheus.auth.token</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Token / API key to access Prometheus, for token-based authentication. May refer to a secret.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.type">.spec.external_services.custom_dashboards.prometheus.auth.type</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The type of authentication to use when contacting the server. Use <code>bearer</code> to send the token to the Prometheus server. Use <code>basic</code> to connect with username and password credentials. Use <code>none</code> to not use any authentication (this is the default).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.use_kiali_token">.spec.external_services.custom_dashboards.prometheus.auth.use_kiali_token</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>When true and if <code>auth.type</code> is <code>bearer</code>, Kiali Service Account token will be used for the API calls to Prometheus (in this case, <code>auth.token</code> config is ignored).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.username">.spec.external_services.custom_dashboards.prometheus.auth.username</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Username to be used when making requests to Prometheus with <code>basic</code> authentication.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.cache_duration">.spec.external_services.custom_dashboards.prometheus.cache_duration</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>Prometheus caching duration expressed in seconds.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.cache_enabled">.spec.external_services.custom_dashboards.prometheus.cache_enabled</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Enable/disable Prometheus caching used for Health services.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.cache_expiration">.spec.external_services.custom_dashboards.prometheus.cache_expiration</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>Prometheus caching expiration expressed in seconds.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.custom_headers">.spec.external_services.custom_dashboards.prometheus.custom_headers</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>A set of name/value settings that will be passed as headers when requests are sent to Prometheus.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.health_check_url">.spec.external_services.custom_dashboards.prometheus.health_check_url</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Used in the Components health feature. This is the url which Kiali will ping to determine whether the component is reachable or not. It defaults to <code>url</code> when not provided.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.is_core">.spec.external_services.custom_dashboards.prometheus.is_core</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.thanos_proxy">.spec.external_services.custom_dashboards.prometheus.thanos_proxy</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Define this section if Prometheus is to be queried through a Thanos proxy. Kiali will still use the <code>url</code> setting to query for Prometheus metrics so make sure that is set appropriately.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.thanos_proxy.enabled">.spec.external_services.custom_dashboards.prometheus.thanos_proxy.enabled</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Set to true when a Thanos proxy is in front of Prometheus.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.thanos_proxy.retention_period">.spec.external_services.custom_dashboards.prometheus.thanos_proxy.retention_period</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Thanos Retention period value expresed as a string.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.thanos_proxy.scrape_interval">.spec.external_services.custom_dashboards.prometheus.thanos_proxy.scrape_interval</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Thanos Scrape interval value expresed as a string.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.url">.spec.external_services.custom_dashboards.prometheus.url</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The URL used to query the Prometheus Server. This URL must be accessible from the Kiali pod. If empty, the default will assume Prometheus is in the Istio control plane namespace; e.g. <code>http://prometheus.&lt;istio_namespace&gt;:9090</code>.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana">.spec.external_services.grafana</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Configuration used to access the Grafana dashboards.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth">.spec.external_services.grafana.auth</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Settings used to authenticate with the Grafana instance.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.ca_file">.spec.external_services.grafana.auth.ca_file</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The certificate authority file to use when accessing Grafana using https. An empty string means no extra certificate authority file is used.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.insecure_skip_verify">.spec.external_services.grafana.auth.insecure_skip_verify</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Set true to skip verifying certificate validity when Kiali contacts Grafana over https.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.password">.spec.external_services.grafana.auth.password</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Password to be used when making requests to Grafana, for basic authentication. May refer to a secret.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.token">.spec.external_services.grafana.auth.token</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Token / API key to access Grafana, for token-based authentication. May refer to a secret.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.type">.spec.external_services.grafana.auth.type</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The type of authentication to use when contacting the server. Use <code>bearer</code> to send the token to the Grafana server. Use <code>basic</code> to connect with username and password credentials. Use <code>none</code> to not use any authentication (this is the default).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.use_kiali_token">.spec.external_services.grafana.auth.use_kiali_token</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>When true and if <code>auth.type</code> is <code>bearer</code>, Kiali Service Account token will be used for the API calls to Grafana (in this case, <code>auth.token</code> config is ignored).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.username">.spec.external_services.grafana.auth.username</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Username to be used when making requests to Grafana with <code>basic</code> authentication.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards">.spec.external_services.grafana.dashboards</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>A list of Grafana dashboards that Kiali can link to.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*]">.spec.external_services.grafana.dashboards[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].name">.spec.external_services.grafana.dashboards[*].name</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The name of the Grafana dashboard.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].variables">.spec.external_services.grafana.dashboards[*].variables</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].variables.app">.spec.external_services.grafana.dashboards[*].variables.app</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The name of a variable that holds the app name, if used in that dashboard (else it must be omitted).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].variables.namespace">.spec.external_services.grafana.dashboards[*].variables.namespace</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The name of a variable that holds the namespace, if used in that dashboard (else it must be omitted).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].variables.service">.spec.external_services.grafana.dashboards[*].variables.service</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The name of a variable that holds the service name, if used in that dashboard (else it must be omitted).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].variables.workload">.spec.external_services.grafana.dashboards[*].variables.workload</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The name of a variable that holds the workload name, if used in that dashboard (else it must be omitted).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.enabled">.spec.external_services.grafana.enabled</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>When true, Grafana support will be enabled in Kiali.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.health_check_url">.spec.external_services.grafana.health_check_url</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Used in the Components health feature. This is the URL which Kiali will ping to determine whether the component is reachable or not. It defaults to <code>in_cluster_url</code> when not provided.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.in_cluster_url">.spec.external_services.grafana.in_cluster_url</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The URL used for in-cluster access. An example would be <code>http://grafana.istio-system:3000</code>. This URL can contain query parameters if needed, such as &lsquo;?orgId=1&rsquo;. If not defined, it will default to <code>http://grafana.&lt;istio_namespace&gt;:3000</code>.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.is_core">.spec.external_services.grafana.is_core</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.url">.spec.external_services.grafana.url</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The URL that Kiali uses when integrating with Grafana. This URL must be accessible to clients external to the cluster in order for the integration to work properly. If empty, an attempt to auto-discover it is made. This URL can contain query parameters if needed, such as &lsquo;?orgId=1&rsquo;.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio">.spec.external_services.istio</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Istio configuration that Kiali needs to know about in order to observe the mesh.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status">.spec.external_services.istio.component_status</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Istio components whose status will be monitored by Kiali.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components">.spec.external_services.istio.component_status.components</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>A specific Istio component whose status will be monitored by Kiali.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components[*]">.spec.external_services.istio.component_status.components[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components[*].app_label">.spec.external_services.istio.component_status.components[*].app_label</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Istio component pod app label.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components[*].is_core">.spec.external_services.istio.component_status.components[*].is_core</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Whether the component is to be considered a core component for your deployment.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components[*].is_proxy">.spec.external_services.istio.component_status.components[*].is_proxy</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Whether the component is a native Envoy proxy.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components[*].namespace">.spec.external_services.istio.component_status.components[*].namespace</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The namespace where the component is installed. It defaults to the Istio control plane namespace (e.g. <code>istio_namespace</code> setting. Note that the Istio documentation suggests you install the ingress and egress to different namespaces, so you most likely will want to explicitly set this namespace value for the ingress and egress components.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.enabled">.spec.external_services.istio.component_status.enabled</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Determines if Istio component statuses will be displayed in the Kiali masthead indicator.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.config_map_name">.spec.external_services.istio.config_map_name</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The name of the istio control plane config map.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.envoy_admin_local_port">.spec.external_services.istio.envoy_admin_local_port</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>The port which kiali will open to fetch envoy config data information.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_canary_revision">.spec.external_services.istio.istio_canary_revision</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>These values are used in Canary upgrade/downgrade functionality when <code>istio_upgrade_action</code> is true.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_canary_revision.current">.spec.external_services.istio.istio_canary_revision.current</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The currently installed Istio revision.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_canary_revision.upgrade">.spec.external_services.istio.istio_canary_revision.upgrade</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The installed Istio canary revision to upgrade to.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_identity_domain">.spec.external_services.istio.istio_identity_domain</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The annotation used by Istio to identify domains.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_injection_annotation">.spec.external_services.istio.istio_injection_annotation</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The name of the field that annotates a workload to indicate a sidecar should be automatically injected by Istio. This is the name of a Kubernetes annotation. Note that some Istio implementations also support labels by the same name. In other words, if a workload has a Kubernetes label with this name, that may also trigger automatic sidecar injection.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_sidecar_annotation">.spec.external_services.istio.istio_sidecar_annotation</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The pod annotation used by Istio to identify the sidecar.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_sidecar_injector_config_map_name">.spec.external_services.istio.istio_sidecar_injector_config_map_name</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The name of the istio-sidecar-injector config map.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istiod_deployment_name">.spec.external_services.istio.istiod_deployment_name</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The name of the istiod deployment.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istiod_pod_monitoring_port">.spec.external_services.istio.istiod_pod_monitoring_port</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>The monitoring port of the IstioD pod (not the Service).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.root_namespace">.spec.external_services.istio.root_namespace</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The namespace to treat as the administrative root namespace for Istio configuration.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.url_service_version">.spec.external_services.istio.url_service_version</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The Istio service used to determine the Istio version. If empty, assumes the URL for the well-known Istio version endpoint.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus">.spec.external_services.prometheus</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>The Prometheus configuration defined here refers to the Prometheus instance that is used by Istio to store its telemetry.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth">.spec.external_services.prometheus.auth</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Settings used to authenticate with the Prometheus instance.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.ca_file">.spec.external_services.prometheus.auth.ca_file</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The certificate authority file to use when accessing Prometheus using https. An empty string means no extra certificate authority file is used.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.insecure_skip_verify">.spec.external_services.prometheus.auth.insecure_skip_verify</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Set true to skip verifying certificate validity when Kiali contacts Prometheus over https.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.password">.spec.external_services.prometheus.auth.password</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Password to be used when making requests to Prometheus, for basic authentication. May refer to a secret.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.token">.spec.external_services.prometheus.auth.token</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Token / API key to access Prometheus, for token-based authentication. May refer to a secret.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.type">.spec.external_services.prometheus.auth.type</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The type of authentication to use when contacting the server. Use <code>bearer</code> to send the token to the Prometheus server. Use <code>basic</code> to connect with username and password credentials. Use <code>none</code> to not use any authentication (this is the default).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.use_kiali_token">.spec.external_services.prometheus.auth.use_kiali_token</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>When true and if <code>auth.type</code> is <code>bearer</code>, Kiali Service Account token will be used for the API calls to Prometheus (in this case, <code>auth.token</code> config is ignored).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.username">.spec.external_services.prometheus.auth.username</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Username to be used when making requests to Prometheus with <code>basic</code> authentication.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.cache_duration">.spec.external_services.prometheus.cache_duration</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>Prometheus caching duration expressed in seconds.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.cache_enabled">.spec.external_services.prometheus.cache_enabled</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Enable/disable Prometheus caching used for Health services.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.cache_expiration">.spec.external_services.prometheus.cache_expiration</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>Prometheus caching expiration expressed in seconds.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.custom_headers">.spec.external_services.prometheus.custom_headers</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>A set of name/value settings that will be passed as headers when requests are sent to Prometheus.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.health_check_url">.spec.external_services.prometheus.health_check_url</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Used in the Components health feature. This is the url which Kiali will ping to determine whether the component is reachable or not. It defaults to <code>url</code> when not provided.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.is_core">.spec.external_services.prometheus.is_core</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.thanos_proxy">.spec.external_services.prometheus.thanos_proxy</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Define this section if Prometheus is to be queried through a Thanos proxy. Kiali will still use the <code>url</code> setting to query for Prometheus metrics so make sure that is set appropriately.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.thanos_proxy.enabled">.spec.external_services.prometheus.thanos_proxy.enabled</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Set to true when a Thanos proxy is in front of Prometheus.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.thanos_proxy.retention_period">.spec.external_services.prometheus.thanos_proxy.retention_period</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Thanos Retention period value expresed as a string.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.thanos_proxy.scrape_interval">.spec.external_services.prometheus.thanos_proxy.scrape_interval</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Thanos Scrape interval value expresed as a string.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.url">.spec.external_services.prometheus.url</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The URL used to query the Prometheus Server. This URL must be accessible from the Kiali pod. If empty, the default will assume Prometheus is in the Istio control plane namespace; e.g. <code>http://prometheus.&lt;istio_namespace&gt;:9090</code>.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing">.spec.external_services.tracing</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Configuration used to access the Tracing (Jaeger) dashboards.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth">.spec.external_services.tracing.auth</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Settings used to authenticate with the Tracing server instance.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.ca_file">.spec.external_services.tracing.auth.ca_file</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The certificate authority file to use when accessing the Tracing server using https. An empty string means no extra certificate authority file is used.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.insecure_skip_verify">.spec.external_services.tracing.auth.insecure_skip_verify</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Set true to skip verifying certificate validity when Kiali contacts the Tracing server over https.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.password">.spec.external_services.tracing.auth.password</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Password to be used when making requests to the Tracing server, for basic authentication. May refer to a secret.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.token">.spec.external_services.tracing.auth.token</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Token / API key to access the Tracing server, for token-based authentication. May refer to a secret.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.type">.spec.external_services.tracing.auth.type</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The type of authentication to use when contacting the server. Use <code>bearer</code> to send the token to the Tracing server. Use <code>basic</code> to connect with username and password credentials. Use <code>none</code> to not use any authentication (this is the default).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.use_kiali_token">.spec.external_services.tracing.auth.use_kiali_token</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>When true and if <code>auth.type</code> is <code>bearer</code>, Kiali Service Account token will be used for the API calls to the Tracing server (in this case, <code>auth.token</code> config is ignored).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.username">.spec.external_services.tracing.auth.username</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Username to be used when making requests to the Tracing server with <code>basic</code> authentication.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.enabled">.spec.external_services.tracing.enabled</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>When true, connections to the Tracing server are enabled. <code>in_cluster_url</code> and/or <code>url</code> need to be provided.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.in_cluster_url">.spec.external_services.tracing.in_cluster_url</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Set URL for in-cluster access, which enables further integration between Kiali and Jaeger. When not provided, Kiali will only show external links using the <code>url</code> setting. Note: Jaeger v1.20+ has separated ports for GRPC(16685) and HTTP(16686) requests. Make sure you use the appropriate port according to the <code>use_grpc</code> value. Example: <a href="http://tracing.istio-system:16685">http://tracing.istio-system:16685</a></p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.is_core">.spec.external_services.tracing.is_core</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.namespace_selector">.spec.external_services.tracing.namespace_selector</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Kiali use this boolean to find traces with a namespace selector : service.namespace.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.url">.spec.external_services.tracing.url</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The external URL that will be used to generate links to Jaeger. It must be accessible to clients external to the cluster (e.g: a browser) in order to generate valid links. If the tracing service is deployed with a QUERY_BASE_PATH set, set this URL like https://<hostname>/<QUERY_BASE_PATH>. For example, <a href="https://tracing-service:8080/jaeger">https://tracing-service:8080/jaeger</a></p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.use_grpc">.spec.external_services.tracing.use_grpc</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Set to true in order to enable GRPC connections between Kiali and Jaeger which will speed up the queries. In some setups you might not be able to use GRPC (e.g. if Jaeger is behind some reverse proxy that doesn&rsquo;t support it). If not specified, this will defalt to &lsquo;false&rsquo; if deployed within a Maistra/OSSM+OpenShift environment, &lsquo;true&rsquo; otherwise.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.whitelist_istio_system">.spec.external_services.tracing.whitelist_istio_system</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>Kiali will get the traces of these services found in the Istio control plane namespace.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.whitelist_istio_system[*]">.spec.external_services.tracing.whitelist_istio_system[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>A name of a service found in the Istio control plane namespace whose traces will be retrieved by Kiali.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.health_config">.spec.health_config</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>This section defines what it means for nodes to be healthy. For more details, see <a href="https://kiali.io/docs/configuration/health/">https://kiali.io/docs/configuration/health/</a></p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.health_config.rate">.spec.health_config.rate</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*]">.spec.health_config.rate[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].kind">.spec.health_config.rate[*].kind</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The type of resource that this configuration applies to. This is a regular expression.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].name">.spec.health_config.rate[*].name</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The name of a resource that this configuration applies to. This is a regular expression.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].namespace">.spec.health_config.rate[*].namespace</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The name of the namespace that this configuration applies to. This is a regular expression.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance">.spec.health_config.rate[*].tolerance</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>A list of tolerances for this configuration.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*]">.spec.health_config.rate[*].tolerance[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*].code">.spec.health_config.rate[*].tolerance[*].code</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The status code that applies for this tolerance. This is a regular expression.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*].degraded">.spec.health_config.rate[*].tolerance[*].degraded</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>Health will be considered degraded when the telemetry reaches this value (specified as an integer representing a percentage).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*].direction">.spec.health_config.rate[*].tolerance[*].direction</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The direction that applies for this tolerance (e.g. inbound or outbound). This is a regular expression.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*].failure">.spec.health_config.rate[*].tolerance[*].failure</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>A failure status will be shown when the telemetry reaches this value (specified as an integer representing a percentage).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*].protocol">.spec.health_config.rate[*].tolerance[*].protocol</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The protocol that applies for this tolerance (e.g. grpc or http). This is a regular expression.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.identity">.spec.identity</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Settings that define the Kiali server identity.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.identity.cert_file">.spec.identity.cert_file</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Certificate file used to identify the Kiali server. If set, you must go over https to access Kiali. The Kiali operator will set this if it deploys Kiali behind https. When left undefined, the operator will attempt to generate a cluster-specific cert file that provides https by default (today, this auto-generation of a cluster-specific cert is only supported on OpenShift). When set to an empty string, https will be disabled.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.identity.private_key_file">.spec.identity.private_key_file</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Private key file used to identify the Kiali server. If set, you must go over https to access Kiali. When left undefined, the Kiali operator will attempt to generate a cluster-specific private key file that provides https by default (today, this auto-generation of a cluster-specific private key is only supported on OpenShift). When set to an empty string, https will be disabled.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.installation_tag">.spec.installation_tag</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Tag used to identify a particular instance/installation of the Kiali server. This is merely a human-readable string that will be used within Kiali to help a user identify the Kiali being used (e.g. in the Kiali UI title bar). See <code>deployment.instance_name</code> for the setting used to customize Kiali resource names that are created.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.istio_labels">.spec.istio_labels</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Defines specific labels used by Istio that Kiali needs to know about.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.istio_labels.app_label_name">.spec.istio_labels.app_label_name</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The name of the label used to define what application a workload belongs to. This is typically something like <code>app</code> or <code>app.kubernetes.io/name</code>.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.istio_labels.injection_label_name">.spec.istio_labels.injection_label_name</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The name of the label used to instruct Istio to automatically inject sidecar proxies when applications are deployed.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.istio_labels.injection_label_rev">.spec.istio_labels.injection_label_rev</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The label used to identify the Istio revision.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.istio_labels.version_label_name">.spec.istio_labels.version_label_name</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The name of the label used to define what version of the application a workload belongs to. This is typically something like <code>version</code> or <code>app.kubernetes.io/version</code>.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.istio_namespace">.spec.istio_namespace</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The namespace where Istio is installed. If left empty, it is assumed to be the same namespace as where Kiali is installed (i.e. <code>deployment.namespace</code>).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags">.spec.kiali_feature_flags</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Kiali features that can be enabled or disabled.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.certificates_information_indicators">.spec.kiali_feature_flags.certificates_information_indicators</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Flag to enable/disable displaying certificates information and which secrets to grant read permissions.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.certificates_information_indicators.enabled">.spec.kiali_feature_flags.certificates_information_indicators.enabled</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.certificates_information_indicators.secrets">.spec.kiali_feature_flags.certificates_information_indicators.secrets</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.certificates_information_indicators.secrets[*]">.spec.kiali_feature_flags.certificates_information_indicators.secrets[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.clustering">.spec.kiali_feature_flags.clustering</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Clustering and federation related features.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.clustering.enabled">.spec.kiali_feature_flags.clustering.enabled</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Flag to enable/disable clustering and federation related features.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.istio_injection_action">.spec.kiali_feature_flags.istio_injection_action</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Flag to enable/disable an Action to label a namespace for automatic Istio Sidecar injection.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.istio_upgrade_action">.spec.kiali_feature_flags.istio_upgrade_action</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Flag to activate the Kiali functionality of upgrading namespaces to point to an installed Istio Canary revision. Related Canary upgrade and current revisions of Istio should be defined in <code>istio_canary_revision</code> section.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults">.spec.kiali_feature_flags.ui_defaults</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Default settings for the UI. These defaults apply to all users.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph">.spec.kiali_feature_flags.ui_defaults.graph</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Default settings for the Graph UI.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.find_options">.spec.kiali_feature_flags.ui_defaults.graph.find_options</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>A list of commonly used and useful find expressions that will be provided to the user out-of-box.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.find_options[*]">.spec.kiali_feature_flags.ui_defaults.graph.find_options[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.find_options[*].description">.spec.kiali_feature_flags.ui_defaults.graph.find_options[*].description</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Human-readable text to let the user know what the expression does.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.find_options[*].expression">.spec.kiali_feature_flags.ui_defaults.graph.find_options[*].expression</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The find expression.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.hide_options">.spec.kiali_feature_flags.ui_defaults.graph.hide_options</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>A list of commonly used and useful hide expressions that will be provided to the user out-of-box.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*]">.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*].description">.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*].description</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Human-readable text to let the user know what the expression does.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*].expression">.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*].expression</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The hide expression.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.traffic">.spec.kiali_feature_flags.ui_defaults.graph.traffic</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>These settings determine which rates are used to determine graph traffic.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.traffic.grpc">.spec.kiali_feature_flags.ui_defaults.graph.traffic.grpc</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>gRPC traffic is measured in requests or sent/received/total messages. Value must be one of: <code>none</code>, <code>requests</code>, <code>sent</code>, <code>received</code>, or <code>total</code>.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.traffic.http">.spec.kiali_feature_flags.ui_defaults.graph.traffic.http</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>HTTP traffic is measured in requests. Value must be one of: <code>none</code> or <code>requests</code>.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.traffic.tcp">.spec.kiali_feature_flags.ui_defaults.graph.traffic.tcp</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>TCP traffic is measured in sent/received/total bytes. Only request traffic supplies response codes. Value must be one of: <code>none</code>, <code>sent</code>, <code>received</code>, or <code>total</code>.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_inbound">.spec.kiali_feature_flags.ui_defaults.metrics_inbound</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Additional label aggregation for inbound metric pages in detail pages.
+You will see these configurations in the &lsquo;Metric Settings&rsquo; drop-down.
+An example,</p>
+
+<pre><code>metrics_inbound:
+  aggregations:
+  - display_name: Istio Network
+    label: topology_istio_io_network
+  - display_name: Istio Revision
+    label: istio_io_rev
+</code></pre>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations">.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*]">.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*].display_name">.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*].display_name</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*].label">.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*].label</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_outbound">.spec.kiali_feature_flags.ui_defaults.metrics_outbound</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Additional label aggregation for outbound metric pages in detail pages.
+You will see these configurations in the &lsquo;Metric Settings&rsquo; drop-down.
+An example,</p>
+
+<pre><code>metrics_outbound:
+  aggregations:
+  - display_name: Istio Network
+    label: topology_istio_io_network
+  - display_name: Istio Revision
+    label: istio_io_rev
+</code></pre>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations">.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-5">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*]">.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*].display_name">.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*].display_name</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-6">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*].label">.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*].label</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_per_refresh">.spec.kiali_feature_flags.ui_defaults.metrics_per_refresh</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Duration of metrics to fetch on each refresh. Value must be one of: <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>30m</code>, <code>1h</code>, <code>3h</code>, <code>6h</code>, <code>12h</code>, <code>1d</code>, <code>7d</code>, or <code>30d</code></p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.namespaces">.spec.kiali_feature_flags.ui_defaults.namespaces</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>Default selections for the namespace selection dropdown. Non-existent or inaccessible namespaces will be ignored. Omit or set to an empty array for no default namespaces.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.namespaces[*]">.spec.kiali_feature_flags.ui_defaults.namespaces[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.refresh_interval">.spec.kiali_feature_flags.ui_defaults.refresh_interval</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The automatic refresh interval for pages offering automatic refresh. Value must be one of: <code>pause</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code> or <code>15m</code></p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.validations">.spec.kiali_feature_flags.validations</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Features specific to the validations subsystem.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.validations.ignore">.spec.kiali_feature_flags.validations.ignore</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>A list of one or more validation codes whose errors are to be ignored.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.validations.ignore[*]">.spec.kiali_feature_flags.validations.ignore[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>A validation code (e.g. <code>KIA0101</code>) for a specific validation error that is to be ignored.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config">.spec.kubernetes_config</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Configuration of Kiali&rsquo;s access of the Kubernetes API.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.burst">.spec.kubernetes_config.burst</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>The Burst value of the Kubernetes client.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_duration">.spec.kubernetes_config.cache_duration</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>The ratio interval (expressed in seconds) used for the cache to perform a full refresh. Only used when <code>cache_enabled</code> is true.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_enabled">.spec.kubernetes_config.cache_enabled</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>Flag to use a Kubernetes cache for watching changes and updating pods and controllers data asynchronously.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_istio_types">.spec.kubernetes_config.cache_istio_types</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>Kiali can cache VirtualService, DestinationRule, Gateway and ServiceEntry Istio resources if they are present on this list of Istio types. Other Istio types are not yet supported.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_istio_types[*]">.spec.kubernetes_config.cache_istio_types[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_namespaces">.spec.kubernetes_config.cache_namespaces</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>List of namespaces or regex defining namespaces to include in a cache.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_namespaces[*]">.spec.kubernetes_config.cache_namespaces[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_token_namespace_duration">.spec.kubernetes_config.cache_token_namespace_duration</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>This Kiali cache is a list of namespaces per user. This is typically a short-lived cache compared with the duration of the namespace cache defined by the <code>cache_duration</code> setting. This is specified in seconds.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.excluded_workloads">.spec.kubernetes_config.excluded_workloads</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(array)</span>
+
+</div>
+
+<div class="property-description">
+<p>List of controllers that won&rsquo;t be used for Workload calculation. Kiali queries Deployment, ReplicaSet, ReplicationController, DeploymentConfig, StatefulSet, Job and CronJob controllers. Deployment and ReplicaSet will be always queried, but ReplicationController, DeploymentConfig, StatefulSet, Job and CronJobs can be skipped from Kiali workloads queries if they are present in this list.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.excluded_workloads[*]">.spec.kubernetes_config.excluded_workloads[*]</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.qps">.spec.kubernetes_config.qps</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>The QPS value of the Kubernetes client.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.login_token">.spec.login_token</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.login_token.expiration_seconds">.spec.login_token.expiration_seconds</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>A user&rsquo;s login token expiration specified in seconds. This is applicable to token and header auth strategies only.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.login_token.signing_key">.spec.login_token.signing_key</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The signing key used to generate tokens for user authentication. Because this is potentially sensitive, you have the option to store this value in a secret. If you store this signing key value in a secret, you must indicate what key in what secret by setting this value to a string in the form of <code>secret:&lt;secretName&gt;:&lt;secretKey&gt;</code>. If left as an empty string, a secret with a random signing key will be generated for you.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server">.spec.server</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Configuration that controls some core components within the Kiali Server.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.address">.spec.server.address</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Where the Kiali server is bound. The console and API server are accessible on this host.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.audit_log">.spec.server.audit_log</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>When true, allows additional audit logging on write operations.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.cors_allow_all">.spec.server.cors_allow_all</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>When true, allows the web console to send requests to other domains other than where the console came from. Typically used for development environments only.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.gzip_enabled">.spec.server.gzip_enabled</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>When true, Kiali serves http requests with gzip enabled (if the browser supports it) when the requests are over 1400 bytes.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.observability">.spec.server.observability</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Settings to enable observability into the Kiali server itself.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.observability.metrics">.spec.server.observability.metrics</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Settings that control how Kiali itself emits its own metrics.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.observability.metrics.enabled">.spec.server.observability.metrics.enabled</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>When true, the metrics endpoint will be available for Prometheus to scrape.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.observability.metrics.port">.spec.server.observability.metrics.port</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>The port that the server will bind to in order to receive metric requests. This is the port Prometheus will need to scrape when collecting metrics from Kiali.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-3">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.observability.tracing">.spec.server.observability.tracing</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>Settings that control how the Kiali server itself emits its own tracing data.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.observability.tracing.collector_url">.spec.server.observability.tracing.collector_url</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The URL used to determine where the Kiali server tracing data will be stored.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-4">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.observability.tracing.enabled">.spec.server.observability.tracing.enabled</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(boolean)</span>
+
+</div>
+
+<div class="property-description">
+<p>When true, the Kiali server itself will product its own tracing data.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.port">.spec.server.port</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(integer)</span>
+
+</div>
+
+<div class="property-description">
+<p>The port that the server will bind to in order to receive console and API requests.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.web_fqdn">.spec.server.web_fqdn</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Defines the public domain where Kiali is being served. This is the &lsquo;domain&rsquo; part of the URL (usually it&rsquo;s a fully-qualified domain name). For example, <code>kiali.example.org</code>. When empty, Kiali will try to guess this value from HTTP headers. On non-OpenShift clusters, you must populate this value if you want to enable cross-linking between Kiali instances in a multi-cluster setup.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.web_history_mode">.spec.server.web_history_mode</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Define the history mode of kiali UI. Value must be one of: <code>browser</code> or <code>hash</code>.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.web_port">.spec.server.web_port</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Defines the ingress port where the connections come from. This is usually necessary when the application responds through a proxy/ingress, and it does not forward the correct headers (when this happens, Kiali cannot guess the port). When empty, Kiali will try to guess this value from HTTP headers.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.web_root">.spec.server.web_root</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Defines the context root path for the Kiali console and API endpoints and readiness probes. When providing a context root path that is not <code>/</code>, do not add a trailing slash (i.e. use <code>/kiali</code> not <code>/kiali/</code>). When empty, this will default to <code>/</code> on OpenShift and <code>/kiali</code> on other Kubernetes environments.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-2">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.server.web_schema">.spec.server.web_schema</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>Defines the public HTTP schema used to serve Kiali. Value must be one of: <code>http</code> or <code>https</code>. When empty, Kiali will try to guess this value from HTTP headers. On non-OpenShift clusters, you must populate this value if you want to enable cross-linking between Kiali instances in a multi-cluster setup.</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-1">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.spec.version">.spec.version</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(string)</span>
+
+</div>
+
+<div class="property-description">
+<p>The version of the Ansible playbook to execute in order to install that version of Kiali.
+It is rare you will want to set this - if you are thinking of setting this, know what you are doing first.
+The only supported value today is <code>default</code>.</p>
+
+<p>If not specified, a default version of Kiali will be installed which will be the most recent release of Kiali.
+Refer to this file to see where these values are defined in the master branch,
+<a href="https://github.com/kiali/kiali-operator/tree/master/playbooks/default-supported-images.yml">https://github.com/kiali/kiali-operator/tree/master/playbooks/default-supported-images.yml</a></p>
+
+<p>This version setting affects the defaults of the deployment.image_name and
+deployment.image_version settings. See the comments for those settings
+below for additional details. But in short, this version setting will
+dictate which version of the Kiali image will be deployed by default.
+Note that if you explicitly set deployment.image_name and/or
+deployment.image_version you are responsible for ensuring those settings
+are compatible with this setting (i.e. the Kiali image must be compatible
+with the rest of the configuration and resources the operator will install).</p>
+
+</div>
+
+</div>
+</div>
+
+
+
+
+
+</div>
+
+
+

--- a/content/en/docs/Configuration/kialis.kiali.io.md
+++ b/content/en/docs/Configuration/kialis.kiali.io.md
@@ -14,7 +14,7 @@ source_repository_ref: master
 <div class="crd-schema-version">
 
 
-<h3 id="crd-example-v1alpha1">Example CR</h3>
+<h3 id="example-cr">Example CR</h3>
 <em>(all values shown here are the defaults unless otherwise noted)</em>
 
 ```yaml
@@ -461,13 +461,13 @@ bash &lt;(curl -sL https://raw.githubusercontent.com/kiali/kiali-operator/master
 
 For additional help in using this validation tool, pass it the `--help` option.
 
-<h3 id="property-details-v1alpha1">Properties</h3>
+<h3 id="property-details">Properties</h3>
 
 
 <div class="property depth-0">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec">.spec</h3>
+<h3 class="property-path" id=".spec">.spec</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -486,7 +486,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 <div class="property depth-1">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.additional_display_details">.spec.additional_display_details</h3>
+<h3 class="property-path" id=".spec.additional_display_details">.spec.additional_display_details</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -512,7 +512,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.additional_display_details[*]">.spec.additional_display_details[*]</h3>
+<h3 class="property-path" id=".spec.additional_display_details[*]">.spec.additional_display_details[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -526,7 +526,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.additional_display_details[*].annotation">.spec.additional_display_details[*].annotation</h3>
+<h3 class="property-path" id=".spec.additional_display_details[*].annotation">.spec.additional_display_details[*].annotation</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -545,7 +545,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.additional_display_details[*].icon_annotation">.spec.additional_display_details[*].icon_annotation</h3>
+<h3 class="property-path" id=".spec.additional_display_details[*].icon_annotation">.spec.additional_display_details[*].icon_annotation</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -564,7 +564,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.additional_display_details[*].title">.spec.additional_display_details[*].title</h3>
+<h3 class="property-path" id=".spec.additional_display_details[*].title">.spec.additional_display_details[*].title</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -583,7 +583,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 <div class="property depth-1">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.api">.spec.api</h3>
+<h3 class="property-path" id=".spec.api">.spec.api</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -597,7 +597,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.api.namespaces">.spec.api.namespaces</h3>
+<h3 class="property-path" id=".spec.api.namespaces">.spec.api.namespaces</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -616,7 +616,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.api.namespaces.exclude">.spec.api.namespaces.exclude</h3>
+<h3 class="property-path" id=".spec.api.namespaces.exclude">.spec.api.namespaces.exclude</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -635,7 +635,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.api.namespaces.exclude[*]">.spec.api.namespaces.exclude[*]</h3>
+<h3 class="property-path" id=".spec.api.namespaces.exclude[*]">.spec.api.namespaces.exclude[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -649,7 +649,7 @@ For additional help in using this validation tool, pass it the `--help` option.
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.api.namespaces.label_selector">.spec.api.namespaces.label_selector</h3>
+<h3 class="property-path" id=".spec.api.namespaces.label_selector">.spec.api.namespaces.label_selector</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -680,7 +680,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-1">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth">.spec.auth</h3>
+<h3 class="property-path" id=".spec.auth">.spec.auth</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -694,7 +694,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid">.spec.auth.openid</h3>
+<h3 class="property-path" id=".spec.auth.openid">.spec.auth.openid</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -713,7 +713,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.additional_request_params">.spec.auth.openid.additional_request_params</h3>
+<h3 class="property-path" id=".spec.auth.openid.additional_request_params">.spec.auth.openid.additional_request_params</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -727,7 +727,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.allowed_domains">.spec.auth.openid.allowed_domains</h3>
+<h3 class="property-path" id=".spec.auth.openid.allowed_domains">.spec.auth.openid.allowed_domains</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -741,7 +741,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.allowed_domains[*]">.spec.auth.openid.allowed_domains[*]</h3>
+<h3 class="property-path" id=".spec.auth.openid.allowed_domains[*]">.spec.auth.openid.allowed_domains[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -755,7 +755,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.api_proxy">.spec.auth.openid.api_proxy</h3>
+<h3 class="property-path" id=".spec.auth.openid.api_proxy">.spec.auth.openid.api_proxy</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -769,7 +769,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.api_proxy_ca_data">.spec.auth.openid.api_proxy_ca_data</h3>
+<h3 class="property-path" id=".spec.auth.openid.api_proxy_ca_data">.spec.auth.openid.api_proxy_ca_data</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -783,7 +783,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.api_token">.spec.auth.openid.api_token</h3>
+<h3 class="property-path" id=".spec.auth.openid.api_token">.spec.auth.openid.api_token</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -797,7 +797,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.authentication_timeout">.spec.auth.openid.authentication_timeout</h3>
+<h3 class="property-path" id=".spec.auth.openid.authentication_timeout">.spec.auth.openid.authentication_timeout</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -811,7 +811,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.authorization_endpoint">.spec.auth.openid.authorization_endpoint</h3>
+<h3 class="property-path" id=".spec.auth.openid.authorization_endpoint">.spec.auth.openid.authorization_endpoint</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -825,7 +825,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.client_id">.spec.auth.openid.client_id</h3>
+<h3 class="property-path" id=".spec.auth.openid.client_id">.spec.auth.openid.client_id</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -839,7 +839,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.disable_rbac">.spec.auth.openid.disable_rbac</h3>
+<h3 class="property-path" id=".spec.auth.openid.disable_rbac">.spec.auth.openid.disable_rbac</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -853,7 +853,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.http_proxy">.spec.auth.openid.http_proxy</h3>
+<h3 class="property-path" id=".spec.auth.openid.http_proxy">.spec.auth.openid.http_proxy</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -867,7 +867,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.https_proxy">.spec.auth.openid.https_proxy</h3>
+<h3 class="property-path" id=".spec.auth.openid.https_proxy">.spec.auth.openid.https_proxy</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -881,7 +881,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.insecure_skip_verify_tls">.spec.auth.openid.insecure_skip_verify_tls</h3>
+<h3 class="property-path" id=".spec.auth.openid.insecure_skip_verify_tls">.spec.auth.openid.insecure_skip_verify_tls</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -895,7 +895,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.issuer_uri">.spec.auth.openid.issuer_uri</h3>
+<h3 class="property-path" id=".spec.auth.openid.issuer_uri">.spec.auth.openid.issuer_uri</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -909,7 +909,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.scopes">.spec.auth.openid.scopes</h3>
+<h3 class="property-path" id=".spec.auth.openid.scopes">.spec.auth.openid.scopes</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -923,7 +923,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.scopes[*]">.spec.auth.openid.scopes[*]</h3>
+<h3 class="property-path" id=".spec.auth.openid.scopes[*]">.spec.auth.openid.scopes[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -937,7 +937,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openid.username_claim">.spec.auth.openid.username_claim</h3>
+<h3 class="property-path" id=".spec.auth.openid.username_claim">.spec.auth.openid.username_claim</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -951,7 +951,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openshift">.spec.auth.openshift</h3>
+<h3 class="property-path" id=".spec.auth.openshift">.spec.auth.openshift</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -970,7 +970,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.openshift.client_id_prefix">.spec.auth.openshift.client_id_prefix</h3>
+<h3 class="property-path" id=".spec.auth.openshift.client_id_prefix">.spec.auth.openshift.client_id_prefix</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -989,7 +989,7 @@ is the namespace where Kiali is to be installed.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.auth.strategy">.spec.auth.strategy</h3>
+<h3 class="property-path" id=".spec.auth.strategy">.spec.auth.strategy</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1024,7 +1024,7 @@ Authorization header and potentially impersonation headers.</li>
 <div class="property depth-1">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.custom_dashboards">.spec.custom_dashboards</h3>
+<h3 class="property-path" id=".spec.custom_dashboards">.spec.custom_dashboards</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1066,7 +1066,7 @@ empty dashboard.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.custom_dashboards[*]">.spec.custom_dashboards[*]</h3>
+<h3 class="property-path" id=".spec.custom_dashboards[*]">.spec.custom_dashboards[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1080,7 +1080,7 @@ empty dashboard.</p>
 <div class="property depth-1">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment">.spec.deployment</h3>
+<h3 class="property-path" id=".spec.deployment">.spec.deployment</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1094,7 +1094,7 @@ empty dashboard.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.accessible_namespaces">.spec.deployment.accessible_namespaces</h3>
+<h3 class="property-path" id=".spec.deployment.accessible_namespaces">.spec.deployment.accessible_namespaces</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1113,7 +1113,7 @@ empty dashboard.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.accessible_namespaces[*]">.spec.deployment.accessible_namespaces[*]</h3>
+<h3 class="property-path" id=".spec.deployment.accessible_namespaces[*]">.spec.deployment.accessible_namespaces[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1127,7 +1127,7 @@ empty dashboard.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.additional_service_yaml">.spec.deployment.additional_service_yaml</h3>
+<h3 class="property-path" id=".spec.deployment.additional_service_yaml">.spec.deployment.additional_service_yaml</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1146,7 +1146,7 @@ empty dashboard.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.affinity">.spec.deployment.affinity</h3>
+<h3 class="property-path" id=".spec.deployment.affinity">.spec.deployment.affinity</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1165,7 +1165,7 @@ empty dashboard.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.affinity.node">.spec.deployment.affinity.node</h3>
+<h3 class="property-path" id=".spec.deployment.affinity.node">.spec.deployment.affinity.node</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1179,7 +1179,7 @@ empty dashboard.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.affinity.pod">.spec.deployment.affinity.pod</h3>
+<h3 class="property-path" id=".spec.deployment.affinity.pod">.spec.deployment.affinity.pod</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1193,7 +1193,7 @@ empty dashboard.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.affinity.pod_anti">.spec.deployment.affinity.pod_anti</h3>
+<h3 class="property-path" id=".spec.deployment.affinity.pod_anti">.spec.deployment.affinity.pod_anti</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1207,7 +1207,7 @@ empty dashboard.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.custom_secrets">.spec.deployment.custom_secrets</h3>
+<h3 class="property-path" id=".spec.deployment.custom_secrets">.spec.deployment.custom_secrets</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1241,7 +1241,7 @@ An example configuration is,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.custom_secrets[*]">.spec.deployment.custom_secrets[*]</h3>
+<h3 class="property-path" id=".spec.deployment.custom_secrets[*]">.spec.deployment.custom_secrets[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1255,7 +1255,7 @@ An example configuration is,</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.custom_secrets[*].mount">.spec.deployment.custom_secrets[*].mount</h3>
+<h3 class="property-path" id=".spec.deployment.custom_secrets[*].mount">.spec.deployment.custom_secrets[*].mount</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1274,7 +1274,7 @@ An example configuration is,</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.custom_secrets[*].name">.spec.deployment.custom_secrets[*].name</h3>
+<h3 class="property-path" id=".spec.deployment.custom_secrets[*].name">.spec.deployment.custom_secrets[*].name</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1293,7 +1293,7 @@ An example configuration is,</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.custom_secrets[*].optional">.spec.deployment.custom_secrets[*].optional</h3>
+<h3 class="property-path" id=".spec.deployment.custom_secrets[*].optional">.spec.deployment.custom_secrets[*].optional</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1312,7 +1312,7 @@ An example configuration is,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.host_aliases">.spec.deployment.host_aliases</h3>
+<h3 class="property-path" id=".spec.deployment.host_aliases">.spec.deployment.host_aliases</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1342,7 +1342,7 @@ A typical way to configure this setting is,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.host_aliases[*]">.spec.deployment.host_aliases[*]</h3>
+<h3 class="property-path" id=".spec.deployment.host_aliases[*]">.spec.deployment.host_aliases[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1356,7 +1356,7 @@ A typical way to configure this setting is,</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.host_aliases[*].hostnames">.spec.deployment.host_aliases[*].hostnames</h3>
+<h3 class="property-path" id=".spec.deployment.host_aliases[*].hostnames">.spec.deployment.host_aliases[*].hostnames</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1370,7 +1370,7 @@ A typical way to configure this setting is,</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.host_aliases[*].hostnames[*]">.spec.deployment.host_aliases[*].hostnames[*]</h3>
+<h3 class="property-path" id=".spec.deployment.host_aliases[*].hostnames[*]">.spec.deployment.host_aliases[*].hostnames[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1384,7 +1384,7 @@ A typical way to configure this setting is,</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.host_aliases[*].ip">.spec.deployment.host_aliases[*].ip</h3>
+<h3 class="property-path" id=".spec.deployment.host_aliases[*].ip">.spec.deployment.host_aliases[*].ip</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1398,7 +1398,7 @@ A typical way to configure this setting is,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.hpa">.spec.deployment.hpa</h3>
+<h3 class="property-path" id=".spec.deployment.hpa">.spec.deployment.hpa</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1426,7 +1426,7 @@ A typical way to configure HPA for Kiali is,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.hpa.api_version">.spec.deployment.hpa.api_version</h3>
+<h3 class="property-path" id=".spec.deployment.hpa.api_version">.spec.deployment.hpa.api_version</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1445,7 +1445,7 @@ A typical way to configure HPA for Kiali is,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.hpa.spec">.spec.deployment.hpa.spec</h3>
+<h3 class="property-path" id=".spec.deployment.hpa.spec">.spec.deployment.hpa.spec</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1464,7 +1464,7 @@ A typical way to configure HPA for Kiali is,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.image_digest">.spec.deployment.image_digest</h3>
+<h3 class="property-path" id=".spec.deployment.image_digest">.spec.deployment.image_digest</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1483,7 +1483,7 @@ A typical way to configure HPA for Kiali is,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.image_name">.spec.deployment.image_name</h3>
+<h3 class="property-path" id=".spec.deployment.image_name">.spec.deployment.image_name</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1502,7 +1502,7 @@ A typical way to configure HPA for Kiali is,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.image_pull_policy">.spec.deployment.image_pull_policy</h3>
+<h3 class="property-path" id=".spec.deployment.image_pull_policy">.spec.deployment.image_pull_policy</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1521,7 +1521,7 @@ A typical way to configure HPA for Kiali is,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.image_pull_secrets">.spec.deployment.image_pull_secrets</h3>
+<h3 class="property-path" id=".spec.deployment.image_pull_secrets">.spec.deployment.image_pull_secrets</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1540,7 +1540,7 @@ A typical way to configure HPA for Kiali is,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.image_pull_secrets[*]">.spec.deployment.image_pull_secrets[*]</h3>
+<h3 class="property-path" id=".spec.deployment.image_pull_secrets[*]">.spec.deployment.image_pull_secrets[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1554,7 +1554,7 @@ A typical way to configure HPA for Kiali is,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.image_version">.spec.deployment.image_version</h3>
+<h3 class="property-path" id=".spec.deployment.image_version">.spec.deployment.image_version</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1589,7 +1589,7 @@ operator itself was configured.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.ingress">.spec.deployment.ingress</h3>
+<h3 class="property-path" id=".spec.deployment.ingress">.spec.deployment.ingress</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1608,7 +1608,7 @@ operator itself was configured.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.additional_labels">.spec.deployment.ingress.additional_labels</h3>
+<h3 class="property-path" id=".spec.deployment.ingress.additional_labels">.spec.deployment.ingress.additional_labels</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1627,7 +1627,7 @@ operator itself was configured.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.class_name">.spec.deployment.ingress.class_name</h3>
+<h3 class="property-path" id=".spec.deployment.ingress.class_name">.spec.deployment.ingress.class_name</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1646,7 +1646,7 @@ operator itself was configured.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.enabled">.spec.deployment.ingress.enabled</h3>
+<h3 class="property-path" id=".spec.deployment.ingress.enabled">.spec.deployment.ingress.enabled</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1665,7 +1665,7 @@ operator itself was configured.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.override_yaml">.spec.deployment.ingress.override_yaml</h3>
+<h3 class="property-path" id=".spec.deployment.ingress.override_yaml">.spec.deployment.ingress.override_yaml</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1713,7 +1713,7 @@ Example,</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.override_yaml.metadata">.spec.deployment.ingress.override_yaml.metadata</h3>
+<h3 class="property-path" id=".spec.deployment.ingress.override_yaml.metadata">.spec.deployment.ingress.override_yaml.metadata</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1727,7 +1727,7 @@ Example,</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.override_yaml.metadata.annotations">.spec.deployment.ingress.override_yaml.metadata.annotations</h3>
+<h3 class="property-path" id=".spec.deployment.ingress.override_yaml.metadata.annotations">.spec.deployment.ingress.override_yaml.metadata.annotations</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1741,7 +1741,7 @@ Example,</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.ingress.override_yaml.spec">.spec.deployment.ingress.override_yaml.spec</h3>
+<h3 class="property-path" id=".spec.deployment.ingress.override_yaml.spec">.spec.deployment.ingress.override_yaml.spec</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1755,7 +1755,7 @@ Example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.instance_name">.spec.deployment.instance_name</h3>
+<h3 class="property-path" id=".spec.deployment.instance_name">.spec.deployment.instance_name</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1774,7 +1774,7 @@ Example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.logger">.spec.deployment.logger</h3>
+<h3 class="property-path" id=".spec.deployment.logger">.spec.deployment.logger</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1793,7 +1793,7 @@ Example,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.logger.log_format">.spec.deployment.logger.log_format</h3>
+<h3 class="property-path" id=".spec.deployment.logger.log_format">.spec.deployment.logger.log_format</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1812,7 +1812,7 @@ Example,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.logger.log_level">.spec.deployment.logger.log_level</h3>
+<h3 class="property-path" id=".spec.deployment.logger.log_level">.spec.deployment.logger.log_level</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1831,7 +1831,7 @@ Example,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.logger.sampler_rate">.spec.deployment.logger.sampler_rate</h3>
+<h3 class="property-path" id=".spec.deployment.logger.sampler_rate">.spec.deployment.logger.sampler_rate</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1850,7 +1850,7 @@ Example,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.logger.time_field_format">.spec.deployment.logger.time_field_format</h3>
+<h3 class="property-path" id=".spec.deployment.logger.time_field_format">.spec.deployment.logger.time_field_format</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1869,7 +1869,7 @@ Example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.namespace">.spec.deployment.namespace</h3>
+<h3 class="property-path" id=".spec.deployment.namespace">.spec.deployment.namespace</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1888,7 +1888,7 @@ Example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.node_selector">.spec.deployment.node_selector</h3>
+<h3 class="property-path" id=".spec.deployment.node_selector">.spec.deployment.node_selector</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1907,7 +1907,7 @@ Example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.pod_annotations">.spec.deployment.pod_annotations</h3>
+<h3 class="property-path" id=".spec.deployment.pod_annotations">.spec.deployment.pod_annotations</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1926,7 +1926,7 @@ Example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.pod_labels">.spec.deployment.pod_labels</h3>
+<h3 class="property-path" id=".spec.deployment.pod_labels">.spec.deployment.pod_labels</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1949,7 +1949,7 @@ An example use for this setting is to inject an Istio sidecar such as,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.priority_class_name">.spec.deployment.priority_class_name</h3>
+<h3 class="property-path" id=".spec.deployment.priority_class_name">.spec.deployment.priority_class_name</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1968,7 +1968,7 @@ An example use for this setting is to inject an Istio sidecar such as,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.replicas">.spec.deployment.replicas</h3>
+<h3 class="property-path" id=".spec.deployment.replicas">.spec.deployment.replicas</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -1987,7 +1987,7 @@ An example use for this setting is to inject an Istio sidecar such as,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.resources">.spec.deployment.resources</h3>
+<h3 class="property-path" id=".spec.deployment.resources">.spec.deployment.resources</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2015,7 +2015,7 @@ limits:
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.secret_name">.spec.deployment.secret_name</h3>
+<h3 class="property-path" id=".spec.deployment.secret_name">.spec.deployment.secret_name</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2034,7 +2034,7 @@ limits:
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.service_annotations">.spec.deployment.service_annotations</h3>
+<h3 class="property-path" id=".spec.deployment.service_annotations">.spec.deployment.service_annotations</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2053,7 +2053,7 @@ limits:
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.service_type">.spec.deployment.service_type</h3>
+<h3 class="property-path" id=".spec.deployment.service_type">.spec.deployment.service_type</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2072,7 +2072,7 @@ limits:
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.tolerations">.spec.deployment.tolerations</h3>
+<h3 class="property-path" id=".spec.deployment.tolerations">.spec.deployment.tolerations</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2091,7 +2091,7 @@ limits:
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.tolerations[*]">.spec.deployment.tolerations[*]</h3>
+<h3 class="property-path" id=".spec.deployment.tolerations[*]">.spec.deployment.tolerations[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2105,7 +2105,7 @@ limits:
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.verbose_mode">.spec.deployment.verbose_mode</h3>
+<h3 class="property-path" id=".spec.deployment.verbose_mode">.spec.deployment.verbose_mode</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2124,7 +2124,7 @@ limits:
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.version_label">.spec.deployment.version_label</h3>
+<h3 class="property-path" id=".spec.deployment.version_label">.spec.deployment.version_label</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2151,7 +2151,7 @@ When empty, its default will be determined as follows,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.deployment.view_only_mode">.spec.deployment.view_only_mode</h3>
+<h3 class="property-path" id=".spec.deployment.view_only_mode">.spec.deployment.view_only_mode</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2170,7 +2170,7 @@ When empty, its default will be determined as follows,</p>
 <div class="property depth-1">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services">.spec.external_services</h3>
+<h3 class="property-path" id=".spec.external_services">.spec.external_services</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2204,7 +2204,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards">.spec.external_services.custom_dashboards</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards">.spec.external_services.custom_dashboards</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2223,7 +2223,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.discovery_auto_threshold">.spec.external_services.custom_dashboards.discovery_auto_threshold</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.discovery_auto_threshold">.spec.external_services.custom_dashboards.discovery_auto_threshold</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2242,7 +2242,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.discovery_enabled">.spec.external_services.custom_dashboards.discovery_enabled</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.discovery_enabled">.spec.external_services.custom_dashboards.discovery_enabled</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2261,7 +2261,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.enabled">.spec.external_services.custom_dashboards.enabled</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.enabled">.spec.external_services.custom_dashboards.enabled</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2280,7 +2280,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.is_core">.spec.external_services.custom_dashboards.is_core</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.is_core">.spec.external_services.custom_dashboards.is_core</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2299,7 +2299,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.namespace_label">.spec.external_services.custom_dashboards.namespace_label</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.namespace_label">.spec.external_services.custom_dashboards.namespace_label</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2318,7 +2318,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus">.spec.external_services.custom_dashboards.prometheus</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus">.spec.external_services.custom_dashboards.prometheus</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2337,7 +2337,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth">.spec.external_services.custom_dashboards.prometheus.auth</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.auth">.spec.external_services.custom_dashboards.prometheus.auth</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2356,7 +2356,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.ca_file">.spec.external_services.custom_dashboards.prometheus.auth.ca_file</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.auth.ca_file">.spec.external_services.custom_dashboards.prometheus.auth.ca_file</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2375,7 +2375,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.insecure_skip_verify">.spec.external_services.custom_dashboards.prometheus.auth.insecure_skip_verify</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.auth.insecure_skip_verify">.spec.external_services.custom_dashboards.prometheus.auth.insecure_skip_verify</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2394,7 +2394,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.password">.spec.external_services.custom_dashboards.prometheus.auth.password</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.auth.password">.spec.external_services.custom_dashboards.prometheus.auth.password</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2413,7 +2413,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.token">.spec.external_services.custom_dashboards.prometheus.auth.token</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.auth.token">.spec.external_services.custom_dashboards.prometheus.auth.token</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2432,7 +2432,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.type">.spec.external_services.custom_dashboards.prometheus.auth.type</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.auth.type">.spec.external_services.custom_dashboards.prometheus.auth.type</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2451,7 +2451,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.use_kiali_token">.spec.external_services.custom_dashboards.prometheus.auth.use_kiali_token</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.auth.use_kiali_token">.spec.external_services.custom_dashboards.prometheus.auth.use_kiali_token</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2470,7 +2470,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.auth.username">.spec.external_services.custom_dashboards.prometheus.auth.username</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.auth.username">.spec.external_services.custom_dashboards.prometheus.auth.username</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2489,7 +2489,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.cache_duration">.spec.external_services.custom_dashboards.prometheus.cache_duration</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.cache_duration">.spec.external_services.custom_dashboards.prometheus.cache_duration</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2508,7 +2508,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.cache_enabled">.spec.external_services.custom_dashboards.prometheus.cache_enabled</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.cache_enabled">.spec.external_services.custom_dashboards.prometheus.cache_enabled</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2527,7 +2527,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.cache_expiration">.spec.external_services.custom_dashboards.prometheus.cache_expiration</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.cache_expiration">.spec.external_services.custom_dashboards.prometheus.cache_expiration</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2546,7 +2546,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.custom_headers">.spec.external_services.custom_dashboards.prometheus.custom_headers</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.custom_headers">.spec.external_services.custom_dashboards.prometheus.custom_headers</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2565,7 +2565,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.health_check_url">.spec.external_services.custom_dashboards.prometheus.health_check_url</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.health_check_url">.spec.external_services.custom_dashboards.prometheus.health_check_url</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2584,7 +2584,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.is_core">.spec.external_services.custom_dashboards.prometheus.is_core</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.is_core">.spec.external_services.custom_dashboards.prometheus.is_core</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2603,7 +2603,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.thanos_proxy">.spec.external_services.custom_dashboards.prometheus.thanos_proxy</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.thanos_proxy">.spec.external_services.custom_dashboards.prometheus.thanos_proxy</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2622,7 +2622,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.thanos_proxy.enabled">.spec.external_services.custom_dashboards.prometheus.thanos_proxy.enabled</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.thanos_proxy.enabled">.spec.external_services.custom_dashboards.prometheus.thanos_proxy.enabled</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2641,7 +2641,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.thanos_proxy.retention_period">.spec.external_services.custom_dashboards.prometheus.thanos_proxy.retention_period</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.thanos_proxy.retention_period">.spec.external_services.custom_dashboards.prometheus.thanos_proxy.retention_period</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2660,7 +2660,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.thanos_proxy.scrape_interval">.spec.external_services.custom_dashboards.prometheus.thanos_proxy.scrape_interval</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.thanos_proxy.scrape_interval">.spec.external_services.custom_dashboards.prometheus.thanos_proxy.scrape_interval</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2679,7 +2679,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.custom_dashboards.prometheus.url">.spec.external_services.custom_dashboards.prometheus.url</h3>
+<h3 class="property-path" id=".spec.external_services.custom_dashboards.prometheus.url">.spec.external_services.custom_dashboards.prometheus.url</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2698,7 +2698,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana">.spec.external_services.grafana</h3>
+<h3 class="property-path" id=".spec.external_services.grafana">.spec.external_services.grafana</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2717,7 +2717,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth">.spec.external_services.grafana.auth</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.auth">.spec.external_services.grafana.auth</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2736,7 +2736,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.ca_file">.spec.external_services.grafana.auth.ca_file</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.auth.ca_file">.spec.external_services.grafana.auth.ca_file</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2755,7 +2755,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.insecure_skip_verify">.spec.external_services.grafana.auth.insecure_skip_verify</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.auth.insecure_skip_verify">.spec.external_services.grafana.auth.insecure_skip_verify</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2774,7 +2774,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.password">.spec.external_services.grafana.auth.password</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.auth.password">.spec.external_services.grafana.auth.password</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2793,7 +2793,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.token">.spec.external_services.grafana.auth.token</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.auth.token">.spec.external_services.grafana.auth.token</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2812,7 +2812,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.type">.spec.external_services.grafana.auth.type</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.auth.type">.spec.external_services.grafana.auth.type</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2831,7 +2831,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.use_kiali_token">.spec.external_services.grafana.auth.use_kiali_token</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.auth.use_kiali_token">.spec.external_services.grafana.auth.use_kiali_token</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2850,7 +2850,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.auth.username">.spec.external_services.grafana.auth.username</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.auth.username">.spec.external_services.grafana.auth.username</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2869,7 +2869,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards">.spec.external_services.grafana.dashboards</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.dashboards">.spec.external_services.grafana.dashboards</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2888,7 +2888,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*]">.spec.external_services.grafana.dashboards[*]</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.dashboards[*]">.spec.external_services.grafana.dashboards[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2902,7 +2902,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].name">.spec.external_services.grafana.dashboards[*].name</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.dashboards[*].name">.spec.external_services.grafana.dashboards[*].name</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2921,7 +2921,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].variables">.spec.external_services.grafana.dashboards[*].variables</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.dashboards[*].variables">.spec.external_services.grafana.dashboards[*].variables</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2935,7 +2935,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].variables.app">.spec.external_services.grafana.dashboards[*].variables.app</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.dashboards[*].variables.app">.spec.external_services.grafana.dashboards[*].variables.app</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2954,7 +2954,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].variables.namespace">.spec.external_services.grafana.dashboards[*].variables.namespace</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.dashboards[*].variables.namespace">.spec.external_services.grafana.dashboards[*].variables.namespace</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2973,7 +2973,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].variables.service">.spec.external_services.grafana.dashboards[*].variables.service</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.dashboards[*].variables.service">.spec.external_services.grafana.dashboards[*].variables.service</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -2992,7 +2992,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.dashboards[*].variables.workload">.spec.external_services.grafana.dashboards[*].variables.workload</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.dashboards[*].variables.workload">.spec.external_services.grafana.dashboards[*].variables.workload</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3011,7 +3011,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.enabled">.spec.external_services.grafana.enabled</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.enabled">.spec.external_services.grafana.enabled</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3030,7 +3030,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.health_check_url">.spec.external_services.grafana.health_check_url</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.health_check_url">.spec.external_services.grafana.health_check_url</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3049,7 +3049,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.in_cluster_url">.spec.external_services.grafana.in_cluster_url</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.in_cluster_url">.spec.external_services.grafana.in_cluster_url</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3068,7 +3068,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.is_core">.spec.external_services.grafana.is_core</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.is_core">.spec.external_services.grafana.is_core</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3087,7 +3087,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.grafana.url">.spec.external_services.grafana.url</h3>
+<h3 class="property-path" id=".spec.external_services.grafana.url">.spec.external_services.grafana.url</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3106,7 +3106,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio">.spec.external_services.istio</h3>
+<h3 class="property-path" id=".spec.external_services.istio">.spec.external_services.istio</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3125,7 +3125,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status">.spec.external_services.istio.component_status</h3>
+<h3 class="property-path" id=".spec.external_services.istio.component_status">.spec.external_services.istio.component_status</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3144,7 +3144,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components">.spec.external_services.istio.component_status.components</h3>
+<h3 class="property-path" id=".spec.external_services.istio.component_status.components">.spec.external_services.istio.component_status.components</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3163,7 +3163,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components[*]">.spec.external_services.istio.component_status.components[*]</h3>
+<h3 class="property-path" id=".spec.external_services.istio.component_status.components[*]">.spec.external_services.istio.component_status.components[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3177,7 +3177,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components[*].app_label">.spec.external_services.istio.component_status.components[*].app_label</h3>
+<h3 class="property-path" id=".spec.external_services.istio.component_status.components[*].app_label">.spec.external_services.istio.component_status.components[*].app_label</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3196,7 +3196,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components[*].is_core">.spec.external_services.istio.component_status.components[*].is_core</h3>
+<h3 class="property-path" id=".spec.external_services.istio.component_status.components[*].is_core">.spec.external_services.istio.component_status.components[*].is_core</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3215,7 +3215,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components[*].is_proxy">.spec.external_services.istio.component_status.components[*].is_proxy</h3>
+<h3 class="property-path" id=".spec.external_services.istio.component_status.components[*].is_proxy">.spec.external_services.istio.component_status.components[*].is_proxy</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3234,7 +3234,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.components[*].namespace">.spec.external_services.istio.component_status.components[*].namespace</h3>
+<h3 class="property-path" id=".spec.external_services.istio.component_status.components[*].namespace">.spec.external_services.istio.component_status.components[*].namespace</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3253,7 +3253,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.component_status.enabled">.spec.external_services.istio.component_status.enabled</h3>
+<h3 class="property-path" id=".spec.external_services.istio.component_status.enabled">.spec.external_services.istio.component_status.enabled</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3272,7 +3272,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.config_map_name">.spec.external_services.istio.config_map_name</h3>
+<h3 class="property-path" id=".spec.external_services.istio.config_map_name">.spec.external_services.istio.config_map_name</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3291,7 +3291,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.envoy_admin_local_port">.spec.external_services.istio.envoy_admin_local_port</h3>
+<h3 class="property-path" id=".spec.external_services.istio.envoy_admin_local_port">.spec.external_services.istio.envoy_admin_local_port</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3310,7 +3310,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_canary_revision">.spec.external_services.istio.istio_canary_revision</h3>
+<h3 class="property-path" id=".spec.external_services.istio.istio_canary_revision">.spec.external_services.istio.istio_canary_revision</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3329,7 +3329,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_canary_revision.current">.spec.external_services.istio.istio_canary_revision.current</h3>
+<h3 class="property-path" id=".spec.external_services.istio.istio_canary_revision.current">.spec.external_services.istio.istio_canary_revision.current</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3348,7 +3348,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_canary_revision.upgrade">.spec.external_services.istio.istio_canary_revision.upgrade</h3>
+<h3 class="property-path" id=".spec.external_services.istio.istio_canary_revision.upgrade">.spec.external_services.istio.istio_canary_revision.upgrade</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3367,7 +3367,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_identity_domain">.spec.external_services.istio.istio_identity_domain</h3>
+<h3 class="property-path" id=".spec.external_services.istio.istio_identity_domain">.spec.external_services.istio.istio_identity_domain</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3386,7 +3386,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_injection_annotation">.spec.external_services.istio.istio_injection_annotation</h3>
+<h3 class="property-path" id=".spec.external_services.istio.istio_injection_annotation">.spec.external_services.istio.istio_injection_annotation</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3405,7 +3405,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_sidecar_annotation">.spec.external_services.istio.istio_sidecar_annotation</h3>
+<h3 class="property-path" id=".spec.external_services.istio.istio_sidecar_annotation">.spec.external_services.istio.istio_sidecar_annotation</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3424,7 +3424,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istio_sidecar_injector_config_map_name">.spec.external_services.istio.istio_sidecar_injector_config_map_name</h3>
+<h3 class="property-path" id=".spec.external_services.istio.istio_sidecar_injector_config_map_name">.spec.external_services.istio.istio_sidecar_injector_config_map_name</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3443,7 +3443,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istiod_deployment_name">.spec.external_services.istio.istiod_deployment_name</h3>
+<h3 class="property-path" id=".spec.external_services.istio.istiod_deployment_name">.spec.external_services.istio.istiod_deployment_name</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3462,7 +3462,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.istiod_pod_monitoring_port">.spec.external_services.istio.istiod_pod_monitoring_port</h3>
+<h3 class="property-path" id=".spec.external_services.istio.istiod_pod_monitoring_port">.spec.external_services.istio.istiod_pod_monitoring_port</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3481,7 +3481,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.root_namespace">.spec.external_services.istio.root_namespace</h3>
+<h3 class="property-path" id=".spec.external_services.istio.root_namespace">.spec.external_services.istio.root_namespace</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3500,7 +3500,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.istio.url_service_version">.spec.external_services.istio.url_service_version</h3>
+<h3 class="property-path" id=".spec.external_services.istio.url_service_version">.spec.external_services.istio.url_service_version</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3519,7 +3519,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus">.spec.external_services.prometheus</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus">.spec.external_services.prometheus</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3538,7 +3538,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth">.spec.external_services.prometheus.auth</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.auth">.spec.external_services.prometheus.auth</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3557,7 +3557,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.ca_file">.spec.external_services.prometheus.auth.ca_file</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.auth.ca_file">.spec.external_services.prometheus.auth.ca_file</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3576,7 +3576,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.insecure_skip_verify">.spec.external_services.prometheus.auth.insecure_skip_verify</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.auth.insecure_skip_verify">.spec.external_services.prometheus.auth.insecure_skip_verify</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3595,7 +3595,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.password">.spec.external_services.prometheus.auth.password</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.auth.password">.spec.external_services.prometheus.auth.password</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3614,7 +3614,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.token">.spec.external_services.prometheus.auth.token</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.auth.token">.spec.external_services.prometheus.auth.token</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3633,7 +3633,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.type">.spec.external_services.prometheus.auth.type</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.auth.type">.spec.external_services.prometheus.auth.type</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3652,7 +3652,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.use_kiali_token">.spec.external_services.prometheus.auth.use_kiali_token</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.auth.use_kiali_token">.spec.external_services.prometheus.auth.use_kiali_token</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3671,7 +3671,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.auth.username">.spec.external_services.prometheus.auth.username</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.auth.username">.spec.external_services.prometheus.auth.username</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3690,7 +3690,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.cache_duration">.spec.external_services.prometheus.cache_duration</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.cache_duration">.spec.external_services.prometheus.cache_duration</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3709,7 +3709,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.cache_enabled">.spec.external_services.prometheus.cache_enabled</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.cache_enabled">.spec.external_services.prometheus.cache_enabled</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3728,7 +3728,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.cache_expiration">.spec.external_services.prometheus.cache_expiration</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.cache_expiration">.spec.external_services.prometheus.cache_expiration</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3747,7 +3747,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.custom_headers">.spec.external_services.prometheus.custom_headers</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.custom_headers">.spec.external_services.prometheus.custom_headers</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3766,7 +3766,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.health_check_url">.spec.external_services.prometheus.health_check_url</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.health_check_url">.spec.external_services.prometheus.health_check_url</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3785,7 +3785,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.is_core">.spec.external_services.prometheus.is_core</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.is_core">.spec.external_services.prometheus.is_core</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3804,7 +3804,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.thanos_proxy">.spec.external_services.prometheus.thanos_proxy</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.thanos_proxy">.spec.external_services.prometheus.thanos_proxy</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3823,7 +3823,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.thanos_proxy.enabled">.spec.external_services.prometheus.thanos_proxy.enabled</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.thanos_proxy.enabled">.spec.external_services.prometheus.thanos_proxy.enabled</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3842,7 +3842,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.thanos_proxy.retention_period">.spec.external_services.prometheus.thanos_proxy.retention_period</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.thanos_proxy.retention_period">.spec.external_services.prometheus.thanos_proxy.retention_period</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3861,7 +3861,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.thanos_proxy.scrape_interval">.spec.external_services.prometheus.thanos_proxy.scrape_interval</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.thanos_proxy.scrape_interval">.spec.external_services.prometheus.thanos_proxy.scrape_interval</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3880,7 +3880,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.prometheus.url">.spec.external_services.prometheus.url</h3>
+<h3 class="property-path" id=".spec.external_services.prometheus.url">.spec.external_services.prometheus.url</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3899,7 +3899,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing">.spec.external_services.tracing</h3>
+<h3 class="property-path" id=".spec.external_services.tracing">.spec.external_services.tracing</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3918,7 +3918,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth">.spec.external_services.tracing.auth</h3>
+<h3 class="property-path" id=".spec.external_services.tracing.auth">.spec.external_services.tracing.auth</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3937,7 +3937,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.ca_file">.spec.external_services.tracing.auth.ca_file</h3>
+<h3 class="property-path" id=".spec.external_services.tracing.auth.ca_file">.spec.external_services.tracing.auth.ca_file</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3956,7 +3956,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.insecure_skip_verify">.spec.external_services.tracing.auth.insecure_skip_verify</h3>
+<h3 class="property-path" id=".spec.external_services.tracing.auth.insecure_skip_verify">.spec.external_services.tracing.auth.insecure_skip_verify</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3975,7 +3975,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.password">.spec.external_services.tracing.auth.password</h3>
+<h3 class="property-path" id=".spec.external_services.tracing.auth.password">.spec.external_services.tracing.auth.password</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -3994,7 +3994,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.token">.spec.external_services.tracing.auth.token</h3>
+<h3 class="property-path" id=".spec.external_services.tracing.auth.token">.spec.external_services.tracing.auth.token</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4013,7 +4013,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.type">.spec.external_services.tracing.auth.type</h3>
+<h3 class="property-path" id=".spec.external_services.tracing.auth.type">.spec.external_services.tracing.auth.type</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4032,7 +4032,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.use_kiali_token">.spec.external_services.tracing.auth.use_kiali_token</h3>
+<h3 class="property-path" id=".spec.external_services.tracing.auth.use_kiali_token">.spec.external_services.tracing.auth.use_kiali_token</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4051,7 +4051,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.auth.username">.spec.external_services.tracing.auth.username</h3>
+<h3 class="property-path" id=".spec.external_services.tracing.auth.username">.spec.external_services.tracing.auth.username</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4070,7 +4070,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.enabled">.spec.external_services.tracing.enabled</h3>
+<h3 class="property-path" id=".spec.external_services.tracing.enabled">.spec.external_services.tracing.enabled</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4089,7 +4089,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.in_cluster_url">.spec.external_services.tracing.in_cluster_url</h3>
+<h3 class="property-path" id=".spec.external_services.tracing.in_cluster_url">.spec.external_services.tracing.in_cluster_url</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4108,7 +4108,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.is_core">.spec.external_services.tracing.is_core</h3>
+<h3 class="property-path" id=".spec.external_services.tracing.is_core">.spec.external_services.tracing.is_core</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4127,7 +4127,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.namespace_selector">.spec.external_services.tracing.namespace_selector</h3>
+<h3 class="property-path" id=".spec.external_services.tracing.namespace_selector">.spec.external_services.tracing.namespace_selector</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4146,7 +4146,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.url">.spec.external_services.tracing.url</h3>
+<h3 class="property-path" id=".spec.external_services.tracing.url">.spec.external_services.tracing.url</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4165,7 +4165,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.use_grpc">.spec.external_services.tracing.use_grpc</h3>
+<h3 class="property-path" id=".spec.external_services.tracing.use_grpc">.spec.external_services.tracing.use_grpc</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4184,7 +4184,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.whitelist_istio_system">.spec.external_services.tracing.whitelist_istio_system</h3>
+<h3 class="property-path" id=".spec.external_services.tracing.whitelist_istio_system">.spec.external_services.tracing.whitelist_istio_system</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4203,7 +4203,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.external_services.tracing.whitelist_istio_system[*]">.spec.external_services.tracing.whitelist_istio_system[*]</h3>
+<h3 class="property-path" id=".spec.external_services.tracing.whitelist_istio_system[*]">.spec.external_services.tracing.whitelist_istio_system[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4222,7 +4222,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-1">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.health_config">.spec.health_config</h3>
+<h3 class="property-path" id=".spec.health_config">.spec.health_config</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4241,7 +4241,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.health_config.rate">.spec.health_config.rate</h3>
+<h3 class="property-path" id=".spec.health_config.rate">.spec.health_config.rate</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4255,7 +4255,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*]">.spec.health_config.rate[*]</h3>
+<h3 class="property-path" id=".spec.health_config.rate[*]">.spec.health_config.rate[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4269,7 +4269,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].kind">.spec.health_config.rate[*].kind</h3>
+<h3 class="property-path" id=".spec.health_config.rate[*].kind">.spec.health_config.rate[*].kind</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4288,7 +4288,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].name">.spec.health_config.rate[*].name</h3>
+<h3 class="property-path" id=".spec.health_config.rate[*].name">.spec.health_config.rate[*].name</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4307,7 +4307,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].namespace">.spec.health_config.rate[*].namespace</h3>
+<h3 class="property-path" id=".spec.health_config.rate[*].namespace">.spec.health_config.rate[*].namespace</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4326,7 +4326,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance">.spec.health_config.rate[*].tolerance</h3>
+<h3 class="property-path" id=".spec.health_config.rate[*].tolerance">.spec.health_config.rate[*].tolerance</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4345,7 +4345,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*]">.spec.health_config.rate[*].tolerance[*]</h3>
+<h3 class="property-path" id=".spec.health_config.rate[*].tolerance[*]">.spec.health_config.rate[*].tolerance[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4359,7 +4359,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*].code">.spec.health_config.rate[*].tolerance[*].code</h3>
+<h3 class="property-path" id=".spec.health_config.rate[*].tolerance[*].code">.spec.health_config.rate[*].tolerance[*].code</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4378,7 +4378,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*].degraded">.spec.health_config.rate[*].tolerance[*].degraded</h3>
+<h3 class="property-path" id=".spec.health_config.rate[*].tolerance[*].degraded">.spec.health_config.rate[*].tolerance[*].degraded</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4397,7 +4397,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*].direction">.spec.health_config.rate[*].tolerance[*].direction</h3>
+<h3 class="property-path" id=".spec.health_config.rate[*].tolerance[*].direction">.spec.health_config.rate[*].tolerance[*].direction</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4416,7 +4416,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*].failure">.spec.health_config.rate[*].tolerance[*].failure</h3>
+<h3 class="property-path" id=".spec.health_config.rate[*].tolerance[*].failure">.spec.health_config.rate[*].tolerance[*].failure</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4435,7 +4435,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.health_config.rate[*].tolerance[*].protocol">.spec.health_config.rate[*].tolerance[*].protocol</h3>
+<h3 class="property-path" id=".spec.health_config.rate[*].tolerance[*].protocol">.spec.health_config.rate[*].tolerance[*].protocol</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4454,7 +4454,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-1">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.identity">.spec.identity</h3>
+<h3 class="property-path" id=".spec.identity">.spec.identity</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4473,7 +4473,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.identity.cert_file">.spec.identity.cert_file</h3>
+<h3 class="property-path" id=".spec.identity.cert_file">.spec.identity.cert_file</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4492,7 +4492,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.identity.private_key_file">.spec.identity.private_key_file</h3>
+<h3 class="property-path" id=".spec.identity.private_key_file">.spec.identity.private_key_file</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4511,7 +4511,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-1">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.installation_tag">.spec.installation_tag</h3>
+<h3 class="property-path" id=".spec.installation_tag">.spec.installation_tag</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4530,7 +4530,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-1">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.istio_labels">.spec.istio_labels</h3>
+<h3 class="property-path" id=".spec.istio_labels">.spec.istio_labels</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4549,7 +4549,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.istio_labels.app_label_name">.spec.istio_labels.app_label_name</h3>
+<h3 class="property-path" id=".spec.istio_labels.app_label_name">.spec.istio_labels.app_label_name</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4568,7 +4568,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.istio_labels.injection_label_name">.spec.istio_labels.injection_label_name</h3>
+<h3 class="property-path" id=".spec.istio_labels.injection_label_name">.spec.istio_labels.injection_label_name</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4587,7 +4587,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.istio_labels.injection_label_rev">.spec.istio_labels.injection_label_rev</h3>
+<h3 class="property-path" id=".spec.istio_labels.injection_label_rev">.spec.istio_labels.injection_label_rev</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4606,7 +4606,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.istio_labels.version_label_name">.spec.istio_labels.version_label_name</h3>
+<h3 class="property-path" id=".spec.istio_labels.version_label_name">.spec.istio_labels.version_label_name</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4625,7 +4625,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-1">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.istio_namespace">.spec.istio_namespace</h3>
+<h3 class="property-path" id=".spec.istio_namespace">.spec.istio_namespace</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4644,7 +4644,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-1">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags">.spec.kiali_feature_flags</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags">.spec.kiali_feature_flags</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4663,7 +4663,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.certificates_information_indicators">.spec.kiali_feature_flags.certificates_information_indicators</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.certificates_information_indicators">.spec.kiali_feature_flags.certificates_information_indicators</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4682,7 +4682,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.certificates_information_indicators.enabled">.spec.kiali_feature_flags.certificates_information_indicators.enabled</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.certificates_information_indicators.enabled">.spec.kiali_feature_flags.certificates_information_indicators.enabled</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4696,7 +4696,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.certificates_information_indicators.secrets">.spec.kiali_feature_flags.certificates_information_indicators.secrets</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.certificates_information_indicators.secrets">.spec.kiali_feature_flags.certificates_information_indicators.secrets</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4710,7 +4710,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.certificates_information_indicators.secrets[*]">.spec.kiali_feature_flags.certificates_information_indicators.secrets[*]</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.certificates_information_indicators.secrets[*]">.spec.kiali_feature_flags.certificates_information_indicators.secrets[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4724,7 +4724,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.clustering">.spec.kiali_feature_flags.clustering</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.clustering">.spec.kiali_feature_flags.clustering</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4743,7 +4743,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.clustering.enabled">.spec.kiali_feature_flags.clustering.enabled</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.clustering.enabled">.spec.kiali_feature_flags.clustering.enabled</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4762,7 +4762,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.istio_injection_action">.spec.kiali_feature_flags.istio_injection_action</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.istio_injection_action">.spec.kiali_feature_flags.istio_injection_action</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4781,7 +4781,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.istio_upgrade_action">.spec.kiali_feature_flags.istio_upgrade_action</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.istio_upgrade_action">.spec.kiali_feature_flags.istio_upgrade_action</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4800,7 +4800,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults">.spec.kiali_feature_flags.ui_defaults</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults">.spec.kiali_feature_flags.ui_defaults</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4819,7 +4819,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph">.spec.kiali_feature_flags.ui_defaults.graph</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.graph">.spec.kiali_feature_flags.ui_defaults.graph</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4838,7 +4838,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.find_options">.spec.kiali_feature_flags.ui_defaults.graph.find_options</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.graph.find_options">.spec.kiali_feature_flags.ui_defaults.graph.find_options</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4857,7 +4857,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.find_options[*]">.spec.kiali_feature_flags.ui_defaults.graph.find_options[*]</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.graph.find_options[*]">.spec.kiali_feature_flags.ui_defaults.graph.find_options[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4871,7 +4871,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.find_options[*].description">.spec.kiali_feature_flags.ui_defaults.graph.find_options[*].description</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.graph.find_options[*].description">.spec.kiali_feature_flags.ui_defaults.graph.find_options[*].description</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4890,7 +4890,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.find_options[*].expression">.spec.kiali_feature_flags.ui_defaults.graph.find_options[*].expression</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.graph.find_options[*].expression">.spec.kiali_feature_flags.ui_defaults.graph.find_options[*].expression</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4909,7 +4909,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.hide_options">.spec.kiali_feature_flags.ui_defaults.graph.hide_options</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.graph.hide_options">.spec.kiali_feature_flags.ui_defaults.graph.hide_options</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4928,7 +4928,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*]">.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*]</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.graph.hide_options[*]">.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4942,7 +4942,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*].description">.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*].description</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.graph.hide_options[*].description">.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*].description</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4961,7 +4961,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*].expression">.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*].expression</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.graph.hide_options[*].expression">.spec.kiali_feature_flags.ui_defaults.graph.hide_options[*].expression</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4980,7 +4980,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.traffic">.spec.kiali_feature_flags.ui_defaults.graph.traffic</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.graph.traffic">.spec.kiali_feature_flags.ui_defaults.graph.traffic</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -4999,7 +4999,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.traffic.grpc">.spec.kiali_feature_flags.ui_defaults.graph.traffic.grpc</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.graph.traffic.grpc">.spec.kiali_feature_flags.ui_defaults.graph.traffic.grpc</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5018,7 +5018,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.traffic.http">.spec.kiali_feature_flags.ui_defaults.graph.traffic.http</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.graph.traffic.http">.spec.kiali_feature_flags.ui_defaults.graph.traffic.http</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5037,7 +5037,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.graph.traffic.tcp">.spec.kiali_feature_flags.ui_defaults.graph.traffic.tcp</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.graph.traffic.tcp">.spec.kiali_feature_flags.ui_defaults.graph.traffic.tcp</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5056,7 +5056,7 @@ to <code>secret:myGrafanaCredentials:myGrafanaPw</code>.</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_inbound">.spec.kiali_feature_flags.ui_defaults.metrics_inbound</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.metrics_inbound">.spec.kiali_feature_flags.ui_defaults.metrics_inbound</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5085,7 +5085,7 @@ An example,</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations">.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations">.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5099,7 +5099,7 @@ An example,</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*]">.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*]</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*]">.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5113,7 +5113,7 @@ An example,</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*].display_name">.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*].display_name</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*].display_name">.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*].display_name</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5127,7 +5127,7 @@ An example,</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*].label">.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*].label</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*].label">.spec.kiali_feature_flags.ui_defaults.metrics_inbound.aggregations[*].label</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5141,7 +5141,7 @@ An example,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_outbound">.spec.kiali_feature_flags.ui_defaults.metrics_outbound</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.metrics_outbound">.spec.kiali_feature_flags.ui_defaults.metrics_outbound</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5170,7 +5170,7 @@ An example,</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations">.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations">.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5184,7 +5184,7 @@ An example,</p>
 <div class="property depth-5">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*]">.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*]</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*]">.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5198,7 +5198,7 @@ An example,</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*].display_name">.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*].display_name</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*].display_name">.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*].display_name</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5212,7 +5212,7 @@ An example,</p>
 <div class="property depth-6">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*].label">.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*].label</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*].label">.spec.kiali_feature_flags.ui_defaults.metrics_outbound.aggregations[*].label</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5226,7 +5226,7 @@ An example,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.metrics_per_refresh">.spec.kiali_feature_flags.ui_defaults.metrics_per_refresh</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.metrics_per_refresh">.spec.kiali_feature_flags.ui_defaults.metrics_per_refresh</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5245,7 +5245,7 @@ An example,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.namespaces">.spec.kiali_feature_flags.ui_defaults.namespaces</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.namespaces">.spec.kiali_feature_flags.ui_defaults.namespaces</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5264,7 +5264,7 @@ An example,</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.namespaces[*]">.spec.kiali_feature_flags.ui_defaults.namespaces[*]</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.namespaces[*]">.spec.kiali_feature_flags.ui_defaults.namespaces[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5278,7 +5278,7 @@ An example,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.ui_defaults.refresh_interval">.spec.kiali_feature_flags.ui_defaults.refresh_interval</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.ui_defaults.refresh_interval">.spec.kiali_feature_flags.ui_defaults.refresh_interval</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5297,7 +5297,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.validations">.spec.kiali_feature_flags.validations</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.validations">.spec.kiali_feature_flags.validations</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5316,7 +5316,7 @@ An example,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.validations.ignore">.spec.kiali_feature_flags.validations.ignore</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.validations.ignore">.spec.kiali_feature_flags.validations.ignore</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5335,7 +5335,7 @@ An example,</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kiali_feature_flags.validations.ignore[*]">.spec.kiali_feature_flags.validations.ignore[*]</h3>
+<h3 class="property-path" id=".spec.kiali_feature_flags.validations.ignore[*]">.spec.kiali_feature_flags.validations.ignore[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5354,7 +5354,7 @@ An example,</p>
 <div class="property depth-1">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config">.spec.kubernetes_config</h3>
+<h3 class="property-path" id=".spec.kubernetes_config">.spec.kubernetes_config</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5373,7 +5373,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.burst">.spec.kubernetes_config.burst</h3>
+<h3 class="property-path" id=".spec.kubernetes_config.burst">.spec.kubernetes_config.burst</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5392,7 +5392,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_duration">.spec.kubernetes_config.cache_duration</h3>
+<h3 class="property-path" id=".spec.kubernetes_config.cache_duration">.spec.kubernetes_config.cache_duration</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5411,7 +5411,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_enabled">.spec.kubernetes_config.cache_enabled</h3>
+<h3 class="property-path" id=".spec.kubernetes_config.cache_enabled">.spec.kubernetes_config.cache_enabled</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5430,7 +5430,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_istio_types">.spec.kubernetes_config.cache_istio_types</h3>
+<h3 class="property-path" id=".spec.kubernetes_config.cache_istio_types">.spec.kubernetes_config.cache_istio_types</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5449,7 +5449,7 @@ An example,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_istio_types[*]">.spec.kubernetes_config.cache_istio_types[*]</h3>
+<h3 class="property-path" id=".spec.kubernetes_config.cache_istio_types[*]">.spec.kubernetes_config.cache_istio_types[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5463,7 +5463,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_namespaces">.spec.kubernetes_config.cache_namespaces</h3>
+<h3 class="property-path" id=".spec.kubernetes_config.cache_namespaces">.spec.kubernetes_config.cache_namespaces</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5482,7 +5482,7 @@ An example,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_namespaces[*]">.spec.kubernetes_config.cache_namespaces[*]</h3>
+<h3 class="property-path" id=".spec.kubernetes_config.cache_namespaces[*]">.spec.kubernetes_config.cache_namespaces[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5496,7 +5496,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.cache_token_namespace_duration">.spec.kubernetes_config.cache_token_namespace_duration</h3>
+<h3 class="property-path" id=".spec.kubernetes_config.cache_token_namespace_duration">.spec.kubernetes_config.cache_token_namespace_duration</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5515,7 +5515,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.excluded_workloads">.spec.kubernetes_config.excluded_workloads</h3>
+<h3 class="property-path" id=".spec.kubernetes_config.excluded_workloads">.spec.kubernetes_config.excluded_workloads</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5534,7 +5534,7 @@ An example,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.excluded_workloads[*]">.spec.kubernetes_config.excluded_workloads[*]</h3>
+<h3 class="property-path" id=".spec.kubernetes_config.excluded_workloads[*]">.spec.kubernetes_config.excluded_workloads[*]</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5548,7 +5548,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.kubernetes_config.qps">.spec.kubernetes_config.qps</h3>
+<h3 class="property-path" id=".spec.kubernetes_config.qps">.spec.kubernetes_config.qps</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5567,7 +5567,7 @@ An example,</p>
 <div class="property depth-1">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.login_token">.spec.login_token</h3>
+<h3 class="property-path" id=".spec.login_token">.spec.login_token</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5581,7 +5581,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.login_token.expiration_seconds">.spec.login_token.expiration_seconds</h3>
+<h3 class="property-path" id=".spec.login_token.expiration_seconds">.spec.login_token.expiration_seconds</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5600,7 +5600,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.login_token.signing_key">.spec.login_token.signing_key</h3>
+<h3 class="property-path" id=".spec.login_token.signing_key">.spec.login_token.signing_key</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5619,7 +5619,7 @@ An example,</p>
 <div class="property depth-1">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server">.spec.server</h3>
+<h3 class="property-path" id=".spec.server">.spec.server</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5638,7 +5638,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.address">.spec.server.address</h3>
+<h3 class="property-path" id=".spec.server.address">.spec.server.address</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5657,7 +5657,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.audit_log">.spec.server.audit_log</h3>
+<h3 class="property-path" id=".spec.server.audit_log">.spec.server.audit_log</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5676,7 +5676,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.cors_allow_all">.spec.server.cors_allow_all</h3>
+<h3 class="property-path" id=".spec.server.cors_allow_all">.spec.server.cors_allow_all</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5695,7 +5695,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.gzip_enabled">.spec.server.gzip_enabled</h3>
+<h3 class="property-path" id=".spec.server.gzip_enabled">.spec.server.gzip_enabled</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5714,7 +5714,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.observability">.spec.server.observability</h3>
+<h3 class="property-path" id=".spec.server.observability">.spec.server.observability</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5733,7 +5733,7 @@ An example,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.observability.metrics">.spec.server.observability.metrics</h3>
+<h3 class="property-path" id=".spec.server.observability.metrics">.spec.server.observability.metrics</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5752,7 +5752,7 @@ An example,</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.observability.metrics.enabled">.spec.server.observability.metrics.enabled</h3>
+<h3 class="property-path" id=".spec.server.observability.metrics.enabled">.spec.server.observability.metrics.enabled</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5771,7 +5771,7 @@ An example,</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.observability.metrics.port">.spec.server.observability.metrics.port</h3>
+<h3 class="property-path" id=".spec.server.observability.metrics.port">.spec.server.observability.metrics.port</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5790,7 +5790,7 @@ An example,</p>
 <div class="property depth-3">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.observability.tracing">.spec.server.observability.tracing</h3>
+<h3 class="property-path" id=".spec.server.observability.tracing">.spec.server.observability.tracing</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5809,7 +5809,7 @@ An example,</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.observability.tracing.collector_url">.spec.server.observability.tracing.collector_url</h3>
+<h3 class="property-path" id=".spec.server.observability.tracing.collector_url">.spec.server.observability.tracing.collector_url</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5828,7 +5828,7 @@ An example,</p>
 <div class="property depth-4">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.observability.tracing.enabled">.spec.server.observability.tracing.enabled</h3>
+<h3 class="property-path" id=".spec.server.observability.tracing.enabled">.spec.server.observability.tracing.enabled</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5847,7 +5847,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.port">.spec.server.port</h3>
+<h3 class="property-path" id=".spec.server.port">.spec.server.port</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5866,7 +5866,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.web_fqdn">.spec.server.web_fqdn</h3>
+<h3 class="property-path" id=".spec.server.web_fqdn">.spec.server.web_fqdn</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5885,7 +5885,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.web_history_mode">.spec.server.web_history_mode</h3>
+<h3 class="property-path" id=".spec.server.web_history_mode">.spec.server.web_history_mode</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5904,7 +5904,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.web_port">.spec.server.web_port</h3>
+<h3 class="property-path" id=".spec.server.web_port">.spec.server.web_port</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5923,7 +5923,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.web_root">.spec.server.web_root</h3>
+<h3 class="property-path" id=".spec.server.web_root">.spec.server.web_root</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5942,7 +5942,7 @@ An example,</p>
 <div class="property depth-2">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.server.web_schema">.spec.server.web_schema</h3>
+<h3 class="property-path" id=".spec.server.web_schema">.spec.server.web_schema</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5961,7 +5961,7 @@ An example,</p>
 <div class="property depth-1">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.spec.version">.spec.version</h3>
+<h3 class="property-path" id=".spec.version">.spec.version</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">
@@ -5995,7 +5995,7 @@ with the rest of the configuration and resources the operator will install).</p>
 <div class="property depth-0">
 <div class="property-header">
 <hr/>
-<h3 class="property-path" id="v1alpha1-.status">.status</h3>
+<h3 class="property-path" id=".status">.status</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">

--- a/content/en/docs/Configuration/kialis.kiali.io.md
+++ b/content/en/docs/Configuration/kialis.kiali.io.md
@@ -1,56 +1,21 @@
 ---
-title: Kiali CRD Schema Reference
-linkTitle: Kiali CRD Schema Reference
+title: Kiali CR Reference
+linkTitle: Kiali CR Reference
 description: |
-  Custom resource definition (CRD) schema reference page for the Kiali CR (kind: kialis.kiali.io).
+  Reference page for the Kiali CR.
   The Kiali Operator will watch for resources of this type and install Kiali according to those resources' configurations.
-weight: 100
-crd:
-  name_camelcase: Kiali
-  name_plural: kialis
-  name_singular: kiali
-  group: kiali.io
-  technical_name: kialis.kiali.io
-  scope: Namespaced
-  source_repository: https://github.com/kiali/kiali-operator
-  source_repository_ref: master
-  versions:
-    - v1alpha1
-  topics:
-layout: crd
-owner:
-  - https://github.com/orgs/kiali/teams/maintainers
-aliases:
-  - /reference/cp-k8s-api/kialis.kiali.io/
 technical_name: kialis.kiali.io
 source_repository: https://github.com/kiali/kiali-operator
 source_repository_ref: master
 ---
 
-# Kiali
-
-<dl class="crd-meta">
-<dt class="fullname">Full name:</dt>
-<dd class="fullname">kialis.kiali.io</dd>
-<dt class="groupname">Group:</dt>
-<dd class="groupname">kiali.io</dd>
-<dt class="singularname">Singular name:</dt>
-<dd class="singularname">kiali</dd>
-<dt class="pluralname">Plural name:</dt>
-<dd class="pluralname">kialis</dd>
-<dt class="scope">Scope:</dt>
-<dd class="scope">Namespaced</dd>
-<dt class="versions">Versions:</dt>
-<dd class="versions"><a class="version" href="#v1alpha1" title="Show schema for version v1alpha1">v1alpha1</a></dd>
-</dl>
-
 
 
 <div class="crd-schema-version">
-<h2 id="v1alpha1">Version v1alpha1</h2>
 
 
-<h3 id="crd-example-v1alpha1">Example CR (all values shown here are the defaults unless otherwise noted)</h3>
+<h3 id="crd-example-v1alpha1">Example CR</h3>
+<em>(all values shown here are the defaults unless otherwise noted)</em>
 
 ```yaml
 apiVersion: kiali.io/v1alpha1
@@ -481,6 +446,20 @@ spec:
     web_schema: ""
 ```
 
+
+### Validating your Kiali CR
+
+A Kiali tool is available to allow you to check your own Kiali CR to ensure it is valid. Simply download [the validation script](https://raw.githubusercontent.com/kiali/kiali-operator/master/crd-docs/bin/validate-kiali-cr.sh) and run it, passing in the location of the Kiali CRD you wish to validate with (e.g. the latest version is found [here](https://raw.githubusercontent.com/kiali/kiali-operator/master/crd-docs/crd/kiali.io_kialis.yaml)) and the location of your Kiali CR. You must be connected to/logged into a cluster for this validation tool to work.
+
+For example, to validate a Kiali CR named `kiali` in the namespace `istio-system` using the latest version of the Kiali CRD, run the following:
+<pre>
+bash &lt;(curl -sL https://raw.githubusercontent.com/kiali/kiali-operator/master/crd-docs/bin/validate-kiali-cr.sh) \
+  -crd https://raw.githubusercontent.com/kiali/kiali-operator/master/crd-docs/crd/kiali.io_kialis.yaml \
+  --kiali-cr-name kiali \
+  -n istio-system
+</pre>
+
+For additional help in using this validation tool, pass it the `--help` option.
 
 <h3 id="property-details-v1alpha1">Properties</h3>
 
@@ -5711,6 +5690,24 @@ Note that if you explicitly set deployment.image_name and/or
 deployment.image_version you are responsible for ensuring those settings
 are compatible with this setting (i.e. the Kiali image must be compatible
 with the rest of the configuration and resources the operator will install).</p>
+
+</div>
+
+</div>
+</div>
+
+<div class="property depth-0">
+<div class="property-header">
+<h3 class="property-path" id="v1alpha1-.status">.status</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+<span class="property-type">(object)</span>
+
+</div>
+
+<div class="property-description">
+<p>The processing status of this CR as reported by the Kiali operator.</p>
 
 </div>
 

--- a/content/en/docs/Configuration/namespace-management.md
+++ b/content/en/docs/Configuration/namespace-management.md
@@ -91,7 +91,7 @@ api:
     label_selector: kiali-enabled=true
 ```
 
-For further information on how this label_selector interacts with `spec.deployment.accessible_namespaces` read the [technical documentation](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml).
+For further information on how this `api.namespaces.label_selector` interacts with `spec.deployment.accessible_namespaces` read the [Kiali CR Reference documentation](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.api.namespaces.label_selector).
 
 To label a namespace you can use the following command. For more information see the [Kubernete's official documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels).
 

--- a/content/en/docs/Configuration/namespace-management.md
+++ b/content/en/docs/Configuration/namespace-management.md
@@ -91,7 +91,7 @@ api:
     label_selector: kiali-enabled=true
 ```
 
-For further information on how this `api.namespaces.label_selector` interacts with `spec.deployment.accessible_namespaces` read the [Kiali CR Reference documentation](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.api.namespaces.label_selector).
+For further information on how this `api.namespaces.label_selector` interacts with `spec.deployment.accessible_namespaces` read the [Kiali CR Reference documentation](/docs/configuration/kialis.kiali.io/#.spec.api.namespaces.label_selector).
 
 To label a namespace you can use the following command. For more information see the [Kubernete's official documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels).
 

--- a/content/en/docs/FAQ/distributed-tracing.md
+++ b/content/en/docs/FAQ/distributed-tracing.md
@@ -61,7 +61,7 @@ If for some reason the GRPC connection fails and you think it shouldn't (e.g. yo
 
 ### Why can't I see any external link to Jaeger?
 
-In addition to the embedded integration that Kiali provides with Jaeger, it is possible to show external links to the Jaeger UI. To do so, the external URL must be configured in the [Kiali CR](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml).
+In addition to the embedded integration that Kiali provides with Jaeger, it is possible to show external links to the Jaeger UI. To do so, the external URL must be configured in the [Kiali CR](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.external_services.tracing.url).
 
 ```yaml
     tracing:
@@ -82,7 +82,7 @@ When configured, this URL will be used to generate a couple of links to Jaeger w
 
 On the Application detail page, the Traces tab might redirect to Jaeger via an external link instead of showing the Kiali Tracing view. It happens when you have the `url` field configured, but not `in_cluster_url`, which means the Kiali backend will not be able to connect to Jaeger.
 
-To fix it, configure `in_cluster_url` in [Kiali CR](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml).
+To fix it, configure `in_cluster_url` in the [Kiali CR](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.external_services.tracing.in_cluster_url).
 
 
 ### Why do I see "Missing root span" for the root span of some span details on Traces tab?

--- a/content/en/docs/FAQ/distributed-tracing.md
+++ b/content/en/docs/FAQ/distributed-tracing.md
@@ -61,7 +61,7 @@ If for some reason the GRPC connection fails and you think it shouldn't (e.g. yo
 
 ### Why can't I see any external link to Jaeger?
 
-In addition to the embedded integration that Kiali provides with Jaeger, it is possible to show external links to the Jaeger UI. To do so, the external URL must be configured in the [Kiali CR](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.external_services.tracing.url).
+In addition to the embedded integration that Kiali provides with Jaeger, it is possible to show external links to the Jaeger UI. To do so, the external URL must be configured in the [Kiali CR](/docs/configuration/kialis.kiali.io/#.spec.external_services.tracing.url).
 
 ```yaml
     tracing:
@@ -82,7 +82,7 @@ When configured, this URL will be used to generate a couple of links to Jaeger w
 
 On the Application detail page, the Traces tab might redirect to Jaeger via an external link instead of showing the Kiali Tracing view. It happens when you have the `url` field configured, but not `in_cluster_url`, which means the Kiali backend will not be able to connect to Jaeger.
 
-To fix it, configure `in_cluster_url` in the [Kiali CR](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.external_services.tracing.in_cluster_url).
+To fix it, configure `in_cluster_url` in the [Kiali CR](/docs/configuration/kialis.kiali.io/#.spec.external_services.tracing.in_cluster_url).
 
 
 ### Why do I see "Missing root span" for the root span of some span details on Traces tab?

--- a/content/en/docs/FAQ/general.md
+++ b/content/en/docs/FAQ/general.md
@@ -205,7 +205,7 @@ When deploying Kiali with the Kiali operator, by default some namespaces are [ex
 
 In addition, you must ensure that Kiali has access to the namespaces you are interested in by setting the `spec.deployment.accessible_namespaces` field on the Kiali CR accordingly. Setting `spec.api.namespaces.exclude` alone does not give Kiali access to the namespaces. See the [Namespace Management]({{< ref "/docs/configuration/namespace-management" >}}) guide for more information.
 
-Kiali also [caches namespaces](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.kubernetes_config.cache_token_namespace_duration) by default for [10 seconds](https://github.com/kiali/kiali-operator/blob/76a9eac29fb942f199db1d0233c5135049d1f1b1/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml#L397). If the cache is enabled, it might take up to the `spec.kubernetes_config.cache_token_namespace_duration` in order for a newly added namespace to be seen by Kiali.
+Kiali also [caches namespaces](/docs/configuration/kialis.kiali.io/#.spec.kubernetes_config.cache_token_namespace_duration) by default for [10 seconds](https://github.com/kiali/kiali-operator/blob/76a9eac29fb942f199db1d0233c5135049d1f1b1/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml#L397). If the cache is enabled, it might take up to the `spec.kubernetes_config.cache_token_namespace_duration` in order for a newly added namespace to be seen by Kiali.
 
 
 ### Workload "is not found as" messages
@@ -214,7 +214,7 @@ Kiali queries *Deployment* ,*ReplicaSet*, *ReplicationController*, *DeploymentCo
 *Deployment*, *ReplicaSet* and *StatefulSet* are always queried, but _ReplicationController_, _DeploymentConfig_, _Job_ and _CronJobs_
 are excluded by default for performance reasons.
 
-To include them, update the list of [excluded_workloads](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.kubernetes_config.excluded_workloads) from the Kiali config.
+To include them, update the list of [excluded_workloads](/docs/configuration/kialis.kiali.io/#.spec.kubernetes_config.excluded_workloads) from the Kiali config.
 
 ```yaml
 #    ---

--- a/content/en/docs/FAQ/general.md
+++ b/content/en/docs/FAQ/general.md
@@ -205,7 +205,7 @@ When deploying Kiali with the Kiali operator, by default some namespaces are [ex
 
 In addition, you must ensure that Kiali has access to the namespaces you are interested in by setting the `spec.deployment.accessible_namespaces` field on the Kiali CR accordingly. Setting `spec.api.namespaces.exclude` alone does not give Kiali access to the namespaces. See the [Namespace Management]({{< ref "/docs/configuration/namespace-management" >}}) guide for more information.
 
-Kiali also caches namespaces by default for [10 seconds](https://github.com/kiali/kiali-operator/blob/v1.33/deploy/kiali/kiali_cr.yaml#L745-L749). If the cache is enabled, it might take up to the `spec.kubernetes_config.cache_token_namespace_duration` in order for a newly added namespace to be seen by Kiali.
+Kiali also [caches namespaces](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.kubernetes_config.cache_token_namespace_duration) by default for [10 seconds](https://github.com/kiali/kiali-operator/blob/76a9eac29fb942f199db1d0233c5135049d1f1b1/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml#L397). If the cache is enabled, it might take up to the `spec.kubernetes_config.cache_token_namespace_duration` in order for a newly added namespace to be seen by Kiali.
 
 
 ### Workload "is not found as" messages
@@ -214,7 +214,7 @@ Kiali queries *Deployment* ,*ReplicaSet*, *ReplicationController*, *DeploymentCo
 *Deployment*, *ReplicaSet* and *StatefulSet* are always queried, but _ReplicationController_, _DeploymentConfig_, _Job_ and _CronJobs_
 are excluded by default for performance reasons.
 
-To include them, update the list of [excluded_workloads](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml#L687) from the Kiali config.
+To include them, update the list of [excluded_workloads](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.kubernetes_config.excluded_workloads) from the Kiali config.
 
 ```yaml
 #    ---

--- a/content/en/docs/FAQ/installation.md
+++ b/content/en/docs/FAQ/installation.md
@@ -34,15 +34,8 @@ one Kiali CR for each Kiali Server you want the Operator to install and manage. 
 
 Most options are described in the pages of the [Installation]({{< relref "../Installation" >}}) and [Configuration]({{< relref "../Configuration" >}}) sections of the documentation.
 
-If you cannot find some configuration, check the [template of the Kiali CR](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml) available in Kiali's GitHub repository, which briefly describes all available options.
-If you are using a specific version of the Operator, the Kiali CR that is valid for that version can be found in the version tag within the github repository
-(e.g. Operator v1.25.0 supported [these Kiali CR settings](https://github.com/kiali/kiali-operator/blob/v1.25.0/deploy/kiali/kiali_cr.yaml)).
-
-Note that that Kiali CR template is formatted in such a way that if you uncomment a line (by deleting the line's leading `#` character), that line's setting
-will be at the appropriate indentation level. This allows you to create an initial Kiali CR by simply uncommenting lines of the settings you want to define.
-The comments are also specifically laid out in such a way that each major top-level group of settings are in their own major comment section, and each value
-in each commented setting is the default value (so if you do not define that setting yourself, you will know what its default value is). 
-
+If you cannot find some configuration, check the [Kiali CR Reference](/docs/configuration/kialis.kiali.io), which briefly describes all available options along with an example CR and all default values.
+If you are using a specific version of the Operator prior to 1.46, the Kiali CR that is valid for that version can be found in the version tag within the github repository (e.g. Operator v1.25.0 supported [these Kiali CR settings](https://github.com/kiali/kiali-operator/blob/v1.25.0/deploy/kiali/kiali_cr.yaml)).
 
 ### How to configure some operator features at runtime {#operator-configuration}
 

--- a/content/en/docs/FAQ/istio-component-status.md
+++ b/content/en/docs/FAQ/istio-component-status.md
@@ -7,7 +7,7 @@ description: "Questions about Kiali's Istio infrastructure health checks."
 ### How can I add one component to the list?
 
 If you are interested in adding one more component to the Istio Component Status tooltip, you have the option to add one new component into the
-[Kiali CR](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml), under the `external_services.istio.component_status` field.
+[Kiali CR](/docs/configuration/kialis.kiali.io), under the `external_services.istio.component_status` field.
 
 For each component there, you will need to specify the `app` label of the deployment's pods, the namespace and whether is a core component or add-on.
 
@@ -17,7 +17,7 @@ For each component there, you will need to specify the `app` label of the deploy
 The first thing you should do is check into the Kiali CR for the `istio.component_status` field.
 
 Kiali looks for a Deployment for which its pods have the `app` label with the specified value in the CR, and lives in that namespace.
-The `app` label name may be changed from the default (app) and it is specified in the `istio_labels.app_label_name` in the [Kiali CR](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml).
+The `app` label name may be changed from the default (app) and it is specified in the `istio_labels.app_label_name` in the [Kiali CR](/docs/configuration/kialis.kiali.io).
 
 Ensure that you have specified correctly the namespace and that the deployment's pod template has the specified label.
 
@@ -45,5 +45,5 @@ external_services:
     url: "http://prometheus.istio-system:9090"
 ```
 
-Please check the [Kiali CR](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml) for more information. Each external service component has its own `health_check_url` and `is_core` setting to tailor the experience in the Istio Component Status feature.
+Please check the [Kiali CR Reference](/docs/configuration/kialis.kiali.io) for more information. Each external service component has its own `health_check_url` and `is_core` setting to tailor the experience in the Istio Component Status feature.
 

--- a/content/en/docs/Features/details.md
+++ b/content/en/docs/Features/details.md
@@ -38,7 +38,7 @@ And also type-specfic information.  For example:
 ![Detail overview service](/images/documentation/features/detail-overview-service.png)
 ![Detail overview workload](/images/documentation/features/detail-overview-workload.png)
 
-Both Workload and Service detail can be customized to some extent, by adding additional details supplied as annotations. This is done through the `additional_display_details` field in [the Kiali CR](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml).
+Both Workload and Service detail can be customized to some extent, by adding additional details supplied as annotations. This is done through the `additional_display_details` field in [the Kiali CR](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.additional_display_details).
 
 ![Detail overview additional details](/images/documentation/features/detail-overview-additional-details.png)
 

--- a/content/en/docs/Features/details.md
+++ b/content/en/docs/Features/details.md
@@ -38,7 +38,7 @@ And also type-specfic information.  For example:
 ![Detail overview service](/images/documentation/features/detail-overview-service.png)
 ![Detail overview workload](/images/documentation/features/detail-overview-workload.png)
 
-Both Workload and Service detail can be customized to some extent, by adding additional details supplied as annotations. This is done through the `additional_display_details` field in [the Kiali CR](/docs/configuration/kialis.kiali.io/#v1alpha1-.spec.additional_display_details).
+Both Workload and Service detail can be customized to some extent, by adding additional details supplied as annotations. This is done through the `additional_display_details` field in [the Kiali CR](/docs/configuration/kialis.kiali.io/#.spec.additional_display_details).
 
 ![Detail overview additional details](/images/documentation/features/detail-overview-additional-details.png)
 

--- a/content/en/docs/Installation/installation-guide/creating-updating-kiali-cr.md
+++ b/content/en/docs/Installation/installation-guide/creating-updating-kiali-cr.md
@@ -4,7 +4,7 @@ description: "Creating and updating the Kiali CR."
 weight: 40
 ---
 
-The Kiali Operator watches the _Kiali Custom Resource_ (Kiali CR), a YAML file
+The Kiali Operator watches the _Kiali Custom Resource_ ([Kiali CR](/docs/configuration/kialis.kiali.io)), a YAML file
 that holds the deployment configuration. Creating, updating, or removing a
 Kiali CR will trigger the Kiali Operator to install, update, or remove Kiali.
 
@@ -69,23 +69,10 @@ Events:        <none>
 
 You may want to check the [example install page]({{< relref "example-install"
 >}}) to see some examples where the Kiali CR has a `spec` and to better
-understand its structre. Most available attributes of the Kiali CR are
+understand its structure. Most available attributes of the Kiali CR are
 described in the pages of the [Installation]({{< relref "../" >}}) and
 [Configuration]({{< relref "../../Configuration" >}}) sections of the
-documentation.
-
-Alternatively, a [Kiali CR YAML template
-file](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml)
-is available in the Operator's GitHub repository. This template file contains
-and describes all available settings. You can download it and edit it being
-*very careful* to maintain proper formatting. Incorrect indentation is a common
-problem!
-
-{{% alert color="warning" %}}
-The link in the previous paragraph is for the example Kiali CR hosted in
-GitHub, in the `master` branch. Use GitHub's branch selector to see the example
-file that matches the Kiali Operator version that you are using.
-{{% /alert %}}
+documentation. For a complete list, see the [Kiali CR Reference](/docs/configuration/kialis.kiali.io).
 
 {{% alert color="danger" %}}
 It is important to understand the `spec.deployment.accessible_namespaces` setting in the CR. See the
@@ -100,3 +87,4 @@ the resource using the usual Kubernetes tools:
 $ kubectl edit kiali kiali -n istio-system
 ```
 
+To confirm your Kiali CR is valid, you can utilize the [Kiali CR validation tool](/docs/configuration/kialis.kiali.io/#validating-your-kiali-cr).


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/4684

`make gen-crd-doc` now generates the CRD schema with an example CR (that contains the defaults).

You can review this new doc in the netlify link here: https://deploy-preview-506--kiali.netlify.app/docs/configuration/kialis.kiali.io/

The configuration of the crd doc generator and the template for this new doc page is located here: https://github.com/kiali/kiali-operator/tree/master/crd-docs/config