### PR TITLE
[current] v2.14 release notes (#900)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -235,11 +235,11 @@ enable = false
   url = "https://v2-13.kiali.io"
 
 [[ params.versions ]]
-  version = "v2.12"
+  version = "v2.12 [istio v1.27]"
   url = "https://v2-12.kiali.io"
 
 [[ params.versions ]]
-  version = "v2.11"
+  version = "v2.11  [ossm v3.1]"
   url = "https://v2-11.kiali.io"
 
 [[ params.versions ]]
@@ -247,7 +247,7 @@ enable = false
   url = "https://v2-10.kiali.io"
 
 [[ params.versions ]]
-  version = "v2.9"
+  version = "v2.9 [istio v1.26]"
   url = "https://v2-9.kiali.io"
 
 [[ params.versions ]]
@@ -283,11 +283,7 @@ enable = false
   url = "https://v1-78.kiali.io"
 
 [[ params.versions ]]
-  version = "v1.75 [istio v1.19]"
-  url = "https://v1-75.kiali.io"
-
-[[ params.versions ]]
-  version = "v1.73 [ossm v2.5/6]"
+  version = "v1.73 [ossm v2.6]"
   url = "https://v1-73.kiali.io"
 
 [[params.versions]]

--- a/content/en/docs/Configuration/multi-cluster/external.md
+++ b/content/en/docs/Configuration/multi-cluster/external.md
@@ -31,3 +31,6 @@ Kiali typically sets its home cluster name to the same cluster name set by the c
 kubernetes_config:
   cluster_name: <KialiHomeClusterName>
 ```
+### Authorization
+
+The external deployment model currently supports openid and anonymous authorization strategies. OpenShift and token auth are untested and considered experimental.

--- a/content/en/docs/Installation/installation-guide/prerequisites.md
+++ b/content/en/docs/Installation/installation-guide/prerequisites.md
@@ -42,9 +42,21 @@ Istio release at the time. Although compatibility may be fine with other version
 
 <br />
 
-## Maistra Version Compatibility
+## OpenShift Service Mesh Version Compatibility
 
-{{<compat-table-maistra>}}
+{{% alert title="OpenShift" color="warning" %}}
+If you are running Red Hat OpenShift Service Mesh (OSSM), use only the bundled, supported version of Kiali.
+{{% /alert %}}
+
+| <div style="width:100px">OSSM</div> | <div style="width:100px">Kiali</div> | Notes                      |
+| ----------------------------------- | ------------------------------------ | -------------------------- |
+| 3.1                                 | 2.11                                 |                            |
+| 3.0                                 | 2.4                                  |                            |
+| 2.6                                 | 1.73                                 | Same version as 2.5        |
+| 2.5                                 | 1.73                                 |                            |
+| 2.4                                 | 1.65                                 | OSSM 2.4 is out of support |
+| 2.3                                 | 1.57                                 | OSSM 2.3 is out of support |
+| 2.2                                 | 1.48                                 | OSSM 2.2 is out of support |
 
 <br />
 
@@ -56,19 +68,9 @@ Kiali server with the same version of OSSMC plugin must be installed previously 
 
 <br />
 
-## OpenShift Service Mesh Version Compatibility
+## Maistra Version Compatibility
 
-{{% alert title="OpenShift" color="warning" %}}
-If you are running Red Hat OpenShift Service Mesh (OSSM), use only the bundled version of Kiali.
-{{% /alert %}}
-
-| <div style="width:100px">OSSM</div> | <div style="width:100px">Kiali</div> | Notes                      |
-| ----------------------------------- | ------------------------------------ | -------------------------- |
-| 2.6                                 | 1.73                                 | Same version as 2.5        |
-| 2.5                                 | 1.73                                 |                            |
-| 2.4                                 | 1.65                                 |                            |
-| 2.3                                 | 1.57                                 | OSSM 2.3 is out of support |
-| 2.2                                 | 1.48                                 | OSSM 2.2 is out of support |
+{{<compat-table-maistra>}}
 
 <br />
 

--- a/content/en/news/release-notes.md
+++ b/content/en/news/release-notes.md
@@ -6,13 +6,40 @@ weight: 1
 
 For additional information check our [sprint demo videos](https://www.youtube.com/channel/UCcm2NzDN_UCZKk2yYmOpc5w) and [blogs](https://medium.com/kialiproject).
 
-Upgrade Change Notes:
+## 2.14.0
+Sprint Release: August 08, 2025
+
+Features:
+
+* [Ambient: UI support to add namespace to Ambient mesh](https://github.com/kiali/kiali/issues/7901)
+* [Deployment: Support for external kiali deployment option](https://github.com/kiali/kiali/issues/8470)
+* [Gateway API: Upgrade K8s Gateway API to v1.3.0](https://github.com/kiali/kiali/issues/8272)
+* [Gateway API: Support Gateway API Inference Extension](https://github.com/kiali/kiali/issues/8555)
+
+Fixes:
+
+* [Authorization: do not perform cluster-wide query when cluster wide access is disabled](https://github.com/kiali/kiali/issues/8585)
+* [Multi-cluster: Detect monitoring port for each controlplane](https://github.com/kiali/kiali/issues/8553)
+* [Validation: Kiali does not recognize `istio-remote` gateway class](https://github.com/kiali/kiali/issues/8590)
+
+#### Upgrade Change Notes:
 
 The following fields are no longer used by the Kiali CR and MUST be removed, if currently set.
 
-* spec.istio_namespace
-* spec.in_cluster
-* spec.deployment.remote_secret_path
+* no longer used
+  * `spec.istio_namespace`
+  * `spec.in_cluster`
+  * `spec.deployment.remote_secret_path`
+* now auto-discovered
+  * `spec.external_services.istio.config_map_name`
+  * `spec.external_services.istio.istiod_pod_monitoring_port`
+  * `spec.external_services.istio.envoy_admin_local_port`
+  * `spec.external_services.istio.istio_canary_version`
+  * `spec.external_services.istio.istio_injection_annotation`
+  * `spec.external_services.istio.istio_sidecar_annotation`
+  * `spec.external_services.istio.istiod_deployment_name`
+  * `spec.external_services.istio.istiod_pod_monitoring_port`
+  * `spec.external_services.istio.url_service_version`
 
 ## 2.13.0
 Sprint Release: July 21, 2025

--- a/data/compatibility/istio.yaml
+++ b/data/compatibility/istio.yaml
@@ -1,12 +1,15 @@
 # The Compatible Version Matrix between upstream Istio and Kiali
 # See: content/en/docs/Installation/installation-guide/prerequisites.md -> {{<compat-table-istio>}}
 versionRange:
+  - meshVersion: "1.27"
+    kialiVersions: "2.12 and higher"
   - meshVersion: "1.26"
     kialiVersions: "2.9 and higher"
   - meshVersion: "1.25"
     kialiVersions: "2.5 and higher"
   - meshVersion: "1.24"
-    kialiVersions: "2.0 and higher"
+    kialiVersions: "2.0-2.13"
+    notes: "Istio 1.24 is out of support."
   - meshVersion: "1.23"
     kialiVersions: "1.87, 2.4-2.8"
     notes: "Istio 1.23 is out of support. Kiali v2 requires migration from Kiali v1 non-default namespace management (i.e. accessible_namespaces) to Discovery Selectors."


### PR DESCRIPTION
- includes update notes for the CRD
- update external kiali authentication strategy info
- updates to compatibility charts
  - re-organize to prioritize ossm over maistra
- update to Release dropdown