### PR TITLE
Align GitHub Actions to latest versions across workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           # Full history needed for ignore_new_urls.sh to detect new files via git diff
           fetch-depth: 0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       releasing_version: ${{ steps.releasing_version.outputs.releasing_version }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -109,7 +109,7 @@ jobs:
       RELEASING_VERSION: ${{ needs.initialize.outputs.releasing_version }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
         fetch-depth: 0

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo content
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: setup python
-        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.10' # install the python version needed      
       - name: install python packages
@@ -52,7 +52,7 @@ jobs:
           make generate_event_json      
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f  # v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f  # v4.8.0
         with:
           branch: gh-pages
           folder: website/build          


### PR DESCRIPTION
### Describe the change

Align all GitHub Actions across workflows to their latest versions with pinned commit SHAs and precise version comments. This resolves Node.js 20 deprecation warnings.

- `actions/checkout`: v4 -> v6.0.2
- `actions/setup-python`: v4 -> v6.2.0
- `JamesIves/github-pages-deploy-action`: precise version comment (v4.8.0)

### Steps to test the PR

- Verify CI and weekly workflows pass
- No functional changes; only action version upgrades

Made with [Cursor](https://cursor.com)