### PR TITLE
[v1.84] Update Kiali compatibility matrix for Istio 1.22 and OSSM 2.5

### DIFF
--- a/content/en/docs/Installation/installation-guide/prerequisites.md
+++ b/content/en/docs/Installation/installation-guide/prerequisites.md
@@ -49,7 +49,7 @@ supported Istio versions.
 
 ## OpenShift Console Plugin (OSSMC) Version Compatibility
 
-Currently OSSMC plugin only works with Kiali server 1.73.
+Kiali server with the same version of OSSMC plugin must be installed previously in your OpenShift cluster.
 
 {{<compat-table-ossmc>}}
 
@@ -61,11 +61,12 @@ Currently OSSMC plugin only works with Kiali server 1.73.
 If you are running Red Hat OpenShift Service Mesh (OSSM), use only the bundled version of Kiali.
 {{% /alert %}}
 
-| <div style="width:70px">OSSM</div> | <div style="width:100px">Kiali</div> | Notes |
-| ---------------------------------- | ------------------------------------ | ----- |
-| 2.4                                | 1.65                                 |       |
-| 2.3                                | 1.57                                 |       |
-| 2.2                                | 1.48                                 |       |
+| <div style="width:100px">OSSM</div> | <div style="width:100px">Kiali</div> | Notes                      |
+| ----------------------------------- | ------------------------------------ | -------------------------- |
+| 2.5                                 | 1.73                                 |                            |
+| 2.4                                 | 1.65                                 |                            |
+| 2.3                                 | 1.57                                 |                            |
+| 2.2                                 | 1.48                                 | OSSM 2.2 is out of support |
 
 <br />
 

--- a/data/compatibility/istio.yaml
+++ b/data/compatibility/istio.yaml
@@ -1,9 +1,13 @@
 # The Compatible Version Matrix between upstream Istio and Kiali
 # See: content/en/docs/Installation/installation-guide/prerequisites.md -> {{<compat-table-istio>}}
 versionRange:
+  - meshVersion: "1.22"
+    kialiMinimumVersion: "1.82.0"
+    kialiMaximumVersion: ""
+    notes: "v1.86.0 is the recommended minimum for Istio Ambient users (also fine for v1.22 classic)."
   - meshVersion: "1.21"
     kialiMinimumVersion: "1.79.0"
-    kialiMaximumVersion: ""
+    kialiMaximumVersion: "1.81.0"
   - meshVersion: "1.20"
     kialiMinimumVersion: "1.76.0"
     kialiMaximumVersion: "1.78.0"

--- a/data/compatibility/ossmc.yaml
+++ b/data/compatibility/ossmc.yaml
@@ -1,9 +1,11 @@
 # The Compatible Version Matrix between OSSMC, OCP and Kiali
 # See: content/en/docs/Installation/installation-guide/prerequisites.md -> {{<compat-table-ossmc>}}
 versionRange:
+  - ocpVersion: "4.15+"
+    minOSSMCVersion: "1.84"
+    maxOSSMCVersion: ""
+    notes:
   - ocpVersion: "4.12+"
     minOSSMCVersion: "1.73"
-    maxOSSMCVersion: "1.73"
-    kialiVersion: "1.73"
-    notes: This is the most tested version.  Newer community versions may also work.
-
+    maxOSSMCVersion: "1.83"
+    notes: "All OSSMC versions from v1.73 to v1.83 are only compatible with Kiali server v1.73"

--- a/layouts/shortcodes/compat-table-ossmc.html
+++ b/layouts/shortcodes/compat-table-ossmc.html
@@ -4,9 +4,8 @@
   <thead>
     <tr>
       <th style="width: 100px">OpenShift</th>
-      <th style="width: 120px">Min OSSMC</th>
-      <th style="width: 120px">Max OSSMC</th>
-      <th style="width: 70px">Kiali</th>
+      <th style="width: 120px">OSSMC Min</th>
+      <th style="width: 120px">OSSMC Max</th>
       <th>Notes</th>
     </tr>
   </thead>
@@ -16,7 +15,6 @@
       <td>{{ .ocpVersion }}</td>
       <td>{{ .minOSSMCVersion }}</td>
       <td>{{ .maxOSSMCVersion }}</td>
-      <td>{{ .kialiVersion }}</td>
       <td>{{ .notes }}</td>
     </tr>
     {{ end }}

--- a/layouts/shortcodes/videos.html
+++ b/layouts/shortcodes/videos.html
@@ -1,6 +1,5 @@
 {{- $maxVids := 3 }}
-{{- $expTimestamp := div now.Unix 6000 }}
-{{- $feedURL      := printf "https://api.rss2json.com/v1/api.json?timestamp=%d&rss_url=https://www.youtube.com/feeds/videos.xml?channel_id=UCcm2NzDN_UCZKk2yYmOpc5w" $expTimestamp }}
+{{- $feedURL      := "https://www.toptal.com/developers/feed2json/convert?url=https://www.youtube.com/feeds/videos.xml?channel_id=UCcm2NzDN_UCZKk2yYmOpc5w" }}
 {{- $json         := getJSON $feedURL }}
 {{- $videos       := first $maxVids $json.items }}
 
@@ -12,21 +11,20 @@
 </h3>
 
 {{ range $videos }}
-  {{ $link    := .link }}
+  {{ $url    := .url }}
   {{ $vidId   := index (split .guid ":") 2 }}
-  {{ $img     := .thumbnail }}
   {{ $title   := .title | truncate 80 }}
-  {{ $dateRaw := .pubDate }}
+  {{ $dateRaw := .date_published }}
   {{ $date    := dateFormat "January 2, 2006" $dateRaw }}
   <div class="col-lg-4 mb-5 mb-lg-0 text-center ">
     <div class="video-card">
       <figure>
-        <img src="{{ $img }}" alt="Thumbnail for {{ $title }}" width="250" height="125">
+        <img src="https://i2.ytimg.com/vi/{{ $vidId }}/hqdefault.jpg" alt="Thumbnail for {{ $title }}" width="250" height="125">
       </figure>
       <div class="video-card-body">
         <div class="video-card-date">Published {{ $date }}</div>
         <div class="video-card-title">{{ $title }}</div>
-        <p class="pt-0"><a href="{{ $link }}" target="_blank">Watch on YouTube</a></p>
+        <p class="pt-0"><a href="{{ $url }}" target="_blank">Watch on YouTube</a></p>
       </div>
     </div>
   </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -144,12 +144,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -322,9 +322,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"


### PR DESCRIPTION
Backport PR of https://github.com/kiali/kiali.io/pull/792 for v1.84 branch