### PR TITLE
docs: add OAuth2 client_credentials authentication for external services

### DIFF
--- a/content/en/docs/Configuration/p8s-jaeger-grafana/grafana.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/grafana.md
@@ -83,6 +83,29 @@ spec:
 
 To configure a secret to be used as a password, see this [FAQ entry]({{< relref "../../FAQ/installation#how-can-i-use-a-secret-to-pass-external-service-credentials-to-the-kiali-server" >}}).
 
+To authenticate using OAuth2 `client_credentials` flow, set `type: "oauth2"` and provide the `oauth2` block:
+
+```yaml
+spec:
+  external_services:
+    grafana:
+      auth:
+        type: "oauth2"
+        oauth2:
+          client_id: "my-client-id"
+          client_secret: "secret:my-oauth2-secret:client_secret"
+          token_url: "https://idp.example.com/token"
+          scopes: []            # optional: list of OAuth2 scopes to request
+          audience: ""          # optional: some providers require this
+          auth_style: "header"  # "header" (default) or "params"
+```
+
+The `client_secret` field supports the `secret:<secretName>:<secretKey>` pattern for automatic secret mounting and rotation without pod restart. See the [FAQ entry]({{< relref "../../FAQ/installation#how-can-i-use-a-secret-to-pass-external-service-credentials-to-the-kiali-server" >}}) for details.
+
+{{% alert color="warning" %}}
+`insecure_skip_verify` applies only to the Grafana connection, not to the OAuth2 token endpoint. The token endpoint always validates TLS certificates. To trust a private CA for the token endpoint, add the CA to the `kiali-cabundle` ConfigMap as described in the [TLS Configuration]({{< relref "./tls-configuration" >}}) page.
+{{% /alert %}}
+
 ### TLS Certificate Configuration
 
 If your Grafana server uses HTTPS with a certificate issued by a private CA, see the [TLS Configuration]({{< relref "./tls-configuration" >}}) page to learn how to configure Kiali to trust your CA.

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/perses.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/perses.md
@@ -82,7 +82,7 @@ The Kiali CR provides authentication configuration that will be used to connect 
 
 ![Kiali Perses Mesh_page](/images/documentation/configuration/perses-meshpage.png)
 
-Just basic authentication is supported. This will be configured in Perses as `native` authentication.
+Basic and OAuth2 `client_credentials` authentication are supported.
 
 ```yaml
 spec:
@@ -98,6 +98,29 @@ spec:
 ```
 
 To configure a secret to be used as a user or password, see this [FAQ entry]({{< relref "../../FAQ/installation#how-can-i-use-a-secret-to-pass-external-service-credentials-to-the-kiali-server" >}}).
+
+To authenticate using OAuth2 `client_credentials` flow, set `type: "oauth2"` and provide the `oauth2` block:
+
+```yaml
+spec:
+  external_services:
+    perses:
+      auth:
+        type: "oauth2"
+        oauth2:
+          client_id: "my-client-id"
+          client_secret: "secret:my-oauth2-secret:client_secret"
+          token_url: "https://idp.example.com/token"
+          scopes: []            # optional: list of OAuth2 scopes to request
+          audience: ""          # optional: some providers require this
+          auth_style: "header"  # "header" (default) or "params"
+```
+
+The `client_secret` field supports the `secret:<secretName>:<secretKey>` pattern for automatic secret mounting and rotation without pod restart. See the [FAQ entry]({{< relref "../../FAQ/installation#how-can-i-use-a-secret-to-pass-external-service-credentials-to-the-kiali-server" >}}) for details.
+
+{{% alert color="warning" %}}
+`insecure_skip_verify` applies only to the Perses connection, not to the OAuth2 token endpoint. The token endpoint always validates TLS certificates. To trust a private CA for the token endpoint, add the CA to the `kiali-cabundle` ConfigMap as described in the [TLS Configuration]({{< relref "./tls-configuration" >}}) page.
+{{% /alert %}}
 
 ### TLS Certificate Configuration
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -225,6 +225,30 @@ spec:
 
 To configure a secret to be used as a password, see this [FAQ entry]({{< relref "../../FAQ/installation#how-can-i-use-a-secret-to-pass-external-service-credentials-to-the-kiali-server" >}}).
 
