### PR TITLE
Upgrade github actions to Node 20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,12 +7,12 @@ on:
     branches: [ staging ]
 
 jobs:
-
   build:
     name: Build and validate
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Validate
         run: make validate-site

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       releasing_version: ${{ steps.releasing_version.outputs.releasing_version }}      
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:          
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -101,7 +101,7 @@ jobs:
       RELEASING_VERSION: ${{ needs.initialize.outputs.releasing_version }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:          
         ref: ${{ github.event.inputs.release_branch || github.ref_name }} 
         fetch-depth: 0


### PR DESCRIPTION
Currently, github actions use v3 of actions/checkout, which internally runs on Node 16 (https://github.com/actions/checkout/blob/v3/action.yml#L90).

This PR upgrades github actions to v4, which internally runs Node on 20 (https://github.com/actions/checkout/blob/v4/action.yml#L102)