### PR TITLE
Update docs for multi-primary support

### DIFF
--- a/content/en/docs/Configuration/multi-cluster.md
+++ b/content/en/docs/Configuration/multi-cluster.md
@@ -11,7 +11,7 @@ Before proceeding with the setup, ensure you meet the requirements.
 
 ### Requirements
 
-1. **Aggregated metrics and traces.** Kiali needs a single endpoint for metrics and a single endpoint for traces where it can consume aggregated metrics/traces across all clusters. There are many ways to aggregate metrics/traces such as prometheus federation or using OTEL collector pipelines but setting these up are outside of the scope of Kiali.
+1. **Aggregated metrics and traces.** Kiali needs a single endpoint for metrics and a single endpoint for traces where it can consume aggregated metrics/traces across all clusters. There are many ways to aggregate metrics/traces such as Prometheus federation or using OTEL collector pipelines but setting these up are outside of the scope of Kiali.
 
 2. **Anonymous or OpenID authentication strategy.** The unified multi-cluster configuration currently only supports anonymous or OpenID [authentication strategies]({{< relref "../Configuration/authentication" >}}). In addition, current support varies by provider for OpenID across clusters.
 

--- a/content/en/docs/Configuration/multi-cluster.md
+++ b/content/en/docs/Configuration/multi-cluster.md
@@ -11,11 +11,9 @@ Before proceeding with the setup, ensure you meet the requirements.
 
 ### Requirements
 
-1. **Primary-remote istio deployment.** Only the primary-remote istio deployment is currently supported.
+1. **Aggregated metrics and traces.** Kiali needs a single endpoint for metrics and a single endpoint for traces where it can consume aggregated metrics/traces across all clusters. There are many ways to aggregate metrics/traces such as prometheus federation or using OTEL collector pipelines but setting these up are outside of the scope of Kiali.
 
-2. **Aggregated metrics and traces.** Kiali needs a single endpoint for metrics and a single endpoint for traces where it can consume aggregated metrics/traces across all clusters. There are many ways to aggregate metrics/traces such as prometheus federation or using OTEL collector pipelines but setting these up are outside of the scope of Kiali.
-
-3. **Anonymous or OpenID authentication strategy.** The unified multi-cluster configuration currently only supports anonymous or OpenID [authentication strategies]({{< relref "../Configuration/authentication" >}}). In addition, current support varies by provider for OpenID across clusters.
+2. **Anonymous or OpenID authentication strategy.** The unified multi-cluster configuration currently only supports anonymous or OpenID [authentication strategies]({{< relref "../Configuration/authentication" >}}). In addition, current support varies by provider for OpenID across clusters.
 
 ### Setup
 
@@ -60,7 +58,7 @@ spec:
 EOF
 ```
 
-As an alternative, it can be added in the Istio tracing config in the primary cluster (Without using the Telemetry API): 
+As an alternative, it can be added in the Istio tracing config in the primary cluster(s) (Without using the Telemetry API):
 
 ```
 meshConfig:

--- a/content/en/docs/Features/multi-cluster.md
+++ b/content/en/docs/Features/multi-cluster.md
@@ -11,7 +11,7 @@ A basic Istio mesh deployment has a single control plane with a single data plan
 [deployment models](https://istio.io/latest/docs/ops/deployment/deployment-models/). It allows a mesh to span multiple primary (control plane) and/or remote (data plane only) clusters, and can use a single or
 [multi-network](https://istio.io/latest/docs/ops/deployment/deployment-models/#multiple-networks) approach. The only strict rule is that within a mesh service names are unique. A non-basic mesh deployment generally involves multiple clusters. See [installation instructions](https://istio.io/docs/setup/install/multicluster/) for more detail on installing advanced mesh deployments.
 
-A single Kiali install can currently work with at most one mesh, one istiod, one metric store and one trace store but it can be configured for "single cluster" or "multi-cluster". All clusters must be part of the same mesh, have data planes controlled by the single istiod (control plane), and report to the same metric and trace store, whether directly or via some sort of aggregator. See the [multi-cluster configuration page]({{< relref "../Configuration/multi-cluster" >}}) for more information on requirements.
+A single Kiali install can currently work with at most one mesh, one metric store and one trace store but it can be configured for "single cluster" or "multi-cluster". All clusters must be part of the same mesh and report to the same metric and trace store, whether directly or via some sort of aggregator. See the [multi-cluster configuration page]({{< relref "../Configuration/multi-cluster" >}}) for more information on requirements.
 
 For multi-cluster configurations, Kiali provides a unified view and management of your mesh across clusters.
 
@@ -35,7 +35,7 @@ Unlike single-cluster configurations, multi-cluster configurations show list/det
 
 ### List Views: Aggregated mesh view
 
-With a multi-cluster Kiali configuration, you can view all apps, workloads, services, and Istio config in your mesh from a single place. Istio configuration is currently read only for remote clusters.
+With a multi-cluster Kiali configuration, you can view all apps, workloads, services, and Istio config in your mesh from a single place.
 
 ![Multi-cluster list pages](/images/documentation/features/multi-cluster-list.png "Multi-cluster list pages")
 


### PR DESCRIPTION
Remove the requirements for primary-remote and having a single istiod. The configuration for multi-primary is the same as the configuration for primary-remote so those instructions stay the same.

Links to updated pages:
https://deploy-preview-732--kiali.netlify.app/docs/features/multi-cluster/
https://deploy-preview-732--kiali.netlify.app/docs/configuration/multi-cluster/

Fixes kiali/kiali#6937