### PR TITLE
add istio 1.19 to compat chart

### DIFF
--- a/data/compatibility/istio.yaml
+++ b/data/compatibility/istio.yaml
@@ -6,7 +6,7 @@ versionRange:
     kialiMaximumVersion: ""
   - meshVersion: "1.18"
     kialiMinimumVersion: "1.67.0"
-    kialiMaximumVersion: "1.71.0"
+    kialiMaximumVersion: "1.73.0"
   - meshVersion: "1.17"
     kialiMinimumVersion: "1.63.2"
     kialiMaximumVersion: "1.66.1"

--- a/data/compatibility/istio.yaml
+++ b/data/compatibility/istio.yaml
@@ -1,8 +1,12 @@
 # The Compatible Version Matrix between upstream Istio and Kiali
+# See: content/en/docs/Installation/installation-guide/prerequisites.md -> {{<compat-table-istio>}}
 versionRange:
+  - meshVersion: "1.19"
+    kialiMinimumVersion: "1.72.0"
+    kialiMaximumVersion: ""
   - meshVersion: "1.18"
     kialiMinimumVersion: "1.67.0"
-    kialiMaximumVersion: ""
+    kialiMaximumVersion: "1.71.0"
   - meshVersion: "1.17"
     kialiMinimumVersion: "1.63.2"
     kialiMaximumVersion: "1.66.1"

--- a/layouts/shortcodes/compat-table-istio.html
+++ b/layouts/shortcodes/compat-table-istio.html
@@ -1,6 +1,6 @@
 {{ $data := index .Site.Data.compatibility.istio }}
 
-<table>
+<table border="1">
   <thead>
     <tr>
       <th style="width:50px">Istio</th>


### PR DESCRIPTION
Should this be cherry-picked to `current` ?? Istio 1.19 isn't released yet, but Kiali 1.72.0 is.

netlify: https://deploy-preview-685--kiali.netlify.app/docs/installation/installation-guide/prerequisites/#version-compatibility

part of: https://github.com/kiali/kiali/issues/6436