### PR TITLE
Build docsy on make serve command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 public
 resources
 tmp-crd-docs
+.hugo_build.lock

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 HUGO_VERSION ?= 0.121.1
 DORP ?= podman
 KIALI_HUGO_IMAGE ?= kiali/hugo:latest
-DOCSY_BUILD=cd themes/docsy && npm install && cd ../.. && npm prune && npm config set fetch-retry-mintimeout 20000 && npm config set fetch-retry-maxtimeout 120000
+DOCSY_BUILD=cd themes/docsy && npm install && cd ../..
 
 .prepare-force-build:
 ifeq ($(DORP),docker)
@@ -83,4 +83,4 @@ URL_IGNORE:=$(URL_IGNORE)$(NEW_URLS)
 ## validate-site: Builds the site and validates the pages. This is used for CI
 .PHONY: validate-site
 validate-site: build-hugo
-	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "${DOCSY_BUILD} && hugo && htmlproofer --typhoeus '{\"connecttimeout\": 60, \"timeout\": 60, \"headers\":{\"User-Agent\":\"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36\"}}' --hydra='{\"max_concurrency\": 6}' --allow-hash-href --allow-missing-href --ignore-empty-alt --ignore-missing-alt --no-check-external-hash --no-check-internal-hash --no-enforce-https --ignore_status_codes "302" --ignore-urls \"${URL_IGNORE}\" ./public"
+	${DORP} run -t -i --rm -v "$(shell pwd)":/site:z -w /site ${KIALI_HUGO_IMAGE} /bin/bash -c "${DOCSY_BUILD} && npm prune && npm config set fetch-retry-mintimeout 20000 && npm config set fetch-retry-maxtimeout 120000 && hugo && htmlproofer --typhoeus '{\"connecttimeout\": 60, \"timeout\": 60, \"headers\":{\"User-Agent\":\"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36\"}}' --hydra='{\"max_concurrency\": 6}' --allow-hash-href --allow-missing-href --ignore-empty-alt --ignore-missing-alt --no-check-external-hash --no-check-internal-hash --no-enforce-https --ignore_status_codes "302" --ignore-urls \"${URL_IGNORE}\" ./public"


### PR DESCRIPTION
Trying to deploy kiali.io site locally with `make serve` command, I found the following error:

```
Error: command error: failed to load modules: module "github.com/FortAwesome/Font-Awesome" not found in "/site/themes/github.com/FortAwesome/Font-Awesome"; either add it as a Hugo Module or store it in "/site/themes".: module does not exist
```

Although I found a workaround with https://github.com/kiali/kiali.io/pull/756, afterwards I noticed that `validate-site` command was working, and the difference with `make serve` is the docsy build 
```
cd themes/docsy && npm install && cd ../..
```

Doing the docsy build on `make serve` does the trick, and it is a better solution than https://github.com/kiali/kiali.io/pull/756