### PR TITLE
Update release notes and compatibility chart due to backport releases

### DIFF
--- a/content/en/docs/Installation/installation-guide/prerequisites.md
+++ b/content/en/docs/Installation/installation-guide/prerequisites.md
@@ -40,10 +40,10 @@ supported Istio versions.
 
 |<div style="width:50px">Istio</div>|<div style="width:125px">Kiali</div>|Notes|
 |-------|------------------|---|
-|1.17   |1.63.1 or later   |   |
-|1.16   |1.59.1 to 1.63.0  |   |
+|1.17   |1.63.2 or later   |Avoid 1.63.0,1.63.1 due to a regression. |
+|1.16   |1.59.1 to 1.63.2  |Avoid 1.62.0,1.63.0,1.63.1 due to a regression. |
 |1.15   |1.55.1 to 1.59.0  |   |
-|1.14   |1.50.0 to 1.54.x  |   |
+|1.14   |1.50.0 to 1.54.x  |Istio 1.14 is out of support. |
 |1.13   |1.45.1 to 1.49.x  |Istio 1.13 is out of support. |
 |1.12   |1.42.0 to 1.44.x  |Istio 1.12 is out of support. |
 |1.11   |1.38.1 to 1.41.x  |Istio 1.11 is out of support. |

--- a/content/en/news/release-notes.md
+++ b/content/en/news/release-notes.md
@@ -6,8 +6,8 @@ weight: 1
 
 For additional information check our [sprint demo videos](https://www.youtube.com/channel/UCcm2NzDN_UCZKk2yYmOpc5w) and [blogs](https://medium.com/kialiproject).
 
-## 1.63.0
-Sprint Release: Jan 27
+## 1.63.2
+Sprint Release: Feb 02, 2023
 
 Features:
 
@@ -37,13 +37,14 @@ Fixes:
 Notes:
 
 * Helm 3.10 is now required to run the Helm Charts.
+* To avoid a known performance degradation, update to v1.63.2 (or later) from earlier revisions of v1.63.
 
 Deprecations:
 
 * [The deprecated support for OpenID's _implicit flow_ has now been removed.](https://github.com/kiali/kiali/issues/4705) If necessary, you must switch to using the more secure _authorization code flow_.
 
-## 1.62.0
-Sprint Release: Jan 06, 2023
+## 1.62.1
+Sprint Release: Feb 02, 2023
 
 Features:
 
@@ -55,6 +56,10 @@ Fixes:
 
 * [Kiali may prevent istiod from becoming ready on initial startup of istiod pod](https://github.com/kiali/kiali/issues/5669)
 * [Kiali errors out loading workload graph in 'default' namespace ](https://github.com/kiali/kiali/issues/5696)
+
+Notes:
+
+* To avoid a known performance degradation, update to v1.62.1 (or later) from v1.62.0.
 
 Deprecations:
 


### PR DESCRIPTION
Update release notes and compatibility chart due to backport release fixing 5784 regression

https://deploy-preview-630--kiali.netlify.app/docs/installation/installation-guide/prerequisites/#version-compatibility
https://deploy-preview-630--kiali.netlify.app/news/release-notes/#1632
https://deploy-preview-630--kiali.netlify.app/news/release-notes/#1621
https://github.com/kiali/kiali/releases/tag/v1.63.2
https://github.com/kiali/kiali/releases/tag/v1.62.1