### PR TITLE
(HTMLProofer) update parameters to be compatible with version 4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN tar xzvf /hugo.tar.gz -C / \
 RUN npm -g -D install postcss postcss-cli autoprefixer
 
 # Install html-proofer
-RUN gem install html-proofer -v 3.19.4
+RUN gem install html-proofer
 
 # Confirm htmlproofer binary is available and show its version
 RUN htmlproofer --version

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ URL_IGNORE:=$(URL_IGNORE)$(NEW_URLS)
 CONFIG='{\"enforce_https\": false,\"check_internal_hash\": false, \"check_external_hash\":false,\"ignore_empty_alt\":true}'
 .PHONY: validate-site
 validate-site: build-hugo
-	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer --assume-extension --enforce_https --check_internal_hash --check_external_hash --ignore_empty_alt --ignore_urls \"${URL_IGNORE}\" ./public"
+	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer ./public --assume-extension --allow-missing-href --ignore_missing_alt --check-external-hash --check_internal_hash --enforce-https false --ignore_urls \"${URL_IGNORE}\""
 	#${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer --assume-extension --enforce_https --check_internal_hash --check_external_hash --ignore_empty_alt --log_level=debug --ignore_urls \"${URL_IGNORE}\" ./public"
 	#${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer --swap_attributes ${CONFIG} ./public"
 

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,5 @@ URL_IGNORE:=$(URL_IGNORE)$(NEW_URLS)
 CONFIG='{\"enforce_https\": false,\"check_internal_hash\": false, \"check_external_hash\":false,\"ignore_empty_alt\":true}'
 .PHONY: validate-site
 validate-site: build-hugo
-	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer ./public --assume-extension --allow-missing-href --ignore_missing_alt --check-external-hash --check_internal_hash --enforce-https false --ignore_urls \"${URL_IGNORE}\""
-	#${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer --assume-extension --enforce_https --check_internal_hash --check_external_hash --ignore_empty_alt --log_level=debug --ignore_urls \"${URL_IGNORE}\" ./public"
-	#${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer --swap_attributes ${CONFIG} ./public"
+	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer ./public --assume_extension --allow_hash_href true --allow_missing_href true ignore_empty_alt true --ignore_missing_alt true --check-external-hash false --check_internal_hash false --enforce_https false --ignore_urls \"${URL_IGNORE}\""
 

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,10 @@ NEW_URLS=$(shell scripts/ignore_new_urls.sh 2> /dev/null)
 URL_IGNORE:=$(URL_IGNORE)$(NEW_URLS)
 
 ## validate-site: Builds the site and validates the pages. This is used for CI
+CONFIG='{\"enforce_https\": false,\"check_internal_hash\": false, \"check_external_hash\":false,\"ignore_empty_alt\":true}'
 .PHONY: validate-site
 validate-site: build-hugo
-	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer --assume-extension --check-external-hash --empty_alt_ignore --url-ignore \"${URL_IGNORE}\" ./public"
+	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer --assume-extension --enforce_https --check_internal_hash --check_external_hash --ignore_empty_alt --ignore_urls \"${URL_IGNORE}\" ./public"
+	#${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer --assume-extension --enforce_https --check_internal_hash --check_external_hash --ignore_empty_alt --log_level=debug --ignore_urls \"${URL_IGNORE}\" ./public"
+	#${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer --swap_attributes ${CONFIG} ./public"
 

--- a/Makefile
+++ b/Makefile
@@ -71,5 +71,5 @@ URL_IGNORE:=$(URL_IGNORE)$(NEW_URLS)
 ## validate-site: Builds the site and validates the pages. This is used for CI
 .PHONY: validate-site
 validate-site: build-hugo
-	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer ./public --assume_extension --allow_hash_href true --allow_missing_href true ignore_empty_alt true --ignore_missing_alt true --check_external_hash false --check_internal_hash false --enforce_https false --ignore_urls \"${URL_IGNORE}\""
+	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer ./public --assume_extension --allow_hash_href true --allow_missing_href true --ignore_empty_alt true --ignore_missing_alt true --check_external_hash false --check_internal_hash false --enforce_https false --ignore_urls \"${URL_IGNORE}\""
 

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ NEW_URLS=$(shell scripts/ignore_new_urls.sh 2> /dev/null)
 URL_IGNORE:=$(URL_IGNORE)$(NEW_URLS)
 
 ## validate-site: Builds the site and validates the pages. This is used for CI
-CONFIG='{\"enforce_https\": false,\"check_internal_hash\": false, \"check_external_hash\":false,\"ignore_empty_alt\":true}'
 .PHONY: validate-site
 validate-site: build-hugo
 	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer ./public --assume_extension --allow_hash_href true --allow_missing_href true ignore_empty_alt true --ignore_missing_alt true --check_external_hash false --check_internal_hash false --enforce_https false --ignore_urls \"${URL_IGNORE}\""

--- a/Makefile
+++ b/Makefile
@@ -72,5 +72,5 @@ URL_IGNORE:=$(URL_IGNORE)$(NEW_URLS)
 CONFIG='{\"enforce_https\": false,\"check_internal_hash\": false, \"check_external_hash\":false,\"ignore_empty_alt\":true}'
 .PHONY: validate-site
 validate-site: build-hugo
-	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer ./public --assume_extension --allow_hash_href true --allow_missing_href true ignore_empty_alt true --ignore_missing_alt true --check-external-hash false --check_internal_hash false --enforce_https false --ignore_urls \"${URL_IGNORE}\""
+	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer ./public --assume_extension --allow_hash_href true --allow_missing_href true ignore_empty_alt true --ignore_missing_alt true --check_external_hash false --check_internal_hash false --enforce_https false --ignore_urls \"${URL_IGNORE}\""
 


### PR DESCRIPTION
This will work from HTMLProofer version 4.3.

Fixes https://github.com/kiali/kiali/issues/5313