### PR TITLE
Add ability to enable/disable Prometheus via external_services.prometheus.enabled

### DIFF
--- a/content/en/docs/Configuration/p8s-jaeger-grafana/_index.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/_index.md
@@ -3,7 +3,7 @@ title: "Prometheus, Tracing, Grafana"
 description: "Kiali data sources and add-ons."
 ---
 
-Prometheus is a required telemetry data source for Kiali. Jaeger/Tempo is a highly recommended tracing data source. Kiali also offers simple add-on integrations for Grafana and Perses. This page describes how to configure Kiali to communicate with these dependencies.
+Prometheus is the default telemetry data source for Kiali and is enabled by default. It can be disabled if metrics features are not needed. Jaeger/Tempo is a highly recommended tracing data source. Kiali also offers simple add-on integrations for Grafana and Perses. This page describes how to configure Kiali to communicate with these dependencies.
 
 Read the dedicated configuration page to learn more.
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -31,6 +31,23 @@ However, the graph, metrics tabs, traffic tabs, and request-rate health will be
 unavailable. Health badges for workloads and apps will degrade to show only
 Kubernetes-level status (replica counts).
 
+The UI will display a subtle informational message reminding you that metrics
+features are unavailable due to your configuration choice.
+
+### When Prometheus is Unreachable
+
+When Prometheus is enabled (the default) but Kiali cannot reach it at startup,
+Kiali will still start successfully with metrics features temporarily unavailable.
+
+The UI will display a warning notification explaining why metrics are
+unavailable. The Prometheus component will still appear in the masthead status
+and the mesh topology page, reported as unhealthy, so you have clear visibility
+into the misconfiguration.
+
+To restore full metrics functionality after a startup failure, fix the Prometheus
+connectivity issue (correct the URL, ensure the Prometheus server is running, etc.) and
+restart Kiali.
+
 ### Configuring the Prometheus URL
 
 By default, Kiali assumes that Prometheus is available at the URL of the form

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -7,12 +7,31 @@ description: >
 
 ## Prometheus configuration
 
-Kiali *requires* Prometheus to generate the
+Kiali uses Prometheus to generate the
 [topology graph]({{< relref "../../Features/topology" >}}),
 [show metrics]({{< relref "../../Features/details#metrics" >}}),
 [calculate health]({{< relref "../../Features/health" >}}) and
-for several other features. If Prometheus is missing or Kiali
-can't reach it, Kiali won't work properly.
+for several other features. Prometheus is enabled by default and is required
+for full Kiali functionality.
+
+### Disabling Prometheus
+
+If you want to run Kiali without a Prometheus instance, you can disable it:
+
+```yaml
+spec:
+  external_services:
+    prometheus:
+      enabled: false
+```
+
+When Prometheus is disabled, Kiali will still start and serve non-metrics features
+such as workload/service/app listing, Istio configuration, and mesh topology.
+However, the graph, metrics tabs, traffic tabs, and request-rate health will be
+unavailable. Health badges for workloads and apps will degrade to show only
+Kubernetes-level status (replica counts).
+
+### Configuring the Prometheus URL
 
 By default, Kiali assumes that Prometheus is available at the URL of the form
 `http://prometheus.<istio_namespace_name>:9090`, which is the usual case if you

--- a/content/en/docs/FAQ/installation.md
+++ b/content/en/docs/FAQ/installation.md
@@ -326,7 +326,7 @@ external_services:
 For certificate files, the secret key name (e.g., `tls.crt`, `tls.key`) is preserved in the mounted file path.
 
 {{% alert color="info" %}}
-**Service Enabled Conditions**: For Grafana, Tracing, Perses, and Custom Dashboards services, credentials are only auto-mounted when the respective service is enabled (e.g., `external_services.grafana.enabled=true`, `external_services.custom_dashboards.enabled=true`). Prometheus credentials are always processed regardless of any enabled flag.
+**Service Enabled Conditions**: For Prometheus, Grafana, Tracing, Perses, and Custom Dashboards services, credentials are only auto-mounted when the respective service is enabled (e.g., `external_services.prometheus.enabled=true`, `external_services.grafana.enabled=true`, `external_services.custom_dashboards.enabled=true`).
 {{% /alert %}}
 
 {{% alert color="info" %}}

--- a/content/en/docs/Installation/installation-guide/prerequisites.md
+++ b/content/en/docs/Installation/installation-guide/prerequisites.md
@@ -6,10 +6,12 @@ weight: 15
 
 ## Istio
 
