### PR TITLE
Remove base64 hint in kiali-cabundle ConfigMap example

### DIFF
--- a/content/en/docs/Configuration/authentication/openid.md
+++ b/content/en/docs/Configuration/authentication/openid.md
@@ -265,7 +265,7 @@ metadata:
   name: kiali-cabundle
   namespace: istio-system # This is Kiali's install namespace
 data:
-  openid-server-ca.crt: <the public component of your CA root certificate encoded in base64>
+  openid-server-ca.crt: <the public component of your CA root certificate>
 ```
 
 After restarting the Kiali pod, Kiali will trust this root certificate for all


### PR DESCRIPTION
Currently there is a hint to provide base64 encoded certificates in the kiali-cabundle ConflgMap when using an own root CA certificate.

However this doesn't work, since Kiali tries to read the certificate in plaintext (see [openID-auth-controller](https://github.com/kiali/kiali/blob/82719968b06f7d69e5955efe08b6a3d59f1e8b8f/business/authentication/openid_auth_controller.go#L923)).

This PR just removes the base64 hint.