### PR TITLE
manual operator reconciliation and new helm requirement

### DIFF
--- a/content/en/docs/Installation/installation-guide/creating-updating-kiali-cr.md
+++ b/content/en/docs/Installation/installation-guide/creating-updating-kiali-cr.md
@@ -4,9 +4,15 @@ description: "Creating and updating the Kiali CR."
 weight: 40
 ---
 
-The Kiali Operator watches the _Kiali Custom Resource_ ([Kiali CR](/docs/configuration/kialis.kiali.io)), a YAML file
-that holds the deployment configuration. Creating, updating, or removing a
+The Kiali Operator watches the _Kiali Custom Resource_ ([Kiali CR](/docs/configuration/kialis.kiali.io)), a custom resource that  contains the Kiali Server deployment configuration. Creating, updating, or removing a
 Kiali CR will trigger the Kiali Operator to install, update, or remove Kiali.
+
+{{% alert color="success" %}}
+If you want the operator to re-process the Kiali CR (called "reconciliation") without having to change the Kiali CR's `spec` fields, you can modify any annotation on the Kiali CR itself. This will trigger the operator to reconcile the current state of the cluster with the desired state defined in the Kiali CR, modifying cluster resources if necessary to get them into their desired state. Here is an example illustrating how you can modify an annotation on a Kiali CR:
+```
+$ kubectl annotate kiali my-kiali -n istio-system --overwrite kiali.io/manual-reconcile="$(date)"
+```
+{{% /alert %}}
 
 The Operator provides comprehensive defaults for all properties of the Kiali
 CR. Hence, the minimal Kiali CR does not have a `spec`:

--- a/content/en/docs/Installation/installation-guide/install-with-helm.md
+++ b/content/en/docs/Installation/installation-guide/install-with-helm.md
@@ -32,7 +32,7 @@ Make sure you have the `helm` command available by following the
 [Helm installation docs](https://helm.sh/docs/intro/install/).
 
 {{% alert color="warning" %}}
-The Kiali Helm Charts have been tested only against Helm version 3. There is no guarantee that previous versions will work.
+The Kiali Helm Charts have been tested only against Helm version 3.10. There is no guarantee that previous versions will work.
 {{% /alert %}}
 
 ## Adding the Kiali Helm Charts repository


### PR DESCRIPTION
Document that the helm charts were tested on Helm 3.10 and earlier versions might not work. 3.5 definitely does not work for the server helm chart.

Document that you can trigger a reconciliation on annotation modification. This feature was introduced in https://github.com/kiali/kiali/issues/5738

Netlify links:
* https://deploy-preview-626--kiali.netlify.app/docs/installation/installation-guide/creating-updating-kiali-cr/
* https://deploy-preview-626--kiali.netlify.app/docs/installation/installation-guide/install-with-helm/ (mentions `Helm 3.10` - that was the only change)