### PR TITLE
Add Ignore CVEs table to Security page

### DIFF
--- a/content/en/news/security-bulletins/_index.md
+++ b/content/en/news/security-bulletins/_index.md
@@ -6,3 +6,11 @@ type: docs
 weight: 2
 ---
 
+Kiali releases every three weeks and so generally resolves CVEs in new releases only.  Golang vulnerabilities are typically resolved in a timely way, as the Go version for release builds increments fairly often. Occasionally, critical CVEs may be resolved in patch releases for supported versions.  Additionally, not every CVE reported against a Kiali dependency is actually a vulnerability.  For reported CVEs that are proven not to affect Kiali, see the table below:
+
+{{<security-cve-table>}}
+
+<br />
+
+For Kiali-specific vulnerabilities there will be releases made as needed.  At release time a security bulletin will be release as well. For prior bulletins see below:
+

--- a/data/security/cve.yaml
+++ b/data/security/cve.yaml
@@ -1,0 +1,6 @@
+# The Reported Kiali CVEs for which Kiali is confirmed to not be vulnerable
+versionRange:
+  - cve: "CVE-2022-1996"
+    severity: critical
+    description: "github.com/emicklei/go-restful"
+    notes: "Despite the package dependency Kiali is not susceptible to this vulnerability"

--- a/layouts/shortcodes/security-cve-table.html
+++ b/layouts/shortcodes/security-cve-table.html
@@ -1,0 +1,20 @@
+{{ $data := index .Site.Data.security.cve }}
+
+<table>
+  <thead>
+    <tr>
+      <th style="width:160px">CVE</th>
+      <th style="width:360px">Description</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{ range $data.versionRange }}
+    <tr>
+      <td>{{ .cve }}</td>
+      <td>{{ .description }}</td>
+      <td>{{ .notes }}</td>
+    </tr>
+    {{ end }}
+  </tbody>
+</table>


### PR DESCRIPTION
We've had several security inquiries about the same CVEs that, after investigating, don't actually affect Kiali.  Some can be hard to update and in that case we want to publicly state that it does not affect Kiali.  This PR also gives a place to put a blurb about how we deal with CVEs in general.

https://deploy-preview-658--kiali.netlify.app/news/security-bulletins/
