### PR TITLE
update workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           # Full history needed for ignore_new_urls.sh to detect new files via git diff
           fetch-depth: 0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,9 +12,13 @@ on:
         default: staging
         type: string
 
+permissions: read-all
+
 jobs:
   initialize:
     name: Initialize
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       release_type: ${{ steps.release_type.outputs.release_type }}
@@ -99,6 +103,8 @@ jobs:
     if: ${{ needs.initialize.outputs.release_type != 'skip' && ((github.event_name == 'schedule' && github.repository == 'kiali/kiali.io') || github.event_name != 'schedule') }}
     runs-on: ubuntu-latest
     needs: [initialize]
+    permissions:
+      contents: write  # needs to push branches and tags
     env:
       RELEASING_VERSION: ${{ needs.initialize.outputs.releasing_version }}
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       releasing_version: ${{ steps.releasing_version.outputs.releasing_version }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -103,7 +103,7 @@ jobs:
       RELEASING_VERSION: ${{ needs.initialize.outputs.releasing_version }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
         fetch-depth: 0

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest       
     steps:
       - name: checkout repo content
-        uses: actions/checkout@v4 # checkout the repository content
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4
         with:
           python-version: '3.10' # install the python version needed      
       - name: install python packages
@@ -48,7 +48,7 @@ jobs:
           make generate_event_json      
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f  # v4
         with:
           branch: gh-pages
           folder: website/build          

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -5,9 +5,13 @@ on:
   schedule:
   # Every week at 00:00 on Sunday
     - cron: "0 0 * * 0"
+permissions: read-all
+
 jobs:
   build:
-    runs-on: ubuntu-latest       
+    permissions:
+      contents: write  # needs to commit metrics.json and push to gh-pages
+    runs-on: ubuntu-latest
     steps:
       - name: checkout repo content
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4


### PR DESCRIPTION
This PR hardens the GitHub Actions workflows against several known vulnerability classes.

**Supply chain risk (unpinned actions):** All third-party actions were using floating version tags (e.g. `@v4`). These are mutable references — a compromised action maintainer can silently retag them to malicious code that executes in CI with access to repository secrets. All action references have been pinned to their full immutable commit SHA, with the version tag retained as a comment.

**Missing `permissions:` blocks:** Neither the release nor the weekly workflow declared explicit token permissions, meaning they inherited the repository default (typically broad write access). Both workflows now declare `permissions: read-all` at the top level, with `contents: write` granted only to the jobs that actually push commits, deploy to `gh-pages`, or push release branches.

Generated-by: Claude