+To authenticate using OAuth2 `client_credentials` flow (for example, Azure Monitor Managed Prometheus or any OAuth2-protected endpoint), set `type: "oauth2"` and provide the `oauth2` block:
+
+```yaml
+spec:
+  external_services:
+    prometheus:
+      auth:
+        type: "oauth2"
+        oauth2:
+          client_id: "my-client-id"
+          client_secret: "secret:my-oauth2-secret:client_secret"
+          token_url: "https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token"
+          scopes:
+          - "https://prometheus.monitor.azure.com/.default"
+          audience: ""          # optional: some providers require this
+          auth_style: "header"  # "header" (default) or "params"
+```
+
+The `client_secret` field supports the `secret:<secretName>:<secretKey>` pattern for automatic secret mounting and rotation without pod restart. See the [FAQ entry]({{< relref "../../FAQ/installation#how-can-i-use-a-secret-to-pass-external-service-credentials-to-the-kiali-server" >}}) for details.
+
+{{% alert color="warning" %}}
+`insecure_skip_verify` applies only to the Prometheus connection, not to the OAuth2 token endpoint. The token endpoint always validates TLS certificates. To trust a private CA for the token endpoint, add the CA to the `kiali-cabundle` ConfigMap as described in the [TLS Configuration]({{< relref "./tls-configuration" >}}) page.
+{{% /alert %}}
+
 ### TLS Certificate Configuration
 
 If your Prometheus server uses HTTPS with a certificate issued by a private CA, see the [TLS Configuration]({{< relref "./tls-configuration" >}}) page to learn how to configure Kiali to trust your CA.

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/jaeger.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/jaeger.md
@@ -73,6 +73,34 @@ spec:
 
 To configure a secret to be used as a password, see this [FAQ entry]({{< relref "../../../FAQ/installation#how-can-i-use-a-secret-to-pass-external-service-credentials-to-the-kiali-server" >}}).
 
+To authenticate using OAuth2 `client_credentials` flow, set `type: "oauth2"` and provide the `oauth2` block:
+
+```yaml
+spec:
+  external_services:
+    tracing:
+      use_grpc: false           # must be false; oauth2 token injection is not implemented for gRPC transport
+      auth:
+        type: "oauth2"
+        oauth2:
+          client_id: "my-client-id"
+          client_secret: "secret:my-oauth2-secret:client_secret"
+          token_url: "https://idp.example.com/token"
+          scopes: []            # optional: list of OAuth2 scopes to request
+          audience: ""          # optional: some providers require this
+          auth_style: "header"  # "header" (default) or "params"
+```
+
+{{% alert color="warning" %}}
+OAuth2 authentication requires `use_grpc: false`. OAuth2 token injection is not implemented for gRPC transport.
+{{% /alert %}}
+
+{{% alert color="warning" %}}
+`insecure_skip_verify` applies only to the Jaeger connection, not to the OAuth2 token endpoint. The token endpoint always validates TLS certificates. To trust a private CA for the token endpoint, add the CA to the `kiali-cabundle` ConfigMap as described in the [TLS Configuration]({{< relref "../tls-configuration" >}}) page.
+{{% /alert %}}
+
+The `client_secret` field supports the `secret:<secretName>:<secretKey>` pattern for automatic secret mounting and rotation without pod restart. See the [FAQ entry]({{< relref "../../../FAQ/installation#how-can-i-use-a-secret-to-pass-external-service-credentials-to-the-kiali-server" >}}) for details.
+
 ### TLS Certificate Configuration
 
 If your Jaeger server uses HTTPS with a certificate issued by a private CA, see the [TLS Configuration]({{< relref "../tls-configuration" >}}) page to learn how to configure Kiali to trust your CA.

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/tracing/tempo.md
@@ -351,6 +351,34 @@ spec:
 
 To configure a secret to be used as a password, see this [FAQ entry]({{< relref "../../../FAQ/installation#how-can-i-use-a-secret-to-pass-external-service-credentials-to-the-kiali-server" >}}).
 
+To authenticate using OAuth2 `client_credentials` flow, set `type: "oauth2"` and provide the `oauth2` block:
+
+```yaml
+spec:
+  external_services:
+    tracing:
+      use_grpc: false           # must be false; oauth2 token injection is not implemented for gRPC transport
+      auth:
+        type: "oauth2"
+        oauth2:
+          client_id: "my-client-id"
+          client_secret: "secret:my-oauth2-secret:client_secret"
+          token_url: "https://idp.example.com/token"
+          scopes: []            # optional: list of OAuth2 scopes to request
+          audience: ""          # optional: some providers require this
+          auth_style: "header"  # "header" (default) or "params"
+```
+
+{{% alert color="warning" %}}
+OAuth2 authentication requires `use_grpc: false`. OAuth2 token injection is not implemented for gRPC transport.
+{{% /alert %}}
+
+{{% alert color="warning" %}}
+`insecure_skip_verify` applies only to the Tempo connection, not to the OAuth2 token endpoint. The token endpoint always validates TLS certificates. To trust a private CA for the token endpoint, add the CA to the `kiali-cabundle` ConfigMap as described in the [TLS Configuration]({{< relref "../tls-configuration" >}}) page.
+{{% /alert %}}
+
+The `client_secret` field supports the `secret:<secretName>:<secretKey>` pattern for automatic secret mounting and rotation without pod restart. See the [FAQ entry]({{< relref "../../../FAQ/installation#how-can-i-use-a-secret-to-pass-external-service-credentials-to-the-kiali-server" >}}) for details.
+
 #### TLS Certificate Configuration
 
 If your Tempo server uses HTTPS with a certificate issued by a private CA, see the [TLS Configuration]({{< relref "../tls-configuration" >}}) page to learn how to configure Kiali to trust your CA.

