### PR TITLE
istiod registry no longer accessed by kiali

### DIFF
--- a/content/en/docs/Configuration/no-istiod.md
+++ b/content/en/docs/Configuration/no-istiod.md
@@ -33,7 +33,6 @@ When the Istio API is not available there is expected feature degradation in Kia
 * The proxy status won't be available in the workloads details view.
 * The [Istio validations](#a-nameistio_validationsa-istio-validations) may not be available.
 * The Kiali validations will not be available.
-* The [Istio Registry Services](#a-nameistio_registrya-istio-registry-services) that are not present in the Kubernetes list won't be available.
 
 Note that [Istio Configurations](#a-nameistio_configurationsa-istio-configurations) will be available. This is because the list of Istio configurations is obtained using the Kubernetes API. 
 
@@ -48,24 +47,12 @@ But, if the Istio Config was created when the validatingwebhookconfiguration web
 
 The Kiali validations won't be available, as they are degraded, so they have been disabled too. 
 
-### <a name="istio_registry"></a> Istio Registry Services
-
-The Istio Registry Services won't be available in the service list when the Istio API is disabled. 
-
-The following image shows a service list when Istio API is enabled: 
-
-<img src="/images/documentation/configuration/registry_services.png" />
-
-The following image shows the same list when it is disabled: 
-
-<img src="/images/documentation/configuration/registry_services_api_disabled.png" />
-
 ### <a name="istio_configurations"></a> Istio Configurations
 
 The Istio Configurations are available in view and edit mode. 
 It is important to know that the validations are disabled, so the configurations created or modified won't be validated.  
 
-There is one scenario where the creation/deletion/edition could fail: If the Istio validation webhook is enabled but the Istio registry is not available. In this case, the webhook should be removed in order for this to work. 
+There is one scenario where the creation/deletion/edition could fail: If the Istio validation webhook is enabled but Istiod is not reachable. In this case, the webhook should be removed in order for this to work.
 
 It can be checked with the following command: 
 

--- a/content/en/docs/Installation/installation-guide/prerequisites.md
+++ b/content/en/docs/Installation/installation-guide/prerequisites.md
@@ -14,8 +14,7 @@ those are not required by Kiali. Refer to the
 
 ### Optionally Enable the Debug Interface
 
-Like `istioctl`, Kiali can make use of Istio's port 8080 "Debug Interface" API. Despite the naming, this is required for accessing the status of the proxies
-and the Istio registry.
+Like `istioctl`, Kiali can make use of Istio's port 8080 "Debug Interface" API. Despite the naming, this is required for accessing the status of the proxies.
 
 The `ENABLE_DEBUG_ON_HTTP` setting controls the relevant API access. Istio suggests to disable this for security, but Kiali requires `ENABLE_DEBUG_ON_HTTP=true`,
 which is the default.


### PR DESCRIPTION
part of: https://github.com/kiali/kiali/issues/6922

* Server PR: https://github.com/kiali/kiali/pull/9269
* Operator PR: https://github.com/kiali/kiali-operator/pull/1015
* Helm Chart PR: https://github.com/kiali/helm-charts/pull/385
* Docs PR: https://github.com/kiali/kiali.io/pull/954

netlify:
* https://deploy-preview-954--kiali.netlify.app/docs/installation/installation-guide/prerequisites/#optionally-enable-the-debug-interface
* https://deploy-preview-954--kiali.netlify.app/docs/configuration/no-istiod/