### PR TITLE
Fix negative rounding issue in the release schedule

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,9 +56,10 @@ jobs:
 
         diff = now - base
 
-        days_elapsed = int(diff / (24*60*60))
-        weeks_elapsed = int(days_elapsed / 7)
-        weeks_mod3 = int(weeks_elapsed % 3)
+        # Use floor division (//) which correctly avoids rounding negative values to 0
+        days_elapsed = diff // (24*60*60)
+        weeks_elapsed = days_elapsed // 7
+        weeks_mod3 = weeks_elapsed % 3
 
         # Only release when weeks_elapsed >= 0 (past the base date) and weeks_mod3 == 0
         print (weeks_elapsed >= 0 and weeks_mod3 == 0) # True in case of release


### PR DESCRIPTION
### Describe the change

The release schedule calculation in the CI workflow could incorrectly trigger releases 1-6 days before the base date (January 26, 2026) due to Python's int() function truncating toward zero instead of flooring.

**Example of the bug**
3 days before base date: diff = -259200 seconds
int(-3/7) = 0 (truncates toward zero)
Condition weeks_elapsed >= 0 evaluates to True -> unintended release

**Root Cause**
Using int(x / y) for division truncates toward zero, which behaves differently for negative numbers compared to floor division:
```
Expression	int() 	// (floor)
-3 / 7	     0	        -1
-6 / 7	     0          -1
```

**Solution**
Replace int(x / y) with floor division (//), which correctly rounds toward negative infinity