### PR TITLE
Release Notes v1.61.0

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -231,7 +231,7 @@ enable = false
   url = "https://v1-58.kiali.io"
 
 [[ params.versions ]]
-  version = "v1.57"
+  version = "v1.57 [ossm v2.3]"
   url = "https://v1-57.kiali.io"
 
 [[ params.versions ]]
@@ -263,24 +263,12 @@ enable = false
   url = "https://v1-50.kiali.io"
 
 [[ params.versions ]]
-  version = "v1.49"
+  version = "v1.49 [istio v1.13]"
   url = "https://v1-49.kiali.io"
 
 [[ params.versions ]]
   version = "v1.48 [ossm v2.2]"
   url = "https://v1-48.kiali.io"
-
-[[ params.versions ]]
-  version = "v1.47"
-  url = "https://v1-47.kiali.io"
-
-[[ params.versions ]]
-  version = "v1.46"
-  url = "https://v1-46.kiali.io"
-
-[[ params.versions ]]
-  version = "v1.45"
-  url = "https://v1-45.kiali.io"
 
 [[ params.versions ]]
   version = "v1.44 [istio v1.12]"
@@ -293,14 +281,6 @@ enable = false
 [[params.versions]]
   version = "v1.36 [ossm v2.1]"
   url = "https://pre-v1-41.kiali.io/documentation/v1.36"
-
-[[params.versions]]
-  version = "v1.24 [ossm v2.0]"
-  url = "https://pre-v1-41.kiali.io/documentation/v1.24"
-
-[[params.versions]]
-  version = "v1.12 [ossm v1.1]"
-  url = "https://pre-v1-41.kiali.io/documentation/v1.12"
 
 [[params.versions]]
   version = "staging"

--- a/content/en/docs/Installation/installation-guide/prerequisites.md
+++ b/content/en/docs/Installation/installation-guide/prerequisites.md
@@ -43,7 +43,7 @@ supported Istio versions.
 |1.16   |1.59.1 or later   |   |
 |1.15   |1.55.1 to 1.59.0  |   |
 |1.14   |1.50.0 to 1.54.x  |   |
-|1.13   |1.45.1 to 1.49.x  |   |
+|1.13   |1.45.1 to 1.49.x  |Istio 1.13 is out of support. |
 |1.12   |1.42.0 to 1.44.x  |Istio 1.12 is out of support. |
 |1.11   |1.38.1 to 1.41.x  |Istio 1.11 is out of support. |
 |1.10   |1.34.1 to 1.37.x  |Istio 1.10 is out of support. |

--- a/content/en/news/release-notes.md
+++ b/content/en/news/release-notes.md
@@ -6,6 +6,20 @@ weight: 1
 
 For additional information check our [sprint demo videos](https://www.youtube.com/channel/UCcm2NzDN_UCZKk2yYmOpc5w) and [blogs](https://medium.com/kialiproject).
 
+## 1.61.0
+Sprint Release: Dec 16
+
+Features:
+
+* [Kiali SA should use view-only role unless using anonymous strategy](https://github.com/kiali/kiali/issues/5611)
+* [openshift auth timeout customizations](https://github.com/kiali/kiali/issues/5650)
+
+Fixes:
+
+* [Kiali distroless version breaks external https calls](https://github.com/kiali/kiali/issues/5643)
+* [Redirect Loop on OpenID Connect Failures](https://github.com/kiali/kiali/issues/5663)
+* [Update GH pipelines removing deprecated warnings](https://github.com/kiali/kiali/issues/5646)
+
 ## 1.60.0
 Sprint Release: Nov 25
 


### PR DESCRIPTION
Updated relnotes:
https://deploy-preview-614--kiali.netlify.app/news/release-notes/#1610

Added 1.13 out of support message:
https://deploy-preview-614--kiali.netlify.app/docs/installation/installation-guide/prerequisites/#version-compatibility

Pruned the Releases Dropdown list:
https://deploy-preview-614--kiali.netlify.app/