### PR TITLE
Enable the release schedule in github actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  #schedule:
+  schedule:
   # Every Monday at 07:00 (UTC)
-  #- cron: '00 7 * * MON'
+  - cron: '00 7 * * MON'
   workflow_dispatch:
     inputs:
       release_branch:


### PR DESCRIPTION
### Describe the change

Now that we have tested the new release GitHub Action and confirmed it works properly, it is time to enable the automated release schedule.