### PR TITLE
Update tempo docs

### DIFF
--- a/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
@@ -11,6 +11,7 @@ There are two possibilities to integrate Kiali with Grafana Tempo:
 
 - [Using the Grafana Tempo API](#using-the-grafana-tempo-api): This option returns the traces from the Tempo API in OpenTelemetry format. 
 - [Using the Jaeger frontend](#using-the-jaeger-frontend-with-grafana-tempo-tracing-backend) with the Grafana Tempo backend.
+- Appendix: [Configuration table](#configuration-table) 
 
 ### Using the Grafana Tempo API 
 
@@ -202,3 +203,32 @@ For the given example, the value would be
 `http://tempo-ssm-query-frontend.tempo.svc.cluster.local:16685`.
 
 There is a [related tutorial]({{< ref "/docs/tutorials/tempo/02-kiali-tempo-integration" >}}) with detailed instructions to setup Kiali and Grafana Tempo with the Operator.
+
+### Configuration table
+
+#### Supported versions
+
+| <div style="width:170px">Kiali Version</div> | <div style="width:70px">Jaeger</div> | <div style="width:70px">Tempo</div> | <div style="width:270px">Tempo with JaegerQuery</div> |
+|----------------------------------------------|--------|-------|-------------------------------------------------------|
+| <= 1.79 (OSSM 2.5)                           | ✅      | ❌     | ✅                                                     |
+| > 1.79                                       | ✅      | ✅     | ✅                                                     |
+
+<br>
+
+#### Minimal configuration for Kiali <= 1.79
+
+In `external_services.tracing`
+
+|                                                    | <div style="width:470px">http<hr></div>                                                    | <div style="width:470px">grpc <hr></div>                                                                                 |
+|----------------------------------------------------|--------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| Jaeger | `.in_cluster_url = 'http://jaeger_service_url:16686/jaeger'`<br/> `.use_grpc = false` <hr> | `.in_cluster_url = 'http://jaeger_service_url:16685/jaeger'`<br/> `.use_grpc = true (Not required: by default)` <br><hr> | 
+| Tempo                                              | `.in_cluster_url = 'http://query_frontend_url:16686'`<br/> `.use_grpc = false` <hr>        | `.in_cluster_url = 'http://query_frontend_url:16685'`  <br/>`.use_grpc = true (Not required: by default)` <br/><hr>                                                    |
+
+<br>
+
+#### Minimal configuration for Kiali > 1.79
+
+|        | <div style="width:470px">http<hr></div>                                                                     | <div style="width:470px">grpc  <hr></div>                                                                                                                        |
+|--------|-------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Jaeger | `.in_cluster_url = 'http://jaeger_service_url:16686/jaeger'`<br/> `.use_grpc = false` <hr>                  | `.in_cluster_url = 'http://jaeger_service_url:16685/jaeger'` <br>`.use_grpc = true (Not required: by default)`<br><hr>                                           | 
+| Tempo  | <br/>`in_cluster_url = 'http://query_frontend_url:3200'`<br/> `.use_grpc = false`<br/> `.provider = 'tempo'`<br/><hr> | `.in_cluster_url = 'http://query_frontend_url:3200'`<br/> `.grpc_port: 9095` <br/>`.provider: 'tempo'`<br/>`.use_grpc = true (Not required: by default)`<hr> |

--- a/content/en/docs/FAQ/distributed-tracing.md
+++ b/content/en/docs/FAQ/distributed-tracing.md
@@ -91,3 +91,13 @@ To fix it, configure `in_cluster_url` in the [Kiali CR](/docs/configuration/kial
 
 In Traces tab, while clicking on a trace, it shows the details of that trace and information about spans. These details also include the root span information. But for the traces for traffic that is not comming from ingress-gateway, the root span information is not available in Jaeger, thus Kiali is displaying "Missing root span" for those traces' details and tooltips in Traces tab and in Graph pages.
 
+### Why do I see "error reading server preface: http2: frame too large" error when Kiali is not able to fetch Traces?
+
+Sometimes this error can occur when there is an error in the configuration and there is a http url configured but Kiali is configured to use grpc. For example: 
+
+```yaml
+use_grpc: true 
+in_cluster_url: "http://jaeger_url:16686/jaeger"
+```
+
+That should be solved when `use_grpc: false` or using the grpc port `in_cluster_url: "http://jaeger_url:16685/jaeger"` 

--- a/content/en/docs/FAQ/distributed-tracing.md
+++ b/content/en/docs/FAQ/distributed-tracing.md
@@ -93,7 +93,7 @@ In Traces tab, while clicking on a trace, it shows the details of that trace and
 
 ### Why do I see "error reading server preface: http2: frame too large" error when Kiali is not able to fetch Traces?
 
-Sometimes this error can occur when there is an problem in the configuration and there is an http url configured but Kiali is configured to use grpc. For example: 
+Sometimes this error can occur when there is a problem in the configuration and there is an http url configured but Kiali is configured to use grpc. For example:
 
 ```yaml
 use_grpc: true 

--- a/content/en/docs/FAQ/distributed-tracing.md
+++ b/content/en/docs/FAQ/distributed-tracing.md
@@ -93,7 +93,7 @@ In Traces tab, while clicking on a trace, it shows the details of that trace and
 
 ### Why do I see "error reading server preface: http2: frame too large" error when Kiali is not able to fetch Traces?
 
-Sometimes this error can occur when there is an error in the configuration and there is a http url configured but Kiali is configured to use grpc. For example: 
+Sometimes this error can occur when there is an problem in the configuration and there is an http url configured but Kiali is configured to use grpc. For example: 
 
 ```yaml
 use_grpc: true 


### PR DESCRIPTION
Update Tempo docs to clarify the configuration and add a FAQ entry.

https://deploy-preview-773--kiali.netlify.app/docs/configuration/p8s-jaeger-grafana/tracing/tempo/#configuration-table
https://deploy-preview-773--kiali.netlify.app/docs/faq/distributed-tracing/#why-do-i-see-error-reading-server-preface-http2-frame-too-large-error-when-kiali-is-not-able-to-fetch-traces 