### PR TITLE
[Tracing] Document OpenShift tempo url provider

### DIFF
--- a/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
@@ -70,7 +70,10 @@ spec:
 ```
 
 Kiali will use the _external_url_ to redirect to the Tracing UI, in the "View in tracing" links. 
-In Tempo, by default, the _url_format_ is set to _grafana_. This will use a particular url path and query for each link. The default UI for Grafana Tempo is Grafana, so it will use the _external_url_ set in the Grafana section, such as this example: 
+For the Tempo provider, by default, the _url_format_ is set to _jaeger_ (Changed from Grafana in Kiali 2.17).
+Kiali will use the _external_url_ set in the tracing section, and the url path and query will be following the Jaeger UI format.
+
+When set to _grafana_, Kiali will use the _external_url_ set in the Grafana section, such as this example:
 
 ```yaml
 spec:
@@ -80,7 +83,19 @@ spec:
       external_url: https://grafana.apps-crc.testing/
 ```
 
-It is also possible to set _url_format_ to "jaeger". In that case, Kiali will use the _external_url_ set in the tracing section, and the url path and query will be following the Jaeger UI format. 
+It is also possible to set _url_format_ to "openshift". In that case, Kiali will use the url format to redirect to the UI Plugin in OpenShift. 
+When it is set to _openshift_, there are other settings as well: 
+
+```yaml
+spec:
+  external_services:
+    tracing:
+      tempo_config:
+        name: "sample"
+        namespace: "tempo"
+        tenant: "default"
+        url_format: "openshift"
+```
 
 #### Set up a Tempo Datasource in Grafana
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
@@ -83,7 +83,7 @@ spec:
       external_url: https://grafana.apps-crc.testing/
 ```
 
-It is also possible to set _url_format_ to "openshift". In that case, the url will redirect to the UI Plugin in OpenShift. 
+It is also possible to set _url_format_ to _openshift_. In this case the URL will redirect to the UI Plugin in the OpenShift console.
 When it is set to _openshift_, there are other settings as well: 
 
 ```yaml

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
@@ -73,7 +73,7 @@ Kiali uses the _external_url_ to construct "View in tracing links in the UI.
 For the Tempo provider the default _url_format_ is _jaeger_ (changed from _grafana_ in Kiali v2.17).
 So, by default the URL will have the Jaeger UI format when linking to specific services and traces.
 
-When the url_format is set to _grafana_, Kiali will use the _external_url_ set in the Grafana section, such as this example:
+If `spec.external_services.tracing.tempo_config.url_format` is set to _grafana_, Kiali will use the _external_url_ set in the `spec.external_services.grafana` section, such as this example:
 
 ```yaml
 spec:

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
@@ -69,7 +69,7 @@ spec:
       external_url: "https://tempo-tempo-query-frontend-tempo.apps-crc.testing/"
 ```
 
-Kiali will use the _external_url_ to redirect to the Tracing UI, in the "View in tracing" links. 
+Kiali uses the _external_url_ to construct "View in tracing links in the UI. 
 For the Tempo provider the default _url_format_ is _jaeger_ (changed from _grafana_ in Kiali v2.17).
 Kiali will use the _external_url_ configuration to create the redirection link. The URL will have the Jaeger UI format to redirect to specific services and traces.
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
@@ -70,7 +70,7 @@ spec:
 ```
 
 Kiali will use the _external_url_ to redirect to the Tracing UI, in the "View in tracing" links. 
-For the Tempo provider, by default, _url_format_ is set to _jaeger_ (Changed from Grafana in Kiali 2.17).
+For the Tempo provider the default _url_format_ is _jaeger_ (changed from _grafana_ in Kiali v2.17).
 Kiali will use the _external_url_ configuration to create the redirection link. The URL will have the Jaeger UI format to redirect to specific services and traces.
 
 When the url_format is set to _grafana_, Kiali will use the _external_url_ set in the Grafana section, such as this example:

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
@@ -70,10 +70,10 @@ spec:
 ```
 
 Kiali will use the _external_url_ to redirect to the Tracing UI, in the "View in tracing" links. 
-For the Tempo provider, by default, the _url_format_ is set to _jaeger_ (Changed from Grafana in Kiali 2.17).
-Kiali will use the _external_url_ set in the tracing section, and the url path and query will be following the Jaeger UI format.
+For the Tempo provider, by default, _url_format_ is set to _jaeger_ (Changed from Grafana in Kiali 2.17).
+Kiali will use the _external_url_ configuration to create the redirection link. The URL will have the Jaeger UI format to redirect to specific services and traces.
 
-When set to _grafana_, Kiali will use the _external_url_ set in the Grafana section, such as this example:
+When the url_format is set to _grafana_, Kiali will use the _external_url_ set in the Grafana section, such as this example:
 
 ```yaml
 spec:
