### PR TITLE
Replace third-party feed converters in blog and videos shortcodes

### DIFF
--- a/layouts/shortcodes/blog.html
+++ b/layouts/shortcodes/blog.html
@@ -1,8 +1,28 @@
 {{- $maxBlogPosts := 3 }}
-{{- $mediumURL    := "https://api.rss2json.com/v1/api.json?rss_url=https://medium.com/feed/kialiproject" }}
-{{- $json         := getJSON $mediumURL }}
-{{- $posts        := first $maxBlogPosts $json.items }}
-{{- $latestPost   := index $json.items 1 }}
+{{- $mediumFeedURL := "https://medium.com/feed/kialiproject" }}
+{{- $feedData     := dict }}
+{{- $opts         := dict "timeout" "10s" }}
+{{- $r            := resources.GetRemote $mediumFeedURL $opts }}
+{{- if $r }}
+  {{- if $r.Err }}
+    {{- warnf "Blog shortcode: failed to fetch Medium feed: %s" $r.Err }}
+  {{- else }}
+    {{- $parsed := $r.Content | transform.Unmarshal (dict "format" "xml") }}
+    {{- if $parsed.channel }}
+      {{- $feedData = $parsed }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- $items := slice }}
+{{- if $feedData.channel.item }}
+  {{- $rawItems := $feedData.channel.item }}
+  {{- if reflect.IsMap $rawItems }}
+    {{- $items = slice $rawItems }}
+  {{- else }}
+    {{- $items = first $maxBlogPosts $rawItems }}
+  {{- end }}
+{{- end }}
 
 <h3 class="blog-header">
   Latest
@@ -11,13 +31,29 @@
   </a>
 </h3>
 
-{{ range $posts }}
-  {{ $link    := .link }}
-  {{ $title   := .title }}
-  {{ $author  := .author }}
-  {{ $dateRaw := .pubDate }}
-  {{ $date    := dateFormat "January 2, 2006" $dateRaw }}
-  {{ $summary := .description | plainify | truncate 200 }}
+{{ range $items }}
+  {{- $link := .link }}
+  {{- $title := .title }}
+  {{- if reflect.IsMap $title }}
+    {{- $title = index $title "#text" | default (index $title "content") | default "" }}
+  {{- end }}
+  {{- $author := or .creator .author "Kiali" }}
+  {{- if reflect.IsMap $author }}
+    {{- $author = index $author "#text" | default "Kiali" }}
+  {{- end }}
+  {{- $dateRaw := .pubDate }}
+  {{- $date := dateFormat "January 2, 2006" $dateRaw }}
+  {{- $desc := .description }}
+  {{- if reflect.IsMap $desc }}
+    {{- $desc = index $desc "#text" | default (index $desc "content") | default "" }}
+  {{- end }}
+  {{- if not $desc }}
+    {{- $desc = .encoded }}
+    {{- if reflect.IsMap $desc }}
+      {{- $desc = index $desc "#text" | default (index $desc "content") | default "" }}
+    {{- end }}
+  {{- end }}
+  {{- $summary := $desc | plainify | truncate 200 }}
   <div class="col-lg-4 mb-5 mb-lg-0 text-center ">
     <div class="blog-card">
       <figure>

--- a/layouts/shortcodes/videos.html
+++ b/layouts/shortcodes/videos.html
@@ -1,12 +1,26 @@
 {{- $maxVids := 3 }}
-{{- $feedURL      := "https://www.toptal.com/developers/feed2json/convert?url=https://www.youtube.com/feeds/videos.xml?channel_id=UCcm2NzDN_UCZKk2yYmOpc5w" }}
-{{- $videos       := slice }}
-{{- $json         := getJSON $feedURL }}
-{{- if $json }}
-  {{- if $json.items }}
-    {{- if gt (len $json.items) 0 }}
-      {{- $videos = first $maxVids $json.items }}
+{{- $feedURL   := "https://www.youtube.com/feeds/videos.xml?channel_id=UCcm2NzDN_UCZKk2yYmOpc5w" }}
+{{- $feedData  := dict }}
+{{- $opts      := dict "timeout" "10s" }}
+{{- $r         := resources.GetRemote $feedURL $opts }}
+{{- if $r }}
+  {{- if $r.Err }}
+    {{- warnf "Videos shortcode: failed to fetch YouTube feed: %s" $r.Err }}
+  {{- else }}
+    {{- $parsed := $r.Content | transform.Unmarshal (dict "format" "xml") }}
+    {{- if $parsed.entry }}
+      {{- $feedData = $parsed }}
     {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- $entries := slice }}
+{{- if $feedData.entry }}
+  {{- $raw := $feedData.entry }}
+  {{- if reflect.IsMap $raw }}
+    {{- $entries = slice $raw }}
+  {{- else }}
+    {{- $entries = first $maxVids $raw }}
   {{- end }}
 {{- end }}
 
@@ -17,13 +31,33 @@
   </a>
 </h3>
 
-{{ if $videos }}
-{{ range $videos }}
-  {{ $url    := .url }}
-  {{ $vidId   := index (split .guid ":") 2 }}
-  {{ $title   := .title | truncate 80 }}
-  {{ $dateRaw := .date_published }}
-  {{ $date    := dateFormat "January 2, 2006" $dateRaw }}
+{{ if $entries }}
+{{ range $entries }}
+  {{- $vidId := .videoId | default (index . "videoId") }}
+  {{- if not $vidId }}
+    {{- $vidId = index (split .id ":") 2 }}
+  {{- end }}
+  {{- $url := "" }}
+  {{- if reflect.IsMap .link }}
+    {{- $url = .link.href | default (index .link "href") | default "" }}
+  {{- else }}
+    {{- range .link }}
+      {{- $rel := .rel | default (index . "-rel") }}
+      {{- if or (eq $rel "alternate") (not $url) }}
+        {{- $url = .href | default (index . "href") | default $url }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- if not $url }}
+    {{- $url = printf "https://www.youtube.com/watch?v=%s" $vidId }}
+  {{- end }}
+  {{- $title := .title }}
+  {{- if reflect.IsMap $title }}
+    {{- $title = index $title "#text" | default (index $title "content") | default "" }}
+  {{- end }}
+  {{- $title = $title | truncate 80 }}
+  {{- $dateRaw := .published | default (index . "published") }}
+  {{- $date := dateFormat "January 2, 2006" $dateRaw }}
   <div class="col-lg-4 mb-5 mb-lg-0 text-center ">
     <div class="video-card">
       <figure>


### PR DESCRIPTION
We are experiencing a lot of failed Netlify builds. I think it has to do with the free converters we were using to convert the RSS feeds into something consumable for Hugo. This PR removes that tooling in favor of native handling. It's sort of yucky looking but seems to work.

https://deploy-preview-959--kiali.netlify.app/#td-block-3

This should get backported to `current` and `v2.23`, neither of which are currently deployed successfully.