### PR TITLE
update docs regarding the root_namespace auto-detection

### DIFF
--- a/content/en/docs/Configuration/istio.md
+++ b/content/en/docs/Configuration/istio.md
@@ -45,15 +45,17 @@ page](https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/) and
 search for "rootNamespace".
 
 Kiali uses the root namespace for some of the validations of Istio resources.
-If you customized the Istio root namespace, you will need to replicate that
-configuration in Kiali. By default, it is unset:
+**Kiali automatically detects the root namespace for each Istio control plane**,
+so no manual configuration is required. This enables Kiali to properly support
+environments with multiple Istio control planes, where each control plane may
+have a different root namespace.
 
-```yaml
-spec:
-  external_services:
-    istio:
-      root_namespace: ""
-```
+{{% alert color="info" %}}
+Prior to Kiali v2.16, the root namespace was configured manually via the
+`external_services.istio.root_namespace` setting. This configuration option
+has been removed as Kiali now autodetects the appropriate root namespace
+for each control plane.
+{{% /alert %}}
 
 ## Sidecar injection, canary upgrade management and Istio revisions
 

--- a/layouts/shortcodes/videos.html
+++ b/layouts/shortcodes/videos.html
@@ -1,7 +1,14 @@
 {{- $maxVids := 3 }}
 {{- $feedURL      := "https://www.toptal.com/developers/feed2json/convert?url=https://www.youtube.com/feeds/videos.xml?channel_id=UCcm2NzDN_UCZKk2yYmOpc5w" }}
+{{- $videos       := slice }}
 {{- $json         := getJSON $feedURL }}
-{{- $videos       := first $maxVids $json.items }}
+{{- if $json }}
+  {{- if $json.items }}
+    {{- if gt (len $json.items) 0 }}
+      {{- $videos = first $maxVids $json.items }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 
 <h3 class="videos-header">
   Latest
@@ -10,6 +17,7 @@
   </a>
 </h3>
 
+{{ if $videos }}
 {{ range $videos }}
   {{ $url    := .url }}
   {{ $vidId   := index (split .guid ":") 2 }}
@@ -28,5 +36,10 @@
       </div>
     </div>
   </div>
+{{ end }}
+{{ else }}
+<div class="col-12 text-center">
+  <p>Unable to load videos at this time. <a href="https://www.youtube.com/channel/UCcm2NzDN_UCZKk2yYmOpc5w" target="_blank">Visit our YouTube channel</a> to see the latest videos.</p>
+</div>
 {{ end }}
 


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/9236

I think we should backport this to `current` branch.

netlify: https://deploy-preview-951--kiali.netlify.app/docs/configuration/istio/#root-namespace

Side-fix: The videos shortcode was failing CI builds when the external feed2json service
returned errors instead of valid YouTube data. The template tried to call Hugo's
'first' function on nil data, causing "both limit and seq must be provided" error.
Added defensive checks to validate JSON response and graceful fallback when videos
can't be loaded, preventing external service outages from breaking site builds.