### PR TITLE
Add OSSMC compatibility matrix

### DIFF
--- a/content/en/docs/Installation/installation-guide/prerequisites.md
+++ b/content/en/docs/Installation/installation-guide/prerequisites.md
@@ -47,7 +47,7 @@ supported Istio versions.
 
 <br />
 
-## Openshift Console Plugin (OSSMC) Version Compatibility
+## OpenShift Console Plugin (OSSMC) Version Compatibility
 
 Currently OSSMC plugin only works with Kiali server 1.73.
 

--- a/content/en/docs/Installation/installation-guide/prerequisites.md
+++ b/content/en/docs/Installation/installation-guide/prerequisites.md
@@ -58,7 +58,7 @@ Currently OSSMC plugin only works with Kiali server 1.73.
 ## OpenShift Service Mesh Version Compatibility
 
 {{% alert title="OpenShift" color="warning" %}}
-If you are running Red Hat OpenShift Service Mesh (RH OSSM), use only the bundled version of Kiali.
+If you are running Red Hat OpenShift Service Mesh (OSSM), use only the bundled version of Kiali.
 {{% /alert %}}
 
 | <div style="width:70px">OSSM</div> | <div style="width:100px">Kiali</div> | Notes |

--- a/content/en/docs/Installation/installation-guide/prerequisites.md
+++ b/content/en/docs/Installation/installation-guide/prerequisites.md
@@ -22,7 +22,6 @@ which is the default.
 
 For more information, see the [Istio documentation](https://istio.io/latest/docs/ops/best-practices/security/#control-plane).
 
-
 ### Version Compatibility
 
 Each Kiali release is tested against the most recent Istio release. In general,
@@ -48,17 +47,25 @@ supported Istio versions.
 
 <br />
 
+## Openshift Console Plugin (OSSMC) Version Compatibility
+
+Currently OSSMC plugin only works with Kiali server 1.73.
+
+{{<compat-table-ossmc>}}
+
+<br />
+
 ## OpenShift Service Mesh Version Compatibility
 
 {{% alert title="OpenShift" color="warning" %}}
 If you are running Red Hat OpenShift Service Mesh (RH OSSM), use only the bundled version of Kiali.
 {{% /alert %}}
 
-|<div style="width:70px">OSSM</div>|<div style="width:100px">Kiali</div>|Notes|
-|-------|------------------|---|
-|2.4   |1.65 |   |
-|2.3   |1.57 |   |
-|2.2   |1.48 |   |
+| <div style="width:70px">OSSM</div> | <div style="width:100px">Kiali</div> | Notes |
+| ---------------------------------- | ------------------------------------ | ----- |
+| 2.4                                | 1.65                                 |       |
+| 2.3                                | 1.57                                 |       |
+| 2.2                                | 1.48                                 |       |
 
 <br />
 
@@ -108,5 +115,3 @@ gcloud compute firewall-rules update <firewall-rule-name> --allow <previous-port
 {{% alert color="success" %}}
 Istio deployments on private clusters also need extra ports to be opened. Check the [Istio installation page for GKE](https://istio.io/latest/docs/setup/platform-setup/gke/) to see all the extra installation steps for this platform.
 {{% /alert %}}
-
-

--- a/data/compatibility/ossmc.yaml
+++ b/data/compatibility/ossmc.yaml
@@ -1,0 +1,9 @@
+# The Compatible Version Matrix between OSSMC, OCP and Kiali
+# See: content/en/docs/Installation/installation-guide/prerequisites.md -> {{<compat-table-ossmc>}}
+versionRange:
+  - ocpVersion: "4.12+"
+    minOSSMCVersion: "0.4.0"
+    maxOSSMCVersion: "1.xx"
+    kialiVersion: "1.73"
+    notes: 
+

--- a/layouts/shortcodes/compat-table-ossmc.html
+++ b/layouts/shortcodes/compat-table-ossmc.html
@@ -3,7 +3,7 @@
 <table>
   <thead>
     <tr>
-      <th style="width: 100px">Openshift</th>
+      <th style="width: 100px">OpenShift</th>
       <th style="width: 120px">Min OSSMC</th>
       <th style="width: 120px">Max OSSMC</th>
       <th style="width: 70px">Kiali</th>

--- a/layouts/shortcodes/compat-table-ossmc.html
+++ b/layouts/shortcodes/compat-table-ossmc.html
@@ -1,0 +1,24 @@
+{{ $data := index .Site.Data.compatibility.ossmc }}
+
+<table>
+  <thead>
+    <tr>
+      <th style="width: 100px">Openshift</th>
+      <th style="width: 120px">Min OSSMC</th>
+      <th style="width: 120px">Max OSSMC</th>
+      <th style="width: 70px">Kiali</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{ range $data.versionRange }}
+    <tr>
+      <td>{{ .ocpVersion }}</td>
+      <td>{{ .minOSSMCVersion }}</td>
+      <td>{{ .maxOSSMCVersion }}</td>
+      <td>{{ .kialiVersion }}</td>
+      <td>{{ .notes }}</td>
+    </tr>
+    {{ end }}
+  </tbody>
+</table>


### PR DESCRIPTION
Add OSSMC compatibility matrix to installation prerequisites pages

Netlify url: https://deploy-preview-755--kiali.netlify.app/docs/installation/installation-guide/prerequisites/#openshift-console-plugin-ossmc-version-compatibility