### PR TITLE
Update Debugging kiali

### DIFF
--- a/content/en/docs/Configuration/debugging-kiali.md
+++ b/content/en/docs/Configuration/debugging-kiali.md
@@ -6,7 +6,7 @@ description: "How to debug Kiali using traces."
 Kiali provides the ability to emit debugging traces to the [distributed tracing](/docs/configuration/p8s-jaeger-grafana/tracing) platform, Jaeger or Grafana Tempo. 
 
 {{% alert color="warning" %}}
-In the next release, the feature of Kiali emitting tracing data into Jaeger **will be deprecated**.
+From Kiali 1.79, the feature of Kiali emitting tracing data into Jaeger **has been removed**.
 {{% /alert %}}
 
 The traces can be sent in HTTP, HTTPS or gRPC protocol. This is specific for the collector type _otel_ - Jaeger traces are sent by http. It is also possible to use TLS. When _tls_enabled_ is set to true, one of the options _skip_verify_ or _ca_name_ should be specified. 


### PR DESCRIPTION
Update "Debugging Kiali" page to reflect that Jaeger collector type has been removed. 

https://deploy-preview-745--kiali.netlify.app/docs/configuration/debugging-kiali/

Ref. https://github.com/kiali/kiali/pull/6991