### PR TITLE
Set release branch in case of no manual input

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:          
-        ref: ${{ github.event.inputs.release_branch }}      
+        ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
     - name: Prepare scripts
       run: |
@@ -103,7 +103,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:          
-        ref: ${{ github.event.inputs.release_branch }}    
+        ref: ${{ github.event.inputs.release_branch || github.ref_name }} 
         fetch-depth: 0
           
     - name: Configure git


### PR DESCRIPTION
Similar to the fix in the operator, although this wasn't an issue, because in the absence of the value, it uses the default branch (staging), but it's better to have a value just in case if in the future GH Actions implements some change in this behavior.