### PR TITLE
Improve Install via Helm.

### DIFF
--- a/content/en/docs/Installation/installation-guide/install-with-helm.md
+++ b/content/en/docs/Installation/installation-guide/install-with-helm.md
@@ -84,7 +84,7 @@ cr.namespace=istio-system` flags instructs to create a Kiali CR in the
 the Kiali operator starts, it will process it to deploy Kiali. After Kiali has started,
 you can access Kiali UI through 'http://localhost:20001' by executing 
 `kubectl port-forward service/kiali -n istio-system 20001:20001`
-because of `--set cr.auth.strategy="anonymous"`.
+because of `--set cr.auth.strategy="anonymous"`. But realize that anonymous mode will allow anyone to be able to see and use Kiali. If you wish to require users to authenticate themselves by logging into Kiali, use one of the other [auth strategies](/configuration/authentication/).
 
 The Kiali Operator Helm Chart is configurable. Check available options and default values by running:
 

--- a/content/en/docs/Installation/installation-guide/install-with-helm.md
+++ b/content/en/docs/Installation/installation-guide/install-with-helm.md
@@ -84,7 +84,7 @@ cr.namespace=istio-system` flags instructs to create a Kiali CR in the
 the Kiali operator starts, it will process it to deploy Kiali. After Kiali has started,
 you can access Kiali UI through 'http://localhost:20001' by executing 
 `kubectl port-forward service/kiali -n istio-system 20001:20001`
-because of `--set cr.auth.strategy="anonymous"`. But realize that anonymous mode will allow anyone to be able to see and use Kiali. If you wish to require users to authenticate themselves by logging into Kiali, use one of the other [auth strategies](/configuration/authentication/).
+because of `--set cr.auth.strategy="anonymous"`. But realize that anonymous mode will allow anyone to be able to see and use Kiali. If you wish to require users to authenticate themselves by logging into Kiali, use one of the other [auth strategies](/docs/configuration/authentication/).
 
 The Kiali Operator Helm Chart is configurable. Check available options and default values by running:
 

--- a/content/en/docs/Installation/installation-guide/install-with-helm.md
+++ b/content/en/docs/Installation/installation-guide/install-with-helm.md
@@ -69,6 +69,7 @@ command:
 $ helm install \
     --set cr.create=true \
     --set cr.namespace=istio-system \
+    --set cr.auth.strategy="anonymous" \
     --namespace kiali-operator \
     --create-namespace \
     kiali-operator \
@@ -80,7 +81,10 @@ create the `kiali-operator` namespace (if needed), and deploy the Kiali
 operator on it.  The `--set cr.create=true` and `--set
 cr.namespace=istio-system` flags instructs to create a Kiali CR in the
 `istio-system` namespace. Since the Kiali CR is created in advance, as soon as
-the Kiali operator starts, it will process it to deploy Kiali.
+the Kiali operator starts, it will process it to deploy Kiali. After Kiali has started,
+you can access Kiali UI through 'http://localhost:20001' by executing 
+`kubectl port-forward service/kiali -n istio-system 20001:20001`
+because of `--set cr.auth.strategy="anonymous"`.
 
 The Kiali Operator Helm Chart is configurable. Check available options and default values by running:
 


### PR DESCRIPTION
### Background
Hi, I'm new in `kiali` and this is my first PR! 
When I first tried to install the `Kiali` operator and access the `Kiali UI`, I encountered a problem where the token could not be found, and it was difficult to find a solution through searching the documentation. 
The problem occurred with the commands below.
```shell
$ helm install \
    --set cr.create=true \
    --set cr.namespace=istio-system \
    --namespace kiali-operator \
    --create-namespace \
    kiali-operator \
    kiali/kiali-operator
```
Thus, IMO, it will be better to add `--set cr.auth.strategy="anonymous"` for newbie in `kiali` to started with `kiali` easily.


### Changes
- Add `--set cr.auth.strategy="anonymous"` to install via helm page.
- Add some comments to describe accessing kiali UI at install via helm page.