### PR TITLE
put CVE-2022-27191 on the not-vulnerable list

### DIFF
--- a/data/security/cve.yaml
+++ b/data/security/cve.yaml
@@ -1,5 +1,9 @@
 # The Reported Kiali CVEs for which Kiali is confirmed to not be vulnerable
 versionRange:
+  - cve: "CVE-2022-27191"
+    severity: high
+    description: "golang.org/x/crypto/ssh allows an attacker to crash a server in certain circumstances involving AddHostKey"
+    notes: "Kiali does not use the AddHostKey API; furthermore, neither Kiali nor its dependencies import this component. Thus Kiali is not susceptible to this vulnerability."
   - cve: "CVE-2022-1996"
     severity: critical
     description: "github.com/emicklei/go-restful"

--- a/layouts/shortcodes/security-cve-table.html
+++ b/layouts/shortcodes/security-cve-table.html
@@ -1,6 +1,6 @@
 {{ $data := index .Site.Data.security.cve }}
 
-<table>
+<table border="1">
   <thead>
     <tr>
       <th style="width:160px">CVE</th>


### PR DESCRIPTION
Kiali does not match the described conditions as detailed here: https://groups.google.com/g/golang-announce/c/-cp44ypCT5shttps://groups.google.com/g/golang-announce/c/-cp44ypCT5s (specifically, the Kiali server is NOT "configured by passing a Signer to ServerConfig.AddHostKey").

Moreover, it does not appear that Kiali or any of its dependencies even pulls in "golang.org/x/crypto/ssh" which is the affected component:

```
$ go mod why golang.org/x/crypto/ssh
# golang.org/x/crypto/ssh
(main module does not need package golang.org/x/crypto/ssh)

$ go mod graph | grep golang.org/x/crypto/ssh
<returns empty>
```

Additionally, this report: https://github.com/advisories/GHSA-8c26-wmh5-6g9v shows it is only applicable up to Go v1.17.8, but the latest Kiali v1.72 uses  Go 1.20.

```
$ podman run -it quay.io/kiali/kiali:v1.72.0 | grep "Go:"
2023-08-21T16:07:14Z INF Kiali: Version: v1.72.0, Commit: 7208cd1767e8347b00bff10391130d7bcc824548, Go: 1.20.5
```

Thus, Kiali is unaffected by this vulnerability detailed in CVE-2022-27191; as such there are no plans to change anything in Kiali for this issue.

netlify link: https://deploy-preview-688--kiali.netlify.app/news/security-bulletins/