### PR TITLE
Update OSSMC compatibility table

### DIFF
--- a/data/compatibility/ossmc.yaml
+++ b/data/compatibility/ossmc.yaml
@@ -1,11 +1,15 @@
 # The Compatible Version Matrix between OSSMC, OCP and Kiali
 # See: content/en/docs/Installation/installation-guide/prerequisites.md -> {{<compat-table-ossmc>}}
 versionRange:
-  - ocpVersion: "4.15+"
-    minOSSMCVersion: "1.84"
+  - ocpVersion: "4.19+"
+    minOSSMCVersion: "2.20"
     maxOSSMCVersion: ""
     notes:
-  - ocpVersion: "4.12+"
+  - ocpVersion: "4.15+"
+    minOSSMCVersion: "1.84"
+    maxOSSMCVersion: "2.19"
+    notes:
+  - ocpVersion: "4.12-4.18"
     minOSSMCVersion: "1.73"
     maxOSSMCVersion: "1.83"
     notes: "All OSSMC versions from v1.73 to v1.83 are only compatible with Kiali server v1.73"


### PR DESCRIPTION
Update OSSMC compatibility table:
- OSSMC versions 1.73-1.83 are not supported in OCP 4.19+
- New OSSMC version 2.20 will be only compatible for OCP 4.19+