### PR TITLE
Update redirect URL format in AAD App Registration instructions

### DIFF
--- a/content/en/docs/Configuration/authentication/openid.md
+++ b/content/en/docs/Configuration/authentication/openid.md
@@ -430,7 +430,7 @@ Once it is enabled, your AKS panel should show the following:
 
 Create a web application for Kiali in your Azure AD panel:
 
-1. Go to _AAD > App Registration_, create an application with a redirect url like `\https://<your-kiali-url>`
+1. Go to _AAD > App Registration_, create an application with a redirect url like `https://<your-kiali-url>/kiali`
 2. Go to _Certificates & secrets_ and create a client secret.
    1. After creating the client secret, take note of the provided secret. Create a
    Kubernetes secret in your cluster as mentioned in the [Set-up


### PR DESCRIPTION
## Commit Summary
This commit updates the documentation for configuring the redirect URI in Azure Active Directory (AAD) App Registration for Kiali.

## Error Encountered
AADSTS50011: The redirect URI specified in the request does not match the redirect URIs configured for the application.
![Screenshot 2024-01-04 at 2 40 55 PM](https://github.com/kiali/kiali.io/assets/15180548/c71c344f-4fda-413b-a4f7-446dc7748ded)


## Resolution
The instructions have been corrected to include '/kiali' at the end of the redirect URI to match the expected configuration in the Azure portal. This update ensures that users follow the correct procedure for setting up their applications, thereby preventing the 'redirect URI mismatch' error that was occurring with the previous instructions.

## Updated Instruction
"Go to AAD > App Registration, create an application with a redirect url like https://<your-kiali-url>/kiali"

This change aligns with the URI format that Azure expects, as encountered in the error above, ensuring successful integration and configuration of AAD with Kiali.
