### PR TITLE
fix link to k8s doc

### DIFF
--- a/content/en/docs/Configuration/istio.md
+++ b/content/en/docs/Configuration/istio.md
@@ -43,7 +43,7 @@ monitoring port of the IstioD pod.
 
 Under some circumstances, you may need to change the monitoring port of the
 IstioD pod to something else. For example, when running IstioD in [_host
-network mode_](https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model)
+network mode_](https://kubernetes.io/docs/concepts/services-networking/)
 the network is shared between several pods, requiring to change listening ports
 of some pods to prevent conflicts.
 


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/4673

The k8s docs seem to have changed - need to fix this link. Our kiali.io CI was failing because the original link no longer exists.

netlify link to review: https://deploy-preview-508--kiali.netlify.app/docs/configuration/istio/#monitoring-port-of-the-istiod-pod