### PR TITLE
external kiali and openshift auth

### DIFF
--- a/content/en/docs/Configuration/authentication/openshift.md
+++ b/content/en/docs/Configuration/authentication/openshift.md
@@ -17,7 +17,7 @@ logged in if the user has enough privileges.
 
 The `openshift` strategy supports [namespace access control]({{< relref "../rbac" >}}).
 
-The `openshift` strategy is only supported for single cluster.
+The `openshift` strategy is supported for single and multi-cluster deployments.
 
 ## Set-up
 
@@ -53,7 +53,7 @@ Assuming Kiali is installed via the Kiali Operator. Any customization would be d
 - `spec.deployment.instance_name`
 
 {{% alert color="info" %}}
-It is recommended that the Kiali Operator be deployed on all clusters, even if Kiali itself is not deployed. This will ensure that the proper directory and remote cluster resources are provided. For clusters without Kiali, requiring only the remote cluster resources (for auth), configure the CR with:
+It is recommended that the Kiali Operator be deployed on all clusters, even if Kiali itself is not deployed. This will ensure that the proper namespace and remote cluster resources are created. For clusters without Kiali, requiring only the remote cluster resources (for auth), configure the CR with:
 
 - `spec.deployment.remote_cluster_resources_only: true`
   {{% /alert %}}

--- a/content/en/docs/Configuration/authentication/openshift.md
+++ b/content/en/docs/Configuration/authentication/openshift.md
@@ -37,7 +37,28 @@ configuration settings that most people will never need but are available in cas
 a situation where the customization is needed. See the Kiali CR Reference page for the
 documentation on those settings.
 
-### Multi-Cluster - Using an internal or self-signed certificate
+### Multi-Cluster
+
+There are some things to know when using the `openshift` strategy with Kiali in a multi-cluster environment.
+
+#### Consistent Kiali Namespace and Instance-Name
+
+The default namespace for Kiali is `istio-system`. But many users prefer to use a dedicated namespace for Kiali, such as `kiali`, `kiali-server`, etc. In a multi-cluster environment Kiali must be deployed in the same namespace on each cluster. Clusters that don't have a Kiali deployment must still provide the namespace, to hold the remote cluster resources.
+
+The default instance-name for kiali is `kiali`. Any change to the default must also be made consistently across all clusters.
+
+Assuming Kiali is installed via the Kiali Operator. Any customization would be done via the following CR settings:
+
+- `spec.deployment.namespace`
+- `spec.deployment.instance_name`
+
+{{% alert color="info" %}}
+It is recommended that the Kiali Operator be deployed on all clusters, even if Kiali itself is not deployed. This will ensure that the proper directory and remote cluster resources are provided. For clusters without Kiali, requiring only the remote cluster resources (for auth), configure the CR with:
+
+- `spec.deployment.remote_cluster_resources_only: true`
+  {{% /alert %}}
+
+#### Using an internal or self-signed certificate
 
 If you have a multi-cluster Kiali deployment and the OAuth server is configured with an external IdP that uses an internal or self-signed certificate, you can configure Kiali to trust the server's certificate by creating a ConfigMap named `kiali-oauth-cabundle` containing the CA certificate bundle for the server under the `oauth-server-ca.crt` key:
 

--- a/content/en/docs/Configuration/multi-cluster/_index.md
+++ b/content/en/docs/Configuration/multi-cluster/_index.md
@@ -20,12 +20,20 @@ Before proceeding with the setup, ensure you meet the requirements.
 The unified Kiali multi-cluster setup requires the Kiali Service Account (SA) to have read access to each Kubernetes cluster in the mesh. This is separate from the user credentials that are required when a user logs into Kiali. The user credentials are used to check user access to a namespace and to perform write operations. In anonymous mode, the Kiali SA is used for all operations. Write access need not be required if you only want to give Kiali "view-only" capabilities. To give the Kiali SA access to each remote cluster, a kubeconfig with credentials needs to be created and mounted into the Kiali pod. While the location of Kiali in relation to the controlplane and dataplane may change depending on your Istio deployment model, the requirements will remain the same.
 
 {{% alert color="info" %}}
