### PR TITLE
Avoid commiting crd docs if there is nothing to commit

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -107,10 +107,17 @@ if [ "${GENERATE_DOCS}" == "true" ]; then
 
   echo "===== Generate the CRD schema documentation"
   make gen-crd-doc
-  git commit -am "Auto-generated CRD schema documentation"
 
-  echo "===== Push the branch [${STAGING_BRANCH}] to remote [${REMOTE_NAME}]"
-  git push ${REMOTE_NAME} ${STAGING_BRANCH}
+  if ! git commit -am "Auto-generated CRD schema documentation"; then
+    if [ "$(git status -s | wc -l)" != "0" ]; then
+      echo "ERROR! Failed to commit changes. Aborting."
+      exit 1
+    fi
+  else
+    echo "===== Push the branch [${STAGING_BRANCH}] to remote [${REMOTE_NAME}]"
+    git push ${REMOTE_NAME} ${STAGING_BRANCH}
+  fi
+
 fi
 
 echo "===== Create a new version branch named [${CURRENT_VERSION}] based on branch [${CURRENT_BRANCH}]"


### PR DESCRIPTION
This fix will check if there are changes to commit handling the exit code form the git commit command.

