### PR TITLE
Remove certificate warning section in OSSMC

### DIFF
--- a/content/en/docs/OSSMC/users-guide.md
+++ b/content/en/docs/OSSMC/users-guide.md
@@ -12,10 +12,6 @@ The features of the OSSMC plugin are the same as those of the standalone Kiali C
 The OSSMC [only supports a single tenant today](https://github.com/kiali/openshift-servicemesh-plugin/issues/187). Whether that tenant is configured to access only a subset of OpenShift projects or has access cluster-wide to all projects does not matter, however, only a single tenant can be accessed.
 {{% /alert %}}
 
-{{% alert color="warning" %}}
-If you are using a certificate that your browser does not initially trust, you must tell your browser to trust the certificate first before you are able to access the OSSMC plugin. To do this, go to the Kiali standalone user interface (UI) and tell the browser to accept its certificate.
-{{% /alert %}}
-
 ## Overview
 
 The **Overview** page provides a summary of your mesh by showing cards representing the namespaces participating in the mesh. Each namespace card has summary metric graphs and additional health details. There are links in the cards that take you to other pages within OSSMC.


### PR DESCRIPTION
Remove the certificate warning section in OSSMC, as it is outdated and refers to a certificate that was required only when the plugin was built with iFrames.