### PR TITLE
Add docs for specifying inaccessible clusters

### DIFF
--- a/content/en/docs/Configuration/multi-cluster.md
+++ b/content/en/docs/Configuration/multi-cluster.md
@@ -19,6 +19,8 @@ Before proceeding with the setup, ensure you meet the requirements.
 
 The unified Kiali multi-cluster setup requires the Kiali Service Account (SA) to have read access to each Kubernetes cluster in the mesh. This is separate from the user credentials that are required when a user logs into Kiali. The user credentials are used to check user access to a namespace and to perform write operations. In anonymous mode, the Kiali SA is used for all operations and write access is also required. To give the Kiali SA access to each remote cluster, a kubeconfig with credentials needs to be created and mounted into the Kiali pod. While the location of Kiali in relation to the controlplane and dataplane may change depending on your istio deployment model, the requirements will remain the same.
 
+If you'd like to keep a separate Kiali per cluster and do not want to give Kiali access to remote clusters you can still manually specify the remote cluster and remote Kiali urls in the Kiali configuration and the UI will try to provide links to the external Kiali where appropriate. See [below]{{< ref "#Adding an Inaccessible Cluster" >}} for more details.
+
 1. **Create a remote cluster secret.** In order to access a remote cluster, you must provide a kubeconfig to Kiali via a Kubernetes secret. You can use [this script](https://github.com/kiali/kiali/blob/master/hack/istio/multicluster/kiali-prepare-remote-cluster.sh) to simplify this process for you. Running this script will:
 
    - Create a Kiali Service Account in the remote cluster.
@@ -81,3 +83,33 @@ That's it! From here you can login to Kiali and manage your mesh across both clu
 To remove a cluster from Kiali, you must delete the associated remote cluster secret. If you originally created the remote cluster secret via the [kiali-prepare-remote-cluster.sh script](https://github.com/kiali/kiali/blob/master/hack/istio/multicluster/kiali-prepare-remote-cluster.sh), run that script again with the same command line options as before but also pass in the command line option `--delete true`.
 
 After the remote cluster secret has been removed, you must then tell the Kiali Operator to re-deploy the Kiali Server so the Kiali Server no longer attempts to access the now-deleted remote cluster secret. If you are using [auto-discovery](/docs/configuration/kialis.kiali.io/#.spec.kiali_feature_flags.clustering.autodetect_secrets), you can tell the Kiali Operator to do this by touching the Kiali CR. The easiest way to do this is to simply add or modify any annotation on the Kiali CR. It is recommended that you use the `kiali.io/reconcile` annotation as described [here](/docs/installation/installation-guide/creating-updating-kiali-cr). If you did not rely on auto-discovery but instead [explicitly specified each remote cluster secret](/docs/configuration/kialis.kiali.io/#.spec.kiali_feature_flags.clustering.clusters) in the Kiali CR, then you simply have to remove the now-deleted remote cluster secret's information from the Kiali CR's `kiali_feature_flags.clustering.clusters` section.
+
+### Adding an Inaccessible Cluster
+
+In situations where Kiali does not have access to remote clusters, you can manually specify the remote cluster info along with any external Kialis running on the remote clusters and Kiali will try to provide links to these in the UI. For example, if there is a kiali on the `east` cluster that does not have access to the `west` cluster and a kiali on the `west` cluster that does not have access to the `east` cluster, you can add the following to your Kiali configurations to have each kiali generates links to the external kiali for that cluster.
+
+East Kiali configuration
+
+```
+clustering:
+  clusters:
+    name: west
+  kiali_urls:
+    cluster_name: west
+    instance_name: kiali
+    namespace: istio-system
+    url: https://kiali-external.west.example.com
+```
+
+West Kiali configuration
+
+```
+clustering:
+  clusters:
+    name: east
+  kiali_urls:
+    cluster_name: east
+    instance_name: kiali
+    namespace: istio-system
+    url: https://kiali-external.east.example.com
+```

--- a/content/en/docs/Configuration/multi-cluster.md
+++ b/content/en/docs/Configuration/multi-cluster.md
@@ -20,7 +20,7 @@ Before proceeding with the setup, ensure you meet the requirements.
 The unified Kiali multi-cluster setup requires the Kiali Service Account (SA) to have read access to each Kubernetes cluster in the mesh. This is separate from the user credentials that are required when a user logs into Kiali. The user credentials are used to check user access to a namespace and to perform write operations. In anonymous mode, the Kiali SA is used for all operations and write access is also required. To give the Kiali SA access to each remote cluster, a kubeconfig with credentials needs to be created and mounted into the Kiali pod. While the location of Kiali in relation to the controlplane and dataplane may change depending on your istio deployment model, the requirements will remain the same.
 
 {{% alert color="info" %}}
-If you'd like to keep a separate Kiali per cluster and do not want to give Kiali access to remote clusters you can still manually specify the remote cluster and remote Kiali urls in the Kiali configuration and the UI will try to provide links to the external Kiali where appropriate. See [below](#adding-an-inaccessible-cluster) for more details.
+If you would like to keep a separate Kiali per cluster and do not want to give Kiali access to remote clusters, you can still manually specify the remote cluster and remote Kiali URLs in the Kiali configuration and the UI will try to provide links to the external Kiali where appropriate. See [below](#adding-an-inaccessible-cluster) for more details.
 {{% /alert %}}
 
 1. **Create a remote cluster secret.** In order to access a remote cluster, you must provide a kubeconfig to Kiali via a Kubernetes secret. You can use [this script](https://github.com/kiali/kiali/blob/master/hack/istio/multicluster/kiali-prepare-remote-cluster.sh) to simplify this process for you. Running this script will:
@@ -88,7 +88,7 @@ After the remote cluster secret has been removed, you must then tell the Kiali O
 
 ### Adding an Inaccessible Cluster
 
-In situations where Kiali does not have access to remote clusters, you can manually specify the remote cluster info along with any external Kialis running on the remote clusters and Kiali will try to provide links to these in the UI. For example, if there is a kiali on the `east` cluster that does not have access to the `west` cluster and a kiali on the `west` cluster that does not have access to the `east` cluster, you can add the following to your Kiali configurations to have each kiali generates links to the external kiali for that cluster.
+In situations where Kiali does not have access to remote clusters, you can manually specify the remote cluster info along with any external Kialis running on the remote clusters and Kiali will try to provide links to these in the UI. For example, if there is a Kiali on the `east` cluster that does not have access to the `west` cluster and a Kiali on the `west` cluster that does not have access to the `east` cluster, you can add the following to your Kiali configurations to have each Kiali generate links to the external Kiali for that cluster.
 
 East Kiali configuration
 

--- a/content/en/docs/Configuration/multi-cluster.md
+++ b/content/en/docs/Configuration/multi-cluster.md
@@ -19,7 +19,9 @@ Before proceeding with the setup, ensure you meet the requirements.
 
 The unified Kiali multi-cluster setup requires the Kiali Service Account (SA) to have read access to each Kubernetes cluster in the mesh. This is separate from the user credentials that are required when a user logs into Kiali. The user credentials are used to check user access to a namespace and to perform write operations. In anonymous mode, the Kiali SA is used for all operations and write access is also required. To give the Kiali SA access to each remote cluster, a kubeconfig with credentials needs to be created and mounted into the Kiali pod. While the location of Kiali in relation to the controlplane and dataplane may change depending on your istio deployment model, the requirements will remain the same.
 
-If you'd like to keep a separate Kiali per cluster and do not want to give Kiali access to remote clusters you can still manually specify the remote cluster and remote Kiali urls in the Kiali configuration and the UI will try to provide links to the external Kiali where appropriate. See [below]{{< ref "#Adding an Inaccessible Cluster" >}} for more details.
+{{% alert color="info" %}}
+If you'd like to keep a separate Kiali per cluster and do not want to give Kiali access to remote clusters you can still manually specify the remote cluster and remote Kiali urls in the Kiali configuration and the UI will try to provide links to the external Kiali where appropriate. See [below](#adding-an-inaccessible-cluster) for more details.
+{{% /alert %}}
 
 1. **Create a remote cluster secret.** In order to access a remote cluster, you must provide a kubeconfig to Kiali via a Kubernetes secret. You can use [this script](https://github.com/kiali/kiali/blob/master/hack/istio/multicluster/kiali-prepare-remote-cluster.sh) to simplify this process for you. Running this script will:
 


### PR DESCRIPTION
Adds docs for setting up kiali with clusters it doesn't have access to.

Relates to kiali/kiali#6243

https://deploy-preview-744--kiali.netlify.app/docs/configuration/multi-cluster/#setup