--- a/content/en/docs/FAQ/installation.md
+++ b/content/en/docs/FAQ/installation.md
@@ -248,6 +248,28 @@ Note that you can share a secret across multiple external services if they use t
 
 The `secret:` pattern works for both simple credential values (tokens, passwords, usernames) and file-based credentials (certificates and keys). For certificate files, the secret key name (e.g., `tls.crt`, `tls.key`) will be preserved when mounted.
 
+For OAuth2 `client_credentials` authentication, store the `client_secret` in a Kubernetes secret and reference it:
+
+```bash
+kubectl create secret generic my-oauth2-secret \
+  --from-literal=client_secret=my-actual-secret \
+  -n istio-system
+```
+
+```yaml
+spec:
+  external_services:
+    prometheus:
+      auth:
+        type: "oauth2"
+        oauth2:
+          client_id: "my-client-id"
+          client_secret: "secret:my-oauth2-secret:client_secret"
+          token_url: "https://idp.example.com/token"
+```
+
+The same `secret:` pattern applies to `oauth2.client_secret` for all external services (prometheus, grafana, tracing, perses, custom_dashboards.prometheus).
+
 {{% alert color="info" %}}
 **Note about CA certificates**: To configure custom CA certificates that Kiali should trust when connecting to external services over HTTPS, see the [TLS Configuration]({{< relref "../Configuration/p8s-jaeger-grafana/tls-configuration" >}}) page. CA certificates are configured globally via a ConfigMap, not per-service.
 {{% /alert %}}
@@ -255,25 +277,30 @@ The `secret:` pattern works for both simple credential values (tokens, passwords
 You can use secrets as explained above for the following fields in the Kiali CR:
 * `spec.external_services.grafana.auth.cert_file`
 * `spec.external_services.grafana.auth.key_file`
+* `spec.external_services.grafana.auth.oauth2.client_secret`
 * `spec.external_services.grafana.auth.password`
 * `spec.external_services.grafana.auth.token`
 * `spec.external_services.grafana.auth.username`
 * `spec.external_services.perses.auth.cert_file`
 * `spec.external_services.perses.auth.key_file`
+* `spec.external_services.perses.auth.oauth2.client_secret`
 * `spec.external_services.perses.auth.password`
 * `spec.external_services.perses.auth.username`
 * `spec.external_services.prometheus.auth.cert_file`
 * `spec.external_services.prometheus.auth.key_file`
+* `spec.external_services.prometheus.auth.oauth2.client_secret`
 * `spec.external_services.prometheus.auth.password`
 * `spec.external_services.prometheus.auth.token`
 * `spec.external_services.prometheus.auth.username`
 * `spec.external_services.tracing.auth.cert_file`
 * `spec.external_services.tracing.auth.key_file`
+* `spec.external_services.tracing.auth.oauth2.client_secret`
 * `spec.external_services.tracing.auth.password`
 * `spec.external_services.tracing.auth.token`
 * `spec.external_services.tracing.auth.username`
 * `spec.external_services.custom_dashboards.prometheus.auth.cert_file`
 * `spec.external_services.custom_dashboards.prometheus.auth.key_file`
+* `spec.external_services.custom_dashboards.prometheus.auth.oauth2.client_secret`
 * `spec.external_services.custom_dashboards.prometheus.auth.password`
 * `spec.external_services.custom_dashboards.prometheus.auth.token`
 * `spec.external_services.custom_dashboards.prometheus.auth.username`
@@ -363,6 +390,7 @@ All credentials mounted from secrets support automatic rotation:
 - Usernames (`auth.username`)
 - Client certificates (`auth.cert_file`)
 - Client private keys (`auth.key_file`)
+- OAuth2 client secrets (`auth.oauth2.client_secret`)
 - Login token signing key (`login_token.signing_key`)
 
 {{% alert color="info" %}}


### PR DESCRIPTION
Documents the new oauth2 auth type across all five external service pages and the credentials FAQ entry. Each service page gains an oauth2 example block with notes on the insecure_skip_verify asymmetry and, for tracing, the use_grpc incompatibility.

Part of: https://github.com/kiali/kiali/issues/9787

Netlify links:
* https://deploy-preview-979--kiali.netlify.app/docs/configuration/p8s-jaeger-grafana/prometheus/#prometheus-authentication-configuration
* https://deploy-preview-979--kiali.netlify.app/docs/configuration/p8s-jaeger-grafana/grafana/#grafana-authentication-configuration
* https://deploy-preview-979--kiali.netlify.app/docs/configuration/p8s-jaeger-grafana/perses/#perses-authentication-configuration
* https://deploy-preview-979--kiali.netlify.app/docs/configuration/p8s-jaeger-grafana/tracing/jaeger/#jaeger-authentication-configuration
* https://deploy-preview-979--kiali.netlify.app/docs/configuration/p8s-jaeger-grafana/tracing/tempo/#tempo-authentication-configuration
* https://deploy-preview-979--kiali.netlify.app/docs/faq/installation/#how-can-i-use-a-secret-to-pass-external-service-credentials-to-the-kiali-server