### PR TITLE
Remove IRC link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -199,11 +199,6 @@ enable = false
 	icon = "fab fa-youtube"
         desc = "Kiali channel on YouTube"
 [[params.links.user]]
-	name = "Kiali on IRC"
-	url = "web.libera.chat?channels=#kiali"
-	icon = "fas fa-comment"
-        desc = "Kiali on IRC"
-[[params.links.user]]
 	name = "Kiali community calendar"
 	url = "https://bit.ly/kiali-calendar"
 	icon = "fas fa-calendar"


### PR DESCRIPTION
Remove IRC button from kiali.io page. Fixes https://github.com/kiali/kiali/issues/5739

Note @ferhoyos  - as a convention for kiali.io PRs, we add links for the relevant pages to make it easy for the reviewer:

- affects bottom of landing page and Community page

https://deploy-preview-624--kiali.netlify.app/
https://deploy-preview-624--kiali.netlify.app/community/
