### PR TITLE
Rework RBAC documentation

### DIFF
--- a/content/en/docs/Configuration/authentication/_index.md
+++ b/content/en/docs/Configuration/authentication/_index.md
@@ -3,11 +3,11 @@ title: "Authentication Strategies"
 description: "Choosing and configuring the appropriate authentication strategy."
 ---
 
-Kiali supports five authentication mechanisms:
+Kiali supports five authentication mechanisms.
 
 * The default authentication strategy for OpenShift clusters is `openshift`.
 * The default authentication strategy for all other Kubernetes clusters is `token`.
 
-All mechanisms other than `anonymous` support [Role-based access control]({{<relref "../rbac" >}}).
+All mechanisms other than `anonymous` support [limiting per-user namespace access control]({{<relref "../rbac" >}}).
 
 Read the dedicated page of each authentication strategy to learn more.

--- a/content/en/docs/Configuration/authentication/header.md
+++ b/content/en/docs/Configuration/authentication/header.md
@@ -10,17 +10,14 @@ weight: 20
 The `header` strategy assumes a reverse proxy is in front of Kiali, such as 
 OpenUnison or OAuth2 Proxy, injecting the user's identity into each request to
 Kiali as an `Authorization` header.  This token can be an OpenID Connect
-token or any other token the cluster recognizes.  All requests to Kubernetes
-will be made with this token, allowing Kiali to use the user's own RBAC 
-context.
+token or any other token the cluster recognizes.
 
 In addition to a user token, the `header` strategy supports impersonation
 headers.  If the impersonation headers are present in the request, then Kiali
 will act on behalf of the user specified by the impersonation (assuming the
 token supplied in the `Authorization` header is authorized to do so).
 
-The `header` strategy takes advantage of the cluster's RBAC. See the
-[Role-based access control documentation]({{< relref "../rbac" >}}) for more details.
+The `header` strategy allows for [namespace access control]({{< relref "../rbac" >}}).
 
 ## Set-up
 

--- a/content/en/docs/Configuration/authentication/openid.md
+++ b/content/en/docs/Configuration/authentication/openid.md
@@ -15,7 +15,7 @@ third-party system.
 If your
 [Kubernetes cluster is also integrated with your OpenId provider](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens),
 then Kiali's `openid` strategy can offer 