-Before you install Kiali you must have already installed Istio along with its
-telemetry storage addon (e.g. Prometheus). You might also consider installing
-Istio's optional tracing addon (e.g. Tempo) and optional Grafana addon but
-those are not required by Kiali. Refer to the
+Before you install Kiali you must have already installed Istio. For full
+functionality, you should also install a telemetry storage addon (e.g.
+Prometheus), though Kiali can run without it if you disable Prometheus in the
+configuration. You might also consider installing Istio's optional tracing
+addon (e.g. Tempo) and optional Grafana addon but those are not required by
+Kiali. Refer to the
 [Istio documentation](https://istio.io/docs/setup/getting-started) for details.
 
 ### Optionally Enable the Debug Interface

--- a/content/en/docs/Installation/quick-start.md
+++ b/content/en/docs/Installation/quick-start.md
@@ -26,6 +26,14 @@ To see the full list of options
 kiali run --help
 ```
 
+If you want to run Kiali locally without a Prometheus instance, use the `--disable-prometheus` flag:
+
+```
+kiali run --disable-prometheus
+```
+
+This is useful for quickly exploring Kiali's non-metrics features (workloads, services, Istio configuration, mesh topology) without needing a Prometheus deployment. See [Disabling Prometheus]({{< relref "/docs/configuration/p8s-jaeger-grafana/prometheus#disabling-prometheus" >}}) for more details.
+
 {{% alert color="info" %}}
 If the cluster name in your kubeconfig does not match the cluster name in Istio you can override this with `--cluster-name-overrides kubeconfig-name=istio-cluster-name`. The flag is a comma separated list so you can override as many names as you need.
 {{% /alert %}}

--- a/content/en/docs/Installation/quick-start.md
+++ b/content/en/docs/Installation/quick-start.md
@@ -40,7 +40,7 @@ see the [installation guide]({{< ref "/docs/installation" >}}).
 {{% /alert %}}
 
 {{% alert color="warning" %}}
-Before you install Kiali you must have already installed Istio along with its telemetry storage addon (i.e. Prometheus). You might also consider installing Istio's optional tracing addon (i.e. Jaeger) and optional Grafana addon but those are not required by Kiali. Refer to the [Istio documentation](https://istio.io/docs/setup/getting-started) for details.
+Before you install Kiali you must have already installed Istio. For full functionality, you should also install a telemetry storage addon (i.e. Prometheus), though Kiali can run without it if you disable Prometheus in the configuration. You might also consider installing Istio's optional tracing addon (i.e. Jaeger) and optional Grafana addon but those are not required by Kiali. Refer to the [Istio documentation](https://istio.io/docs/setup/getting-started) for details.
 {{% /alert %}}
 
 ### Install via Istio Addons


### PR DESCRIPTION
Introduce a new `external_services.prometheus.enabled` configuration field (default true) that allows Kiali to run without a Prometheus metrics store. When disabled, a no-op Prometheus client is injected so the server starts without a Prometheus connection. Metrics-dependent features degrade gracefully: the graph page and mini-graph cards show an empty state with an explanation, health badges fall back to Kubernetes-only replica status, metrics and traffic tabs are hidden from detail pages, mesh target panels display a disabled message, and MCP/AI metric tools return an informative error. Non-metrics features (workload/service/app listing, Istio config, mesh topology, logs, traces) continue to work normally.

Changes span the Kiali server (config, noop client, handler guards, mesh generator, addon status, version probe), operator (CRD schema, defaults, conditional URL defaulting and secret mounts), Helm charts (credential gating, values, template tests), frontend (config type, empty states, tab hiding, test data), molecule tests (baseline and disabled assertions in metrics-test and config-values-test), and kiali.io documentation.

Part of: https://github.com/kiali/kiali/issues/8654

Netlify links:
* https://deploy-preview-967--kiali.netlify.app/docs/configuration/p8s-jaeger-grafana/
* https://deploy-preview-967--kiali.netlify.app/docs/configuration/p8s-jaeger-grafana/prometheus/
* https://deploy-preview-967--kiali.netlify.app/docs/installation/installation-guide/prerequisites/
* https://deploy-preview-967--kiali.netlify.app/docs/faq/installation/#how-can-i-use-a-secret-to-pass-external-service-credentials-to-the-kiali-server
* https://deploy-preview-967--kiali.netlify.app/docs/installation/quick-start/#install-kiali