### PR TITLE
Update the relnotes script to generate Release notes

### DIFF
--- a/scripts/relnotes.py
+++ b/scripts/relnotes.py
@@ -56,16 +56,6 @@ query = """
                                }
                             }
                        }
-                       ...on PullRequest {
-                           title
-                           url
-                           state
-                           labels(first:10) {
-                                 nodes{
-                                       name
-                                 }
-                           }
-                       }
                      }
                 }
             }
@@ -108,7 +98,8 @@ print("\nRelease Notes for {}, Project: {}".format(version, projectName))
 print("Add the below text to: content/news/release-notes.adoc")
 print("------------Clip Below This Line----------------")
 print("## {}".format(version))
-print("Sprint Release: {}".format([releaseDate.group(1),"Unknown"][releaseDate is None]))
+if releaseDate:
+    print("Sprint Release: {}".format([releaseDate.group(1),"Unknown"][releaseDate is None]))
 
 print("\nFeatures:\n")
 


### PR DESCRIPTION
I was running this script using python 3.8.13 and I get information empty from the project information: 

```
scripts/relnotes.py v1.53 59 TOKEN
Traceback (most recent call last):
  File "scripts/relnotes.py", line 77, in <module>
    projectName = project["name"]
TypeError: 'NoneType' object is not subscriptable
```
The result of the query was: 

`{'data': {'organization': {'name': 'Kiali - Service Mesh Management for Istio', 'project': None}}}`

It looks like it was updated to use the object ProjectV2 (https://docs.github.com/en/issues/trying-out-the-new-projects-experience/using-the-api-to-manage-projects)

I have updated the script using ProjectV2 object, it gets the project information with the same parameter. 

Note: It retrieves the Issue items (Not the Pull requests) and it filters by the state CLOSED and MERGED (Even this is just for Pull Requests, I think).
