### PR TITLE
Add typhoeus to validation to control timeout and concurrency settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN gem install html-proofer
 # Confirm htmlproofer binary is available and show its version
 RUN htmlproofer --version
 
+# This allows us to increase timeouts, and avoid htmlproofer errors
 RUN gem install typhoeus
 
 # Confirm hugo binary is available and show its version

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,7 @@ RUN gem install html-proofer
 # Confirm htmlproofer binary is available and show its version
 RUN htmlproofer --version
 
+RUN gem install typhoeus
+
 # Confirm hugo binary is available and show its version
 RUN hugo version

--- a/Makefile
+++ b/Makefile
@@ -71,5 +71,4 @@ URL_IGNORE:=$(URL_IGNORE)$(NEW_URLS)
 ## validate-site: Builds the site and validates the pages. This is used for CI
 .PHONY: validate-site
 validate-site: build-hugo
-	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer ./public --assume_extension --allow_hash_href true --allow_missing_href true --ignore_empty_alt true --ignore_missing_alt true --check_external_hash false --check_internal_hash false --enforce_https false --ignore_urls \"${URL_IGNORE}\""
-
+	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer ./public --typhoeus '{\"connecttimeout\": 30}' --allow_hash_href true --allow_missing_href true --ignore_empty_alt true --ignore_missing_alt true --check_external_hash false --check_internal_hash false --enforce_https false --ignore_urls \"${URL_IGNORE}\""

--- a/Makefile
+++ b/Makefile
@@ -71,4 +71,4 @@ URL_IGNORE:=$(URL_IGNORE)$(NEW_URLS)
 ## validate-site: Builds the site and validates the pages. This is used for CI
 .PHONY: validate-site
 validate-site: build-hugo
-	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer ./public --typhoeus '{\"connecttimeout\": 30}' --allow_hash_href true --allow_missing_href true --ignore_empty_alt true --ignore_missing_alt true --check_external_hash false --check_internal_hash false --enforce_https false --ignore_urls \"${URL_IGNORE}\""
+	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "npm prune && hugo && htmlproofer ./public --typhoeus '{\"connecttimeout\": 50}' --allow_hash_href true --allow_missing_href true --ignore_empty_alt true --ignore_missing_alt true --check_external_hash false --check_internal_hash false --enforce_https false --ignore_urls \"${URL_IGNORE}\""


### PR DESCRIPTION
There are many status code 0 errors from the validation (See last validations https://github.com/kiali/kiali.io/pull/565)
With [typhoeus](https://github.com/typhoeus/typhoeus#other-curl-options) it is possible to control parameters like the time out. 

The tool is documented in the html-proofer documentation: 
https://github.com/gjtorikian/html-proofer#readme 