-[namespace access control]({{< relref "../rbac" >}}) for more details.
+[namespace access control]({{< relref "../rbac" >}}).
 
 Kiali only supports the _authorization code flow_ of the [OpenId Connect spec](https://openid.net/connect/).
 

--- a/content/en/docs/Configuration/authentication/openid.md
+++ b/content/en/docs/Configuration/authentication/openid.md
@@ -14,9 +14,8 @@ third-party system.
 
 If your
 [Kubernetes cluster is also integrated with your OpenId provider](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens),
-then Kiali's `openid` strategy can offer role-based access control (RBAC) through the
-[Kubernetes authorization mechanisms](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). See the
-[RBAC documentation]({{< relref "../rbac" >}}) for more details.
+then Kiali's `openid` strategy can offer 
+[namespace access control]({{< relref "../rbac" >}}) for more details.
 
 Kiali only supports the _authorization code flow_ of the [OpenId Connect spec](https://openid.net/connect/).
 
@@ -26,10 +25,10 @@ The [Kiali's signing key]({{< relref "session-configs" >}}) needs to be 16, 24
 or 32 byte long. If you install Kiali via the operator and don't set a custom
 signing key, the operator should create a 16 byte long signing key.
 
-If you *_don't need_* RBAC support, you can use any
+If you *_don't need_* namespace access control support, you can use any
 working OpenId Server where Kiali can be configured as a client application.
 
-If you *_do need_* RBAC support, you need either:
+If you *_do need_* namespace access control support, you need either:
 
 * A [Kubernetes cluster configured with OpenID connect integration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens),
 which results in the API server accepting tokens issued by your identity provider.
@@ -48,7 +47,7 @@ strategy by using
 reverse proxy that handles the OpenID authentication and forwards the
 authenticated requests to the Kubernetes API.
 
-## Set-up with RBAC support {#setup-with-rbac}
+## Set-up with namespace access control support {#setup-with-rbac}
 
 Assuming you already have a working Kubernetes cluster with OpenId integration
 (or a working alternative like `kube-oidc-proxy`), you should already had
@@ -114,7 +113,7 @@ attribute is the URI of the reverse proxy or cluster API replacement (only
 HTTPS is allowed). The `api_proxy_ca_data` is the public certificate authority
 file encoded in a base64 string, to trust the secure connection.
 
-## Set-up with no RBAC support
+## Set-up with no namespace access control support
 
 Register Kiali as a client application in your OpenId Server. Use the root path
 of your Kiali instance as the callback URL. If the OpenId Server provides you a
@@ -144,7 +143,7 @@ spec:
 ```
 
 {{% alert color="warning" %}}
-As RBAC is disabled, all users logging into Kiali
+As namespace access control is disabled, all users logging into Kiali
 will share the same cluster-wide privileges.
 {{% /alert %}}
 
@@ -164,10 +163,11 @@ spec:
       username_claim: "email"
 ```
 
-If you enabled RBAC, you will want the `username_claim` attribute to match the
-`--oidc-username-claim` flag used to start the Kubernetes API server, or the
-equivalent option if you are using a replacement or reverse proxy of the API
-server. Else, any user-friendly claim will be OK as it is purely informational.
+If you enabled namespace access control, you will want the `username_claim`
+attribute to match the `--oidc-username-claim` flag used to start the
+Kubernetes API server, or the equivalent option if you are using a replacement
+or reverse proxy of the API server. Else, any user-friendly claim will be OK as
+it is purely informational.
 
 ### Configuring requested scopes {#configure-scopes}
 
@@ -406,7 +406,7 @@ refresh your Kiali Pod to _set_ the Secret if you add the Secret after the Kiali
 {{% alert color="warning" %}}
 The OpenID authentication strategy can be used
 with Azure Kubernetes Service (AKS) and Azure Active Directory (AAD) with Kiali
-versions 1.33 and later. Prior Kiali versions do not support RBAC on Azure.
+versions 1.33 and later. Prior Kiali versions do not support namespace access control on Azure.
 {{% /alert %}}
 
 AKS has support for a feature named _AKS-managed Azure Active Directory_, which
@@ -420,7 +420,7 @@ rather than via the [Kubernetes OpenID Connect Tokens authentication](https://ku
 (see [the Azure AD integration section in AKS Concepts documentation](https://docs.microsoft.com/en-us/azure/aks/concepts-identity#azure-ad-integration)).
 Because of this difference, authentication in AKS behaves slightly different from a standard
 OpenID setup, but Kiali's OpenID authentication strategy can still be used with
-full RBAC support by following the next steps.
+namespace access control support by following the next steps.
 
 First, enable the AAD integration on your AKS cluster. See the
 [official AKS documentation to learn how](https://docs.microsoft.com/en-us/azure/aks/managed-aad).
@@ -434,7 +434,7 @@ Create a web application for Kiali in your Azure AD panel:
 2. Go to _Certificates & secrets_ and create a client secret.
    1. After creating the client secret, take note of the provided secret. Create a
    Kubernetes secret in your cluster as mentioned in the [Set-up
-   with RBAC support](#setup-with-rbac) section. Please, note that the suggested name for the
+   with namespace access control support](#setup-with-rbac) section. Please, note that the suggested name for the
    Kubernetes Secret is `kiali`. If you want to customize the secret name, you
    will have to specify your custom name in the Kiali CR. See: [secret_name in Kial CR Reference](/docs/configuration/kialis.kiali.io/#.spec.deployment.secret_name).
 3. Go to _API Permissions_ and press the _Add a permission_ button. In the new page that appears, switch to the

--- a/content/en/docs/Configuration/authentication/openshift.md
+++ b/content/en/docs/Configuration/authentication/openshift.md
@@ -15,9 +15,7 @@ redirected to the login page of the OpenShift console. Once the user provides
 his OpenShift credentials, he will be redireted back to Kiali and will be
 logged in if the user has enough privileges.
 
-The `openshift` strategy takes advantage of the cluster's RBAC. See the
-[Role-based access control documentation]({{< relref "../rbac" >}}) for more
-details.
+The `openshift` strategy supports [namespace access control]({{< relref "../rbac" >}}).
 
 ## Set-up
 

--- a/content/en/docs/Configuration/authentication/token.md
+++ b/content/en/docs/Configuration/authentication/token.md
@@ -11,8 +11,7 @@ The `token` authentication strategy allows a user to login to Kiali using the
 token of a Kubernetes ServiceAccount. This is similar to the
 [login view of Kubernetes Dashboard](https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/README.md#login-view).
 
-The `token` strategy takes advantage of the cluster's RBAC. See the [Role-based access control documentation]({{< relref "../rbac" >}})
-for more details.
+The `token` strategy supports [namespace access control]({{< relref "../rbac" >}}).
 
 ## Set-up
 

--- a/content/en/docs/Configuration/rbac.md
+++ b/content/en/docs/Configuration/rbac.md
@@ -1,5 +1,5 @@
 ---
-title: "Namespace Authorization"
+title: "Namespace access control"
 description: "Configuring per-user authorized namespaces."
 ---
 

--- a/content/en/docs/Configuration/rbac.md
+++ b/content/en/docs/Configuration/rbac.md
@@ -6,7 +6,7 @@ description: "Configuring per-user authorized namespaces."
 ## Introduction
 
 In authentication strategies other than `anonymous` Kiali supports limiting the
-namespaces that are accessible in a per-user basis. The `anonymous`
+namespaces that are accessible on a per-user basis. The `anonymous`
 authentication strategy does not support this, although you can still limit
 privileges when using an OpenShift cluster. See the [access control section in
 Anonymous strategy]({{< relref "./authentication/anonymous#access-control" >}}).
@@ -43,7 +43,7 @@ Kiali is going to reject login to users that aren't authorized to see any namesp
 ## Granting access to namespaces
 
 In general, Kiali will give _read_ access to namespaces where the logged in
-user is granted to _"GET"_ its definition -- i.e. the user is allowed to do a
+user is allowed to _"GET"_ its definition -- i.e. the user is allowed to do a
 `GET` call to the `api/v1/namespaces/{namespace-name}` endpoint of the cluster
 API. Users granted the _LIST_ verb would get access to all namespaces of the
 cluster (that's a `GET` call to the `api/v1/namespaces` endpoint of the cluster
@@ -159,7 +159,7 @@ authorization system.
 Changing resources in the cluster can be a sensitive operation. Because of
 this, the logged in user will need to be given the needed privileges to perform
 any updates through Kiali. The following `ClusterRole` contains all write
-privileges that may used in Kiali:
+privileges that may be used in Kiali:
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -203,7 +203,7 @@ rules:
 ```
 
 {{% alert color="info" %}}
-If needed, you can reduce the set of write privileges to prevent users changing
+If needed, you can reduce the set of write privileges to prevent users from changing
 unwanted resources.
 {{% /alert %}}
 

--- a/content/en/docs/Configuration/rbac.md
+++ b/content/en/docs/Configuration/rbac.md
@@ -1,120 +1,138 @@
 ---
-title: "Role-based access control"
-description: "Configuring RBAC based on the authentication strategy."
+title: "Namespace Authorization"
+description: "Configuring per-user authorized namespaces."
 ---
 
 ## Introduction
 
-Kiali supports role-based access control (RBAC) when using any authentication strategy other than `anonymous`.
+In authentication strategies other than `anonymous` Kiali supports limiting the
+namespaces that are accessible in a per-user basis. The `anonymous`
+authentication strategy does not support this, although you can still limit
+privileges when using an OpenShift cluster. See the [access control section in
+Anonymous strategy]({{< relref "./authentication/anonymous#access-control" >}}).
 
-Although the `anonymous` strategy does not support RBAC, you can still limit privileges if using an OpenShift cluster. See the
-[access control section in Anonymous strategy]({{< relref "./authentication/anonymous#access-control" >}}).
+To authorize namespaces, the standard `Roles` resources (or `ClusterRoles`)
+and `RoleBindings` resources (or `ClusterRoleBindings`) are used.
 
-Kiali uses the RBAC capabilities of the underlying cluster. Thus, RBAC is
-accomplished by using the standard RBAC features of the cluster, which is
-through ClusterRoles, ClusterRoleBindings, Roles and RoleBindings resources.
-Read the [Kubernetes RBAC documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
-for details. If you are using OpenShift, read the
-[OpenShift RBAC documentation](https://docs.openshift.com/container-platform/4.5/authentication/using-rbac.html).
+{{% alert color="info" %}}
+The [Kubernetes RBAC documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+describe how to use _Roles, ClusterRoles, RoleBindings_ and _ClusterRoleBindings_
+resources. If you are using OpenShift, read the
+[OpenShift RBAC documentation](https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html).
+{{% /alert %}}
 
-In general, Kiali will give access to the resources granted to the account used
-to login. Specifically, depending on the authentication strategy, this
-translates to:
+Kiali can only restrict or grant _read_ access to namespaces as a whole. So,
+keep in mind that while the RBAC capabilities of the cluster are used to give
+access, Kiali won't offer the same privilege granularity that the cluster
+supports. For example, a user that does not have privileges to get Kubernetes
+`Deployments` via typical tools (e.g. `kubectl`) would still be able to get
+some details of Deployments through Kiali when [listing Workloads or when
+viewing detail pages]({{<relref "../features/details">}}), or in the
+[Graph]({{<relref "../features/topology">}}).
 
-|Authentication Strategy|Access To|
-|------------|------------------|
-|`header`    |resources granted to the user of the header-supplied token|
-|`openid`    |resources granted to the user of the third-party authentication system|
-|`openshift` |resources granted to the OpenShift user|
-|`token`     |resources granted to the ServiceAccount token used to login|
+Some features allow creating or changing resources in the cluster (for example,
+[the Wizards]({{<relref "../features/wizards" >}})). For these _write_
+operations which may be sensitive, the users will need to have the required
+privileges in the cluster to perform updates - i.e. the cluster RBAC takes
+effect.
 
-For example, if you are using the `token` strategy, you would grant
-cluster-wide privileges to a ServiceAccount with this command:
+{{% alert color="warning" %}}
+Kiali is going to reject login to users that aren't authorized any namespace.
+{{% /alert %}}
 
-```
-$ kubectl create clusterrolebinding john-binding --clusterrole=kiali --serviceaccount=mynamespace:john
-```
+## Granting or restricting access to namespaces
 
-and if you are using `openshift` or `openid` strategies, you could assign
-privileges with any of these commands:
+In general, Kiali will give _read_ access to namespaces where the logged in
+user is granted to _"GET"_ its definition -- i.e. the user is allowed to do a
+`GET` call to the `api/v1/namespaces/{namespace-name}` endpoint of the cluster
+API. Users granted the _LIST_ verb would get access to all namespaces of the
+cluster (that's a `GET` call to the `api/v1/namespaces` endpoint of the cluster
+API).
 
-```
-$ kubectl create rolebinding john-openid-binding --clusterrole=kiali --user="john@example.com" --namespace=mynamespace
-$ oc adm policy add-role-to-user kiali john -n mynamespace # For OpenShift clusters
-```
+You, probably, will want to have this small `ClusterRole` to help you in
+authorizing individual namespaces in Kiali:
 
-Please read your cluster RBAC documentation to learn how to assign privileges.
-
-## Minimum required privileges to login
-
-The `get namespace` privilege in some namespace is the minimum privilege needed
-in order to be able to login to Kiali. This means you need the following
-minimal `Role` bound to the user that wants to login:
-
-```
+```yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
+metadata:
+  name: kiali-namespace-authorization
 rules:
 - apiGroups: [""]
   resources:
   - namespaces
+  - pods/log
   verbs:
   - get
+``` 
+
+This `ClusterRole` can be created with the following command:
+
+```bash
+$ kubectl create clusterrole kiali-namespace-authorization --verb=get --resource=namespaces,pods/log
 ```
 
-This minimal `Role` will allow a user to login. Kiali may work partially, but
-some pages may be blank or show erroneous information, and errors will be
-logged constantly. You will need a broader set of privileges so that Kiali
-works fine.
-
-## Privileges required for Kiali to work correctly
-
-The default installation of Kiali creates a `ClusterRole` with the needed
-privileges to take the most advantage of all Kiali features. Inspect the
-privileges with
-
-```
-kubectl describe clusterrole kiali
-```
-
-{{% alert color="warning" %}}
-If you installed Kiali with `view_only_mode: true`
-option, the `ClusterRole` will be named `kiali-viewer` instead of `kiali`.
+{{% alert color="info" %}}
+The `pods/log` privilege is needed for the [pods Logs view]({{<relref "../features/details#logs">}}).
+Since logs are potentially sensitive, you could remove that privilege if you
+don't want users to be able to fetch pod logs.
 {{% /alert %}}
 
-Alternatively, check in the Kiali Operator source code. See either the
-[Kubernetes role.yaml template file](https://github.com/kiali/kiali-operator/blob/v1.42.0/roles/default/kiali-deploy/templates/kubernetes/role.yaml), or the
-[OpenShift role.yaml template file](https://github.com/kiali/kiali-operator/blob/v1.42.0/roles/default/kiali-deploy/templates/openshift/role.yaml).
+Once you have created this `ClusterRole`, you would authorize a namespace
+`foobar` to user `john` with the following `RoleBinding`:
 
-You can use this `ClusterRole` to assign privileges to users requiring access
-to Kiali. You can assign privileges either in one namespace, which will result in
-users being able to see only resources in that namespace; or assign
-cluster-wide privileges.
-
-For example, to assign privileges to the `john` user and limiting access to the
-`myApp` namespace, you could run either:
-
-```
-$ kubectl create rolebinding john-binding --clusterrole=kiali --user="john" --namespace=myApp
-$ oc adm policy add-role-to-user kiali john -n myApp # For OpenShift clusters
-```
-
-But if you need to assign cluster-wide privileges, you could run either:
-
-```
-$ kubectl create clusterrolebinding john-admin-binding --clusterrole=kiali --user="john"
-$ oc adm policy add-cluster-role-to-user kiali john # For OpenShift clusters
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: authorize-ns-foobar-to-john
+  namespace: foobar
+subjects:
+- kind: User
+  name: john
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: kiali-namespace-authorization # The name of the ClusterRole created previously
+  apiGroup: rbac.authorization.k8s.io
 ```
 
-In case you need to assign a more limited set of privileges than the ones
-present in the Kiali `ClusterRole`, create your own `ClusterRole` or `Role`
-based off the privileges in Kiali's `ClusterRole` and remove the privileges you
-want to ban. You must understand that some Kiali features may not work properly
-because of the reduced privilege set.
+This `RoleBinding` can be created with the following command:
 
-{{% alert color="warning" %}}
-Do not edit the `kiali` or the `kiali-viewer`
-`ClusterRoles` because they are bound to the Kiali ServiceAccount and editing
-them may lead to Kiali not working properly.
+```bash
+$ kubectl create rolebinding authorize-ns-foobar-to-john --clusterrole=kiali-namespace-authorization --user=john --namespace=foobar
+$ oc adm policy add-role-to-user kiali-namespace-authorization john -n foobar # For OpenShift clusters
+```
+
+{{% alert color="info" %}}
+Note that in this example, the subject kind is `User`, which is the case when
+using `openid` or `openshift` authentication strategies. For other
+authentication strategies you would need to adjust the `RoleBinding` to use the
+right subject kind.
+{{% /alert %}}
+
+If you want to authorize a user to access _all namespaces_ in the cluster, the
+most efficient way to do it is by creating a `ClusterRole` with the _list_ verb
+for namespaces and bind it to the user using a `ClusterRoleBinding`. The
+following commands do this (it is left to the reader to infer the equivalent
+YAML):
+
+```bash
+# Create the ClusterRole
+$ kubectl create clusterrole kiali-all-namespaces-authorization --verb=list --resource=namespaces,pods/log
+
+# Create the ClusterRoleBinding
+$ kubectl create clusterrolebinding authorize-all-namespaces-to-john --clusterrole=kiali-all-namespaces-authorization --user=john
+$ oc adm policy add-cluster-role-to-user kiali-all-namespaces-authorization john # For OpenShift clusters
+```
+
+Alternatively, you could also use the previously mentioned
+`kiali-namespace-authorization` rather than creating a new one with the _list_
+privilege, and it will work. However, Kiali will perform better if you grant the
+_list_ privilege.
+
+{{% alert color="info" %}}
+Please read your cluster RBAC documentation to learn more about the
+authorization system.
 {{% /alert %}}
 


### PR DESCRIPTION
Since Kiali is no longer allowing to turn off the kube cache, the RBAC documentation no longer stands. It was anyway due an update.

This is a re-write of the RBAC documentation to reflect current behavior.

Fixes kiali/kiali#5720