-If you would like to keep a separate Kiali per cluster and do not want to give Kiali access to remote clusters, you can still manually specify the remote cluster and remote Kiali URLs in the Kiali configuration and the UI will try to provide links to the external Kiali where appropriate. See [below](#adding-an-inaccessible-cluster) for more details.
+Although not required for some deployment models, it is recommended that the Kiali namespace and instance name be consistent across all clusters, including remote clusters without a Kiali server deployed. If not using default values, the following Kiali CR settings should typically have consistent values:
+
+- `spec.deployment.namespace`
+- `spec.deployment.instance_name`
+  {{% /alert %}}
+
+{{% alert color="info" %}}
+If you would like to keep a separate Kiali per cluster and do not want to give Kiali access to remote clusters, you can still manually specify the remote cluster and remote Kiali URLs in the Kiali configuration and the UI will try to provide links to the remote Kiali where appropriate. See [below](#adding-an-inaccessible-cluster) for more details.
 {{% /alert %}}
 
 1. **Create a SA and its associated resources on the remote cluster.** In order for Kiali to access a remote cluster, you first must create a SA and its role/role binding with the proper permissions. The Kiali Operator can create these resources for you; simply deploy the Kiali Operator on the remote cluster and then create a Kiali CR on that remote cluster making sure to set the Kiali CR setting `spec.deployment.remote_cluster_resources_only` to `true`. The Kiali Operator will manage those remote cluster resources for you; deleting the Kiali CR will instruct the Kiali Operator to remove the resources. If you elect not to use the Kiali Operator, you can use the Kiali Server helm chart (with the `--set deployment.remote_cluster_resources_only=true` option) or the [kiali-prepare-remote-cluster.sh script](https://github.com/kiali/kiali/blob/master/hack/istio/multicluster/kiali-prepare-remote-cluster.sh) (with the `--process-remote-resources true` option) to create these remote cluster resources.
 
 2. **Create a remote cluster secret.** In order for Kiali to access a remote cluster, you must provide a kubeconfig to Kiali via a Kubernetes secret. This requires you to obtain a token for the remote cluster's SA created in step 1. A remote cluster secret will look something like this:
+
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -54,7 +62,9 @@ stringData:
         server: <...the URL to your remote cluster goes here...>
         certificate-authority-data: <...the long CA data goes here...>
 ```
+
 You can place multiple kubeconfigs in a single secret. A Kiali multi-cluster secret will look similar to a single cluster secret, but with multiple kubeconfigs each with a key that is the name of the remote cluster (in the example below, there are two keys: `my-cluster-name` and `my-other-cluster`). Name the secret `kiali-multi-cluster-secret` for the added benefit of having the operator automatically detect this secret without having to configure anything within the Kiali CR. If you do name the secret `kiali-multi-cluster-secret` you also can add to it the label `kiali.io/kiali-multi-cluster-secret="true"` which will tell the operator to restart the Kiali Server pod automatically when the secret changes thus allowing the server to pick up the changes immediately.
+
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -104,41 +114,45 @@ stringData:
 ```
 
 The [verify-kiali-permissions.sh script](https://github.com/kiali/kiali/blob/master/hack/istio/multicluster/verify-kiali-permissions.sh) can be used to check that your remote cluster secret provides the necessary permissions that Kiali needs to access the remote cluster. See the comments at the top of the script and its `--help` output for details on how to run it, but here's an example:
-   ```sh
-   curl -L -o verify-kiali-permissions.sh https://raw.githubusercontent.com/kiali/kiali/master/hack/istio/multicluster/verify-kiali-permissions.sh
-   chmod +x verify-kiali-permissions.sh
-   ./verify-kiali-permissions.sh --kubeconfig-secret istio-system:kiali-multi-cluster-secret:my-cluster-name --kiali-version v2.10.0
-   ```
+
+```sh
+curl -L -o verify-kiali-permissions.sh https://raw.githubusercontent.com/kiali/kiali/master/hack/istio/multicluster/verify-kiali-permissions.sh
+chmod +x verify-kiali-permissions.sh
+./verify-kiali-permissions.sh --kubeconfig-secret istio-system:kiali-multi-cluster-secret:my-cluster-name --kiali-version v2.10.0
+```
 
 It is up to you how you want to create and manage the token and secret, however, you can use the [kiali-prepare-remote-cluster.sh script](https://github.com/kiali/kiali/blob/master/hack/istio/multicluster/kiali-prepare-remote-cluster.sh) (with the `--process-kiali-secret true` option) to simplify this process for you.
 
 {{% alert color="info" %}}
 The `kiali-prepare-remote-cluster.sh` script can be used to:
-   - Create a Kiali SA and its role/role-binding in the remote cluster
 
-   and/or,
+- Create a Kiali SA and its role/role-binding in the remote cluster
 
-   - Create a kubeconfig file and store it in a Kubernetes secret that is created in the namespace where Kiali is deployed.
+and/or,
+
+- Create a kubeconfig file and store it in a Kubernetes secret that is created in the namespace where Kiali is deployed.
 
 In order to run this script you will need adequate permissions configured in your local kubeconfig for both the cluster on which Kiali is deployed and the remote cluster.
 
 For example:
-   ```sh
-   curl -L -o kiali-prepare-remote-cluster.sh https://raw.githubusercontent.com/kiali/kiali/master/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
-   chmod +x kiali-prepare-remote-cluster.sh
-   ./kiali-prepare-remote-cluster.sh --kiali-cluster-context east --remote-cluster-context west --view-only false --process-kiali-secret true --process-remote-resources true
-   ```
+
+```sh
+curl -L -o kiali-prepare-remote-cluster.sh https://raw.githubusercontent.com/kiali/kiali/master/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+chmod +x kiali-prepare-remote-cluster.sh
+./kiali-prepare-remote-cluster.sh --kiali-cluster-context east --remote-cluster-context west --view-only false --process-kiali-secret true --process-remote-resources true
+```
+
 Use the option `--help` for additional details on using the script to create and delete the remote cluster resources and secrets.
 {{% /alert %}}
 
 3. **Configure Kiali.** The Kiali CR provides configuration settings that enable the Kiali Server to use remote cluster secrets in order to access remote clusters. By default, the Kiali Operator will [auto-detect](/docs/configuration/kialis.kiali.io/#.spec.clustering.autodetect_secrets) any remote cluster secret that has a label `kiali.io/multiCluster="true"` and is found in the Kiali deployment namespace. The secrets created by the `kiali-prepare-remote-cluster.sh` script will be created that way and thus can be auto-detected. Alternatively, in the Kiali CR you can [explicitly specify each remote cluster secret](/docs/configuration/kialis.kiali.io/#.spec.clustering.clusters) rather than rely on auto-discovery. As a final alternative, you can create a single secret named `kiali-multi-cluster-secret` within the Kiali deployment namespace. Within that single secret you put the kubeconfigs for all of your remote clusters, each kubeconfig within its own top-level key under the secret's `stringData`, where the key name is the name of the cluster. As an added feature, if you label that `kiali-multi-cluster-secret` with the label `kiali.io/kiali-multi-cluster-secret="true"` then the Kiali Operator will be able to auto-detect changes to that secret and rollout a new Kiali Server pod so it can automatically update the remote cluster information.
-{{% alert color="info" %}}
-Do **not** use the label `kiali.io/kiali-multi-cluster-secret="true"` on any other secret not specifically named `kiali-multi-cluster-secret`. The operator will not have permission to see that secret and errors will occur if you attempt this.
-{{% /alert %}}
-{{% alert color="info" %}}
-If you have multiple Kial Servers deployed in the same namespace, and you want to use that single secret named `kiali-multi-cluster-secret`, all Kiali Servers in that namespace are required to use that secret. If you want each Kiali Server to talk to a different set of clusters, you must not use the `kiali-multi-cluster-secret` secret.
-{{% /alert %}}
-Given the remote cluster secrets it knows about (either through auto-discovery or through explicit configuration) the Kiali Operator will mount the remote cluster secrets into the Kiali Server pod effectively putting Kiali in "multi-cluster" mode. Kiali will begin using those credentials to communicate with the other clusters in the mesh.
+   {{% alert color="info" %}}
+   Do **not** use the label `kiali.io/kiali-multi-cluster-secret="true"` on any other secret not specifically named `kiali-multi-cluster-secret`. The operator will not have permission to see that secret and errors will occur if you attempt this.
+   {{% /alert %}}
+   {{% alert color="info" %}}
+   If you have multiple Kial Servers deployed in the same namespace, and you want to use that single secret named `kiali-multi-cluster-secret`, all Kiali Servers in that namespace are required to use that secret. If you want each Kiali Server to talk to a different set of clusters, you must not use the `kiali-multi-cluster-secret` secret.
+   {{% /alert %}}
+   Given the remote cluster secrets it knows about (either through auto-discovery or through explicit configuration) the Kiali Operator will mount the remote cluster secrets into the Kiali Server pod effectively putting Kiali in "multi-cluster" mode. Kiali will begin using those credentials to communicate with the other clusters in the mesh.
 
 4. Optional - **Configure user access in your OIDC provider.** When using anonymous mode, the Kiali SA credentials will be used to display mesh info to the user. When not using anonymous mode, Kiali will check the user's access to each configured cluster's namespace before showing the user any resources from that namespace. Please refer to your OIDC provider's instructions for configuring user access to a kube cluster for this.
 
@@ -158,7 +172,7 @@ After the remote cluster secret has been removed, you must then tell the Kiali O
 
 ### Adding an Inaccessible Cluster
 
-In situations where Kiali does not have access to remote clusters, you can manually specify the remote cluster info along with any external Kialis running on the remote clusters and Kiali will try to provide links to these in the UI. For example, if there is a Kiali on the `east` cluster that does not have access to the `west` cluster and a Kiali on the `west` cluster that does not have access to the `east` cluster, you can add the following to your Kiali configurations to have each Kiali generate links to the external Kiali for that cluster.
+In situations where Kiali does not have access to remote clusters, you can manually specify the remote cluster info along with any Kialis running on the remote clusters and Kiali will try to provide links to these in the UI. For example, if there is a Kiali on the `east` cluster that does not have access to the `west` cluster and a Kiali on the `west` cluster that does not have access to the `east` cluster, you can add the following to your Kiali configurations to have each Kiali generate links to the Kiali for that cluster.
 
 East Kiali configuration
 

--- a/content/en/docs/Configuration/multi-cluster/external/_index.md
+++ b/content/en/docs/Configuration/multi-cluster/external/_index.md
@@ -3,20 +3,27 @@ title: "External Kiali"
 description: "Deploy Kiali on a Management Cluster."
 ---
 
-Larger mesh deployments may desire to separate mesh operation from mesh observability. By deploying Kiali on a cluster away from the mesh, it allows for dedicated management and resource consumption.
+Larger mesh deployments may desire to separate mesh operation from mesh observability. This means deploying Kiali, and potentially other observability tooling, away from the mesh.
+
+This separation allows for:
+
+- Dedicated management of mesh observability
+- Reduced resource consumption on mesh clusters
+- Centralized visibility across multiple mesh clusters
+- Improved security isolation
 
 ### Deployment Model
 
 This deployment model requires a minimum of two clusters. The Kiali "home" cluster (where Kiali is deployed) will serve as the "management" cluster. The "mesh" cluster(s) will be where your service mesh is deployed. The mesh deployment will still conform to any of the Istio deployment models that Kiali already supports. The fundamental difference is that Kiali will not be co-located with an Istio control plane, but instead will reside away from the mesh. For multi-cluster mesh deployments, all of the same requirements apply, such as unified metrics and traces, etc.
 
-It is recommended, but not required, that joining Kiali on the "management" cluster, you also place your other observability tooling, like the metrics store. This will further reduce observability resources on the mesh cluster(s), and will likely reduce latency between Kiali and those data stores.
+It is recommended, but not required, that joining Kiali on the "management" cluster is other observability tooling, like the metrics store. This will further reduce observability resources on the mesh cluster(s), and will likely reduce latency between Kiali and those data stores. But, it may require additional work, like federating Prometheus databases, etc.
 
 The high-level deployment model looks like this:
 ![Kiali multi-cluster](/images/documentation/configuration/external-kiali.png)
 
 ### Configuration
 
-Configuring Kiali for the external deployment model has the same requirements needed for a co-located Kiali in a [multi-cluster installation]({{< relref "../Multi-cluster" >}}). Kiali still needs the necessary secrets for accessing the remote clusters. 
+Configuring Kiali for the external deployment model has the same requirements needed for a co-located Kiali in a [multi-cluster installation]({{< relref "../../Multi-cluster" >}}). Kiali still needs the necessary secrets for accessing the remote clusters.
 
 Additionally, the configuration needs to indicate that Kiali will not be managing its home cluster. This is done in the Kiali CR by setting:
 
@@ -31,6 +38,7 @@ Kiali typically sets its home cluster name to the same cluster name set by the c
 kubernetes_config:
   cluster_name: <KialiHomeClusterName>
 ```
+
 ### Authorization
 
-The external deployment model currently supports openid and anonymous authorization strategies. OpenShift and token auth are untested and considered experimental.
+The external deployment model currently supports `openid`, `openshift`, and `anonymous` authorization strategies. `token` auth is untested and considered experimental.

--- a/content/en/docs/Configuration/multi-cluster/external/_index.md
+++ b/content/en/docs/Configuration/multi-cluster/external/_index.md
@@ -16,7 +16,7 @@ This separation allows for:
 
 This deployment model requires a minimum of two clusters. The Kiali "home" cluster (where Kiali is deployed) will serve as the "management" cluster. The "mesh" cluster(s) will be where your service mesh is deployed. The mesh deployment will still conform to any of the Istio deployment models that Kiali already supports. The fundamental difference is that Kiali will not be co-located with an Istio control plane, but instead will reside away from the mesh. For multi-cluster mesh deployments, all of the same requirements apply, such as unified metrics and traces, etc.
 
-It is recommended, but not required, that joining Kiali on the "management" cluster is other observability tooling, like the metrics store. This will further reduce observability resources on the mesh cluster(s), and will likely reduce latency between Kiali and those data stores. But, it may require additional work, like federating Prometheus databases, etc.
+It can be beneficial to co-locate other observability tooling on the management cluster. For example, co-locating Prometheus will likely improve Kiali's metric query performance, while also reducing Prometheus resource consumption on the mesh cluster(s). Although, it may require additional configuration, like federating Prometheus databases, etc.
 
 The high-level deployment model looks like this:
 ![Kiali multi-cluster](/images/documentation/configuration/external-kiali.png)

--- a/content/en/docs/Configuration/multi-cluster/external/external-openshift.md
+++ b/content/en/docs/Configuration/multi-cluster/external/external-openshift.md
@@ -1,0 +1,19 @@
+---
+title: "OpenShift"
+description: "Deploying External Kiali on OpenShift"
+weight: 10
+---
+
+These are specific notes for the External Kiali deployment model on OpenShift.
+
+## Installation
+
+It is highly recommended that the Kiali Operator be deployed on all clusters, even if Kiali itself is not deployed. This will ensure that the proper directory and remote cluster resources are provided. Clusters without Kiali require only the remote cluster resources (for auth), configure the CR with:
+
+- `spec.deployment.remote_cluster_resources_only: true`
+
+Running the Kiali Operator in this more requires very limited resources.
+
+## Authorization Strategy
+
+The openshift authentication strategy is required for production Kiali deployments on OpenShift. Make sure to read and apply any guidance found in the notes for [multi-cluster]({{< relref "../../authentication/openshift#multi-cluster" >}}).

--- a/content/en/docs/Configuration/multi-cluster/external/external-openshift.md
+++ b/content/en/docs/Configuration/multi-cluster/external/external-openshift.md
@@ -8,7 +8,7 @@ These are specific notes for the External Kiali deployment model on OpenShift.
 
 ## Installation
 
-It is highly recommended that the Kiali Operator be deployed on all clusters, even if Kiali itself is not deployed. This will ensure that the proper directory and remote cluster resources are provided. Clusters without Kiali require only the remote cluster resources (for auth), configure the CR with:
+It is highly recommended that the Kiali Operator be deployed on all clusters, even if Kiali itself is not deployed. This will ensure that the proper namespace and remote cluster resources are created. Clusters without Kiali require only the remote cluster resources (for auth), configure the CR with:
 
 - `spec.deployment.remote_cluster_resources_only: true`
 


### PR DESCRIPTION
Add and restructure some information around "openshift" auth strategy on MC, and External Kiali deployment on OpenShift.

https://deploy-preview-922--kiali.netlify.app/docs/configuration/authentication/openshift/#consistent-kiali-namespace-and-instance-name

https://deploy-preview-922--kiali.netlify.app/docs/configuration/multi-cluster/#setup

https://deploy-preview-922--kiali.netlify.app/docs/configuration/multi-cluster/external/#authorization

https://deploy-preview-922--kiali.netlify.app/docs/configuration/multi-cluster/external/external-openshift/