### PR TITLE
Update Certificate information indicators, removing 404 url, adding new

### DIFF
--- a/content/en/docs/Features/istio-component-status.md
+++ b/content/en/docs/Features/istio-component-status.md
@@ -25,7 +25,7 @@ The certificates shown depends on how Istio is configured. The following cases a
 
 * Using Istio CA certificates (default), the information shown is from a secret named *istio-ca-secret*.
 * Using [Plug in CA certificates](https://istio.io/latest/docs/tasks/security/cert-management/plugin-ca-cert/), the information shown is from a secret named *cacerts*.
-* Using [Custom CA with Kubernetes CSR](https://istio.io/latest/docs/tasks/security/cert-management/custom-ca-k8s/), the information shown is from a custom CA integrated with the Kubernetes CSR API.
+* Using [DNS certificates](https://istio.io/v1.13/docs/tasks/security/cert-management/dns-cert/), the information shown is from reading many secrets found in Istio configuration. *DNS certificates are not supported since Istio 1.14*
 
 The following is an example of viewing the default case:
 

--- a/content/en/docs/Features/istio-component-status.md
+++ b/content/en/docs/Features/istio-component-status.md
@@ -25,7 +25,7 @@ The certificates shown depends on how Istio is configured. The following cases a
 
 * Using Istio CA certificates (default), the information shown is from a secret named *istio-ca-secret*.
 * Using [Plug in CA certificates](https://istio.io/latest/docs/tasks/security/cert-management/plugin-ca-cert/), the information shown is from a secret named *cacerts*.
-* Using [DNS certificates](https://istio.io/latest/docs/tasks/security/cert-management/dns-cert/), the information shown is from reading many secrets found in Istio configuration.
+* Using [Custom CA with Kubernetes CSR](https://istio.io/latest/docs/tasks/security/cert-management/custom-ca-k8s/), the information shown is from a custom CA integrated with the Kubernetes CSR API.
 
 The following is an example of viewing the default case:
 


### PR DESCRIPTION
Update Certificate information indicators, removing 404 url, addingew custom CA from k8s

Note: I've some doubts adding the new URL, as this is a feature in development. But, if this is in the Istio docs, I guess it can be added also in Kiali.io

Fixes [#5192 ](https://github.com/kiali/kiali/issues/5192)