@@ -83,7 +83,7 @@ spec:
       external_url: https://grafana.apps-crc.testing/
 ```
 
-It is also possible to set _url_format_ to "openshift". In that case, Kiali will use the url format to redirect to the UI Plugin in OpenShift. 
+It is also possible to set _url_format_ to "openshift". In that case, the url will redirect to the UI Plugin in OpenShift. 
 When it is set to _openshift_, there are other settings as well: 
 
 ```yaml

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
@@ -71,7 +71,7 @@ spec:
 
 Kiali uses the _external_url_ to construct "View in tracing links in the UI. 
 For the Tempo provider the default _url_format_ is _jaeger_ (changed from _grafana_ in Kiali v2.17).
-Kiali will use the _external_url_ configuration to create the redirection link. The URL will have the Jaeger UI format to redirect to specific services and traces.
+So, by default the URL will have the Jaeger UI format when linking to specific services and traces.
 
 When the url_format is set to _grafana_, Kiali will use the _external_url_ set in the Grafana section, such as this example:
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
@@ -69,7 +69,7 @@ spec:
       external_url: "https://tempo-tempo-query-frontend-tempo.apps-crc.testing/"
 ```
 
-Kiali uses the _external_url_ to construct "View in tracing links in the UI. 
+Kiali uses the _external_url_ to construct "View in tracing" links in the UI. 
 For the Tempo provider the default _url_format_ is _jaeger_ (changed from _grafana_ in Kiali v2.17).
 So, by default the URL will have the Jaeger UI format when linking to specific services and traces.
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
@@ -87,6 +87,13 @@ spec:
         url_format: "openshift"
 ```
 
+When the tenant is specified, if _internal_url_ doesn't have a path, it will be autocompleted with the Tempo path. For this example:
+```yaml
+internal_url: https://tempo-sample-gateway.tempo.svc.cluster.local:8080/
+```
+
+Will be autocompleted to: _https://tempo-sample-gateway.tempo.svc.cluster.local:8080/api/traces/v1/{tenant}/tempo_
+
 The other valid option for _url_format_ is _jaeger_, used when the Jaeger UI is available in Tempo.
 
 #### Set up a Tempo Datasource in Grafana

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
@@ -66,22 +66,12 @@ spec:
         url_format: "grafana"
       use_grpc: false
       # Public facing URL of Tempo 
-      external_url: "https://tempo-tempo-query-frontend-tempo.apps-crc.testing/"
+      external_url: "https://grafana-istio-system.apps-crc.testing/"
 ```
 
 Kiali uses the _external_url_ to construct "View in tracing" links in the UI. 
-For the Tempo provider the default _url_format_ is _jaeger_ (changed from _grafana_ in Kiali v2.17).
-So, by default the URL will have the Jaeger UI format when linking to specific services and traces.
-
-If `spec.external_services.tracing.tempo_config.url_format` is set to _grafana_, Kiali will use the _external_url_ set in the `spec.external_services.grafana` section, such as this example:
-
-```yaml
-spec:
-  external_services:
-    grafana:
-      enabled: true
-      external_url: https://grafana.apps-crc.testing/
-```
+For the Tempo provider the default _url_format_ is _grafana_.
+So, by default the URL will have the Grafana UI format when linking to specific services and traces.
 
 It is also possible to set _url_format_ to _openshift_. In this case the URL will redirect to the UI Plugin in the OpenShift console.
 When it is set to _openshift_, there are other settings as well: 
@@ -96,6 +86,8 @@ spec:
         tenant: "default"
         url_format: "openshift"
 ```
+
+The other valid option for _url_format_ is _jaeger_, used when the Jaeger UI is available in Tempo.
 
 #### Set up a Tempo Datasource in Grafana
 

--- a/content/en/docs/FAQ/distributed-tracing.md
+++ b/content/en/docs/FAQ/distributed-tracing.md
@@ -135,26 +135,26 @@ Sometimes Tempo is configured outside the Kiali namespace, so there might be add
 
 ### Why can't I see the link "View in Tracing" when using Tempo?
 
-Some settings needs to be configured in order to enable the external_url.
+Some settings need to be configured in order to enable the external_url.
 
-When _tempo_ is set in the Kiali CR `external_services.tracing.provider`, the default `url_format` is `jaeger`, and `external_services.tracing.external_url` needs to be set accordingly.
+When _tempo_ is set in the Kiali CR `external_services.tracing.provider`, the default `url_format` is `grafana`, and `external_services.tracing.external_url` needs to be set accordingly.
 ```yaml
 tracing:
   provider: "tempo"
-  external_url: "http://jaeger_url"
-  tempo_config:
-    url_format: "jaeger"
-```
-
-When `url_format` is set to _grafana_, Grafana should be enabled, and the `external_services.grafana.external_url` needs to be set: 
-```yaml
-tracing:
-  provider: "tempo"
+  external_url: "http://external-grafana-url"
   tempo_config:
     url_format: "grafana"
+```
+
+When `url_format` is set to _jaeger_, the `external_services.grafana.external_url` needs to be set as well: 
+```yaml
+tracing:
+  provider: "tempo"
+  tempo_config:
+    url_format: "jaeger"
 grafana: 
   enabled: "true"
-  external_url: "http://grafana_url"
+  external_url: "https://tempo-tempo-query-frontend-tempo.apps-crc.testing/"
 ```
 
 When `url_format` is set to _openshift_, there are additional parameters to set:

--- a/content/en/docs/FAQ/distributed-tracing.md
+++ b/content/en/docs/FAQ/distributed-tracing.md
@@ -135,9 +135,9 @@ Sometimes Tempo is configured outside the Kiali namespace, so there might be add
 
 ### Why can't I see the link "View in Tracing" when using Tempo?
 
-When Tempo is set in the Kiali CR `external_services.tracing.provider` but Grafana is not enabled, as Grafana is the default UI for Tempo, Kiali will hide the `View in Tracing links`
-If the Jaeger UI is enabled in Tempo, configure:
+Some settings needs to be configured in order to enable the external_url.
 
+When Tempo is set in the Kiali CR `external_services.tracing.provider`, the default `url_format` is set to `jaeger` and `external_services.tracing.external_url` needs to be set.
 ```yaml
 tracing:
   provider: "tempo"
@@ -145,6 +145,30 @@ tracing:
   tempo_config:
     url_format: "jaeger"
 ```
+
+When `url_format` is set to `grafana`, Grafana should be enabled, and the `external_services.grafana.external_url` needs to be set. 
+```yaml
+tracing:
+  provider: "tempo"
+  tempo_config:
+    url_format: "grafana"
+grafana: 
+  enabled: "true"
+  external_url: "http://grafana_url"
+```
+
+When `url_format` is set to `openshift`, there are additional parameters to set.
+```yaml
+tracing:
+  provider: "tempo"
+  tempo_config:
+    name: "sample"
+    namespace: "tempo"
+    tenant: "default"
+    url_format: "openshift"
+```
+
+Where name, is the name of the Tempo instance, the namespace where is installed and the tenant name where the traces are sent. 
 
 ![View in Tracing](/images/documentation/faq/tracing/view-in-tracing.png)
 

--- a/content/en/docs/FAQ/distributed-tracing.md
+++ b/content/en/docs/FAQ/distributed-tracing.md
@@ -146,7 +146,7 @@ tracing:
     url_format: "jaeger"
 ```
 
-When `url_format` is set to `grafana`, Grafana should be enabled, and the `external_services.grafana.external_url` needs to be set: 
+When `url_format` is set to _grafana_, Grafana should be enabled, and the `external_services.grafana.external_url` needs to be set: 
 ```yaml
 tracing:
   provider: "tempo"

--- a/content/en/docs/FAQ/distributed-tracing.md
+++ b/content/en/docs/FAQ/distributed-tracing.md
@@ -157,7 +157,7 @@ grafana:
   external_url: "http://grafana_url"
 ```
 
-When `url_format` is set to `openshift`, there are additional parameters to set:
+When `url_format` is set to _openshift_, there are additional parameters to set:
 ```yaml
 tracing:
   provider: "tempo"

--- a/content/en/docs/FAQ/distributed-tracing.md
+++ b/content/en/docs/FAQ/distributed-tracing.md
@@ -146,7 +146,7 @@ tracing:
     url_format: "jaeger"
 ```
 
-When `url_format` is set to `grafana`, Grafana should be enabled, and the `external_services.grafana.external_url` needs to be set. 
+When `url_format` is set to `grafana`, Grafana should be enabled, and the `external_services.grafana.external_url` needs to be set: 
 ```yaml
 tracing:
   provider: "tempo"
@@ -157,7 +157,7 @@ grafana:
   external_url: "http://grafana_url"
 ```
 
-When `url_format` is set to `openshift`, there are additional parameters to set.
+When `url_format` is set to `openshift`, there are additional parameters to set:
 ```yaml
 tracing:
   provider: "tempo"
@@ -168,7 +168,10 @@ tracing:
     url_format: "openshift"
 ```
 
-Where name, is the name of the Tempo instance, the namespace where is installed and the tenant name where the traces are sent. 
+Where:
+- name: is the name of the Tempo instance
+- namespace where the Tempo instance is installed 
+- tenant: The tenant name where the traces are sent
 
 ![View in Tracing](/images/documentation/faq/tracing/view-in-tracing.png)
 

--- a/content/en/docs/FAQ/distributed-tracing.md
+++ b/content/en/docs/FAQ/distributed-tracing.md
@@ -137,7 +137,7 @@ Sometimes Tempo is configured outside the Kiali namespace, so there might be add
 
 Some settings needs to be configured in order to enable the external_url.
 
-When Tempo is set in the Kiali CR `external_services.tracing.provider`, the default `url_format` is set to `jaeger` and `external_services.tracing.external_url` needs to be set.
+When _tempo_ is set in the Kiali CR `external_services.tracing.provider`, the default `url_format` is `jaeger`, and `external_services.tracing.external_url` needs to be set accordingly.
 ```yaml
 tracing:
   provider: "tempo"

--- a/content/en/docs/FAQ/distributed-tracing.md
+++ b/content/en/docs/FAQ/distributed-tracing.md
@@ -146,21 +146,20 @@ tracing:
     url_format: "grafana"
 ```
 
-When `url_format` is set to _jaeger_, the `external_services.grafana.external_url` needs to be set as well: 
+When `url_format` is set to _jaeger_, the `external_services.tracing.external_url` needs to be set as well: 
 ```yaml
 tracing:
   provider: "tempo"
+  external_url: "https://tempo-tempo-query-frontend-tempo.apps-crc.testing/"
   tempo_config:
     url_format: "jaeger"
-grafana: 
-  enabled: "true"
-  external_url: "https://tempo-tempo-query-frontend-tempo.apps-crc.testing/"
 ```
 
 When `url_format` is set to _openshift_, there are additional parameters to set:
 ```yaml
 tracing:
   provider: "tempo"
+  external_url: "https://console-openshift-console.apps-crc.testing/"
   tempo_config:
     name: "sample"
     namespace: "tempo"


### PR DESCRIPTION
- Tempo config update: https://deploy-preview-916--kiali.netlify.app/docs/configuration/p8s-jaeger-grafana/tracing/tempo/#set-up-the-kiali-cr
- FAQ Update: https://deploy-preview-916--kiali.netlify.app/docs/faq/distributed-tracing/#why-cant-i-see-the-link-view-in-tracing-when-using-tempo 

Ref. PR: https://github.com/kiali/kiali/issues/8762 