### PR TITLE
be more explicit about the setting names

### DIFF
--- a/content/en/docs/FAQ/istio-component-status.md
+++ b/content/en/docs/FAQ/istio-component-status.md
@@ -7,17 +7,17 @@ description: "Questions about Kiali's Istio infrastructure health checks."
 ### How can I add one component to the list?
 
 If you are interested in adding one more component to the Istio Component Status tooltip, you have the option to add one new component into the
-[Kiali CR](/docs/configuration/kialis.kiali.io), under the `external_services.istio.component_status` field.
+[Kiali CR](/docs/configuration/kialis.kiali.io), under the `spec.external_services.istio.component_status` field.
 
 For each component there, you will need to specify the `app` label of the deployment's pods, the namespace and whether is a core component or add-on.
 
 
 ### One component is 'Not found' but I can see it running. What can I do?
 
-The first thing you should do is check into the Kiali CR for the `istio.component_status` field.
+The first thing you should do is check the Kiali CR for the `spec.external_services.istio.component_status` field (see the [reference documentation here](/docs/configuration/kialis.kiali.io/#.spec.external_services.istio.component_status))
 
 Kiali looks for a Deployment for which its pods have the `app` label with the specified value in the CR, and lives in that namespace.
-The `app` label name may be changed from the default (app) and it is specified in the `istio_labels.app_label_name` in the [Kiali CR](/docs/configuration/kialis.kiali.io).
+The `app` label name may be changed from the default (app) and it is specified in the `spec.istio_labels.app_label_name` in the [Kiali CR](/docs/configuration/kialis.kiali.io/#.spec.istio_labels.app_label_name).
 
 Ensure that you have specified correctly the namespace and that the deployment's pod template has the specified label.
 
@@ -45,5 +45,5 @@ external_services:
     url: "http://prometheus.istio-system:9090"
 ```
 
-Please check the [Kiali CR Reference](/docs/configuration/kialis.kiali.io) for more information. Each external service component has its own `health_check_url` and `is_core` setting to tailor the experience in the Istio Component Status feature.
+Please read the [Kiali CR Reference](/docs/configuration/kialis.kiali.io) for more information. Each external service component has its own `health_check_url` and `is_core` setting to tailor the experience in the Istio Component Status feature.
 


### PR DESCRIPTION
As it is, people are confused because we do not specify the full path of the setting.
This is in response to https://github.com/kiali/kiali/discussions/5381

netlify: https://deploy-preview-571--kiali.netlify.app/docs/faq/istio-component-status/