### PR TITLE
use 'create token' command to generate token

### DIFF
--- a/content/en/docs/FAQ/authentication.md
+++ b/content/en/docs/FAQ/authentication.md
@@ -8,8 +8,25 @@ description: "Questions about authentication strategy or configuration."
 
 When configuring Kiali to use the `token` auth strategy, it requires users to log into Kiali as a specific user via the user's service account token. Thus, in order to log into Kiali you must provide a valid Kubernetes token.
 
-To obtain a token for the kiali-service-account in the istio-system namespace, issue this kubectl command:
+Note that the following examples assume you installed Kiali in the `istio-system` namespace.
+
+**For kubernetes prior to v1.24**
+
+You can extract a service account's token from the secret that was created for you when you created the service account.
+
+For example, if you want to log into Kiali using Kiali's own service account, you can get the token like this:
+
+```
+kubectl get secret -n istio-system $(kubectl get sa kiali-service-account -n istio-system -o "jsonpath={.secrets[0].name}") -o jsonpath={.data.token} | base64 -d
+```
+
+**For kubernetes v1.24+**
+
+You can request a short lived token for a service account by issuing the following command:
+
 > kubectl -n istio-system create token kiali-service-account
+
+**Using the token**
 
 Once you obtain the token, you can go to the Kiali login page and copy-and-paste that token into the token field. At this point, you have logged into Kiali with the same permissions as that of the Kiali server itself (note: this gives the user the permission to see everything).
 

--- a/content/en/docs/FAQ/authentication.md
+++ b/content/en/docs/FAQ/authentication.md
@@ -10,7 +10,7 @@ When configuring Kiali to use the `token` auth strategy, it requires users to lo
 
 Note that the following examples assume you installed Kiali in the `istio-system` namespace.
 
-**For kubernetes prior to v1.24**
+**For Kubernetes prior to v1.24**
 
 You can extract a service account's token from the secret that was created for you when you created the service account.
 

--- a/content/en/docs/FAQ/authentication.md
+++ b/content/en/docs/FAQ/authentication.md
@@ -20,7 +20,7 @@ For example, if you want to log into Kiali using Kiali's own service account, yo
 kubectl get secret -n istio-system $(kubectl get sa kiali-service-account -n istio-system -o "jsonpath={.secrets[0].name}") -o jsonpath={.data.token} | base64 -d
 ```
 
-**For kubernetes v1.24+**
+**For Kubernetes v1.24+**
 
 You can request a short lived token for a service account by issuing the following command:
 

--- a/content/en/docs/FAQ/authentication.md
+++ b/content/en/docs/FAQ/authentication.md
@@ -24,7 +24,9 @@ kubectl get secret -n istio-system $(kubectl get sa kiali-service-account -n ist
 
 You can request a short lived token for a service account by issuing the following command:
 
-> kubectl -n istio-system create token kiali-service-account
+```
+kubectl -n istio-system create token kiali-service-account
+```
 
 **Using the token**
 

--- a/content/en/docs/FAQ/authentication.md
+++ b/content/en/docs/FAQ/authentication.md
@@ -8,15 +8,8 @@ description: "Questions about authentication strategy or configuration."
 
 When configuring Kiali to use the `token` auth strategy, it requires users to log into Kiali as a specific user via the user's service account token. Thus, in order to log into Kiali you must provide a valid Kubernetes token.
 
-You can extract a service account's token from the secret that was created for you when you created the service account.
-
-For example, if you want to log into Kiali using Kiali's own service account, you can get the token like this:
-
-```
-kubectl get secret -n istio-system $(kubectl get sa kiali-service-account -n istio-system -o "jsonpath={.secrets[0].name}") -o jsonpath={.data.token} | base64 -d
-```
-
-Note that this example assumes you installed Kiali in the `istio-system` namespace.
+To obtain a token for the kiali-service-account in the istio-system namespace, issue this kubectl command:
+> kubectl -n istio-system create token kiali-service-account
 
 Once you obtain the token, you can go to the Kiali login page and copy-and-paste that token into the token field. At this point, you have logged into Kiali with the same permissions as that of the Kiali server itself (note: this gives the user the permission to see everything).
 


### PR DESCRIPTION
The secret that was referenced in these instructions did not exist for me. But I had used the `create token` command before to do this same thing for the kubernetes-dashboard, so I figured it would work for kiali, and it did!