### PR TITLE
Use html proofer version 3.19.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN tar xzvf /hugo.tar.gz -C / \
 RUN npm -g -D install postcss postcss-cli autoprefixer
 
 # Install html-proofer
-RUN gem install html-proofer
+RUN gem install html-proofer -v 3.19.4
 
 # Confirm htmlproofer binary is available and show its version
 RUN htmlproofer --version


### PR DESCRIPTION
This PR just specifies the html-proofer version in the Dockerfile. It was upgraded to a major version (from 3 to 4), and
the compatibility is broken. While they are not addressed (https://github.com/kiali/kiali/issues/5313), this forces
to use the version 3.