### PR TITLE
Docs: recording rules and federation for Prometheus tuning

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -6,3 +6,14 @@ Hide the "create documentation issue" links and defer "create project issue".  K
 .td-page-meta > a:nth-child(3) { display: none !important; }
 .td-page-meta--issue { display: none !important; }
 
+// Docsy's `.td-content table { @extend .td-table }` does not reliably compile
+// into the Bootstrap table rules. Style markdown tables directly instead.
+.td-content table:not(.td-initial) {
+  @extend .table;
+  @extend .table-striped;
+  @extend .table-bordered;
+  display: block;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -115,7 +115,7 @@ Istio and Envoy generate a large amount of telemetry for analysis and troublesho
 
 ### Option 1: Recording Rules and Federation (Recommended)
 
-For production meshes at scale, [metric thinning](#metric-thinning) on a single Prometheus TSDB reduces storage somewhat but still retains per-proxy Istio series. A more efficient approach—aligned with [Istio Observability Best Practices](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)—is to:
+For production meshes at scale, [metric thinning](#option-2-metric-thinning) on a single Prometheus TSDB reduces storage somewhat but still retains per-proxy Istio series. A more efficient approach—aligned with [Istio Observability Best Practices](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)—is to:
 
 1. **Aggregate at the edge** using Prometheus recording rules that sum away per-proxy labels (`pod`, `instance`, etc.) into `workload:*` series.
 2. **Federate** only those aggregates (plus a small set of control-plane metrics) into your long-retention production Prometheus.
@@ -160,9 +160,10 @@ Federation configuration is split so operators only pull what they need:
 | Tier | Purpose | Required for |
 | ---- | ------- | ------------ |
 | **Core** | [Kiali required metrics]({{< ref "/docs/faq/general#requiredmetrics" >}}) | Traffic graph, health, lists, mesh overview |
-| **Dashboards** (optional) | Additional control-plane, performance, ztunnel, and WASM metrics | [Perses Istio dashboards](https://github.com/perses/community-mixins/tree/main/examples/dashboards/perses/istio) |
+| **Dashboards** | Optional control-plane, perf, ztunnel, and WASM metrics | [Perses Istio dashboards](https://github.com/perses/community-mixins/tree/main/examples/dashboards/perses/istio) |
+&nbsp;
 
-Mesh, service, and workload Perses dashboards work on the **core** tier alone. Enable the **dashboard** tier only when those detailed dashboards are in use.
+Mesh, service, and workload Perses dashboards work on the **core** tier alone. Enable the **Dashboards** tier only when using those detailed dashboards.
 
 Reference files for both tiers live in the Kiali repository under [`hack/istio/metric-rules/`](https://github.com/kiali/kiali/tree/master/hack/istio/metric-rules):
 
@@ -172,6 +173,7 @@ Reference files for both tiers live in the Kiali repository under [`hack/istio/m
 | `kiali-required-metrics.yml` | Canonical core metric list |
 | `federation-match-dashboards.yml` | Optional federation `match[]` selectors for Perses dashboards |
 | `prometheus-prod.yaml` | Example production federation scrape job (core tier) |
+&nbsp;
 
 #### Recording rules (edge Prometheus)
 
@@ -251,13 +253,86 @@ See [`hack/istio/metric-rules/README.md`](https://github.com/kiali/kiali/blob/ma
 4. Optionally extend `match[]` with **dashboard-tier** selectors if Perses Istio dashboards are enabled.
 5. Point **`external_services.prometheus.url`** at production Prometheus (and Perses at the same URL).
 6. **Validate** equivalence between edge aggregates and federated data (see below).
-7. Tune **scrape interval**, **rule evaluation interval**, and **retention** using the guidance in the following sections.
+7. Tune intervals using [Interval tuning](#interval-tuning) below.
 
 For **multi-cluster** deployments, federation is typically per mesh cluster (edge → production for that cluster). Kiali already supports per-cluster Prometheus URLs in multicluster configuration.
 
-#### Scrape interval and minimum duration
+#### Interval tuning
 
-With federated aggregated metrics, the limiting factor for rate queries is no longer only Envoy scrape interval. Account for **recording rule evaluation interval** plus **federation scrape interval** when choosing minimum graph durations. Kiali filters duration options using `globalScrapeInterval × 2` from the Prometheus Kiali queries; when using federation, ensure production Prometheus reports a scrape interval that reflects the effective sampling of federated data (often the federation job interval).
+Several independent intervals affect freshness, CPU use, and the minimum time windows Kiali can use for `rate()` queries. Set them together—not in isolation.
+
+| Setting | Where configured | Role |
+| ------- | ---------------- | ---- |
+| **Edge scrape interval** | Edge Prometheus `global.scrape_interval` (or per-job override on Istio/Envoy targets) | How often raw `istio_*` counters are collected from proxies |
+| **Recording rule interval** | `interval` on the rule group in `recording-rules.yml` | How often `workload:*` aggregates are recomputed on the edge |
+| **Federation scrape interval** | `scrape_interval` on the production federation job | How often production Prometheus pulls `workload:*` (and other federated series) from the edge |
+| **Edge retention** | Edge Prometheus `storage.tsdb.retention.time` | How long raw and `workload:*` series are kept before expiry (short, e.g. 6h) |
+| **Production retention** | Production Prometheus retention | Long-term history Kiali and dashboards query |
+
+**Rules of thumb**
+
+1. **Recording rule interval ≥ edge scrape interval.** Rules read raw series; evaluating more often than scrapes complete adds CPU without new data. A practical range is **equal to the scrape interval, up to 2× the scrape interval** ([Istio guidance](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)).
+2. **Federation interval ≥ recording rule interval.** Production should pull aggregates after the edge has evaluated them. **30s** is a common federation interval and matches the Kiali reference configuration.
+3. **Set `scrape_timeout` below `scrape_interval`** on the federation job (for example `25s` timeout with `30s` interval) so slow federation scrapes do not overlap.
+4. **Kiali minimum duration** depends on the **effective sampling** of the data it queries (production Prometheus), not the edge scrape interval. With federation, that is roughly **recording rule interval + federation scrape interval**. Kiali needs at least **two samples** in a rate window, so minimum graph duration should be **≥ 2× that effective interval** (see [Scrape Interval](#scrape-interval) below).
+
+##### Recommended settings when edge scrape is 30s
+
+This is a common production default (for example kube-prometheus-stack). The Kiali reference bundle uses these values:
+
+| Setting | Recommended value | Notes |
+| ------- | ----------------- | ----- |
+| Edge `scrape_interval` | `30s` | Your stated baseline |
+| Recording rule `interval` | `30s` | Matches scrape; good balance of freshness and CPU |
+| Federation `scrape_interval` | `30s` | Istio-recommended; used in `prometheus-prod.yaml` |
+| Federation `scrape_timeout` | `25s` | Slightly less than scrape interval |
+| Edge retention | `6h` | Enough for troubleshooting; raw series expire after federation |
+| Effective sampling (Kiali) | `~60s` | Rule interval + federation interval |
+| Practical minimum Kiali duration | `≥ 2m` (`120s`) | `2 × 60s`; Kiali may round up in the duration dropdown |
+
+Example edge rule group header and production federation job:
+
+```yaml
+# Edge Prometheus — recording rules
+groups:
+- name: istio.workload-aggregation
+  interval: 30s          # match 30s scrape_interval
+  rules:
+  - record: workload:istio_requests_total
+    expr: sum without (pod, instance, namespace, job, node) (istio_requests_total)
+```
+
+```yaml
+# Production Prometheus — federation job
+- job_name: istio-mesh-federate
+  scrape_interval: 30s
+  scrape_timeout: 25s
+  metrics_path: /federate
+  # ... match[] and relabel configs
+```
+
+**Expected freshness:** mesh traffic visible in Kiali on production Prometheus is typically on the order of **one to two minutes** behind live traffic (one scrape + one rule evaluation + one federation cycle, plus alignment jitter).
+
+##### Other edge scrape intervals
+
+| Edge scrape | Recording rules | Federation | Effective sampling | Min duration (2×) |
+| ----------- | --------------- | ---------- | ------------------ | ----------------- |
+| `15s` (Istio add-on demo) | `15s`–`30s` | `30s` | `45s`–`60s` | `90s`–`120s` |
+| `30s` (recommended row above) | `30s` | `30s` | `60s` | `120s` |
+| `1m` | `1m` | `1m` | `2m` | `4m` |
+
+For **fresher** aggregates at the cost of more edge CPU, use a recording rule interval **equal to** the scrape interval (for example both `15s`). For **lower** edge CPU, use rule interval **2×** scrape (for example `30s` rules with `15s` scrape, or `60s` rules with `30s` scrape)—accepting additional lag before `workload:*` updates.
+
+Istio’s own examples sometimes use **5s** rule evaluation with **30s** federation for faster edge aggregation; that is reasonable when edge scrape is `15s` and you want sub-minute freshness. It increases rule-evaluation load and is optional—not required for Kiali correctness.
+
+##### Kiali duration dropdown
+
+Today Kiali reads `globalScrapeInterval` from the Prometheus URL in `external_services.prometheus.url` (production) and filters durations with **`≥ 2 × globalScrapeInterval`**. When using federation:
+
+- Ensure production Prometheus **`global.scrape_interval`** (or the value exposed in `/api/v1/status/config`) reflects the **federation job interval** if that is the coarsest sampling Kiali sees, **or**
+- Plan for a future **`metric_aggregation_interval`** setting (see the [metric rules KEP](https://github.com/kiali/kiali/blob/master/design/KEPS/metric-rules/proposal.md)) to set the minimum duration floor explicitly to **rule interval + federation interval**.
+
+Until `metric_aggregation_interval` is available, if production `global.scrape_interval` is `1m` but federation runs every `30s`, Kiali may offer durations that are shorter than ideal for federated traffic metrics. Operators can rely on slightly longer graph durations (for example `2m` or `5m`) for rate-based views when in doubt.
 
 #### Validation
 
@@ -278,7 +353,7 @@ count({__name__="istio_requests_total"})
 count({__name__="workload:istio_requests_total"})
 ```
 
-The `workload:*` count should be substantially lower when workloads have multiple proxy replicas.
+The `workload:*` count should be substantially lower when workloads have been associated with multiple pods (replicas or restarts).
 
 
 ### Option 2: Metric Thinning
@@ -305,7 +380,7 @@ Applying this configuration should reduce the number of stored metrics by about 
 
 
 
-### Metric Thinning with Crippling
+### Metric Thinning with Disabled Features
 
 The section above drops metrics unused by Kiali. As such, making those configuration changes should not negatively impact Kiali behavior in any way. But some very heavy metrics remain. These metrics can also be dropped, but their removal will impact the behavior of Kiali.  This may be OK if you don't use the affected features of Kiali, or if you are willing to sacrifice the feature for the associated metric savings. In particular, these are "Histogram" metrics.  Istio is planning to make some improvements to help users better configure these metrics, but as of this writing they are still defined with fairly inefficient default "buckets", making the number of associated time-series quite large, and the overhead of maintaining and querying the metrics, intensive.  Each histogram actually is comprised of 3 stored metrics.  For example, a histogram named `xxx` would result in the following metrics stored into Prometheus:
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -178,6 +178,174 @@ This metric is used to produce the `Request Duration` chart on the metric tabs. 
 - Appending `|istio_request_duration_milliseconds_bucket` to the `drop` regex above would prevent any request duration/response time percentile reporting in the Kiali metric charts or graph edge labels.
 
 
+### Recording Rules and Federation
+
+For production meshes at scale, [metric thinning](#metric-thinning) on a single Prometheus TSDB reduces storage somewhat but still retains per-proxy Istio series. A more efficient approach—aligned with [Istio Observability Best Practices](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)—is to:
+
+1. **Aggregate at the edge** using Prometheus recording rules that sum away per-proxy labels (`pod`, `instance`, etc.) into `workload:*` series.
+2. **Federate** only those aggregates (plus a small set of control-plane metrics) into your long-retention production Prometheus.
+3. **Relabel** `workload:istio_requests_total` back to `istio_requests_total` on the production instance so Kiali queries standard metric names.
+
+Kiali already aggregates traffic at workload/service granularity in its PromQL; it does not use per-pod Istio labels. Pre-aggregated counters and histograms are therefore compatible with the traffic graph, health monitoring, and metrics tabs.
+
+{{% alert color="info" %}}
+This pattern uses **two Prometheus roles** (edge and production). They are often in different namespaces or clusters in real deployments. The Kiali repository includes a **demo lab harness** that co-locates both in `istio-system` for learning and CI—it is not a production installer.
+{{% /alert %}}
+
+#### Architecture
+
+```
+  Edge Prometheus                         Production Prometheus
+  (scrapes Istio/Envoy)                   (long retention; Kiali queries here)
+        │                                           ▲
+        │  recording rules                          │  /federate
+        │  istio_*  →  workload:*                   │  + relabel workload: → istio_
+        │  short retention                          │
+        └───────────────────────────────────────────┘
+```
+
+**Edge Prometheus** is whichever instance scrapes Istio mesh telemetry (often *not* the same as your platform monitoring stack). It evaluates recording rules and keeps a **short retention** (for example 6 hours) on raw and aggregated series.
+
+**Production Prometheus** is the TSDB Kiali should query. It federates selected series from the edge, relabels `workload:*` back to `istio_*`, and holds **long retention**. Configure Kiali accordingly:
+
+```yaml
+spec:
+  external_services:
+    prometheus:
+      # Production Prometheus URL — not the edge Istio scraper
+      url: "http://prometheus-prod.monitoring:9090/"
+```
+
+If you use [Kiali Perses dashboards]({{< relref "./perses" >}}), point Perses at the same production Prometheus URL.
+
+#### Metric tiers
+
+Federation configuration is split so operators only pull what they need:
+
+| Tier | Purpose | Required for |
+| ---- | ------- | ------------ |
+| **Core** | [Kiali required metrics]({{< ref "/docs/faq/general#requiredmetrics" >}}) | Traffic graph, health, lists, mesh overview |
+| **Dashboards** (optional) | Additional control-plane, performance, ztunnel, and WASM metrics | [Perses Istio dashboards](https://github.com/perses/community-mixins/tree/main/examples/dashboards/perses/istio) |
+
+Mesh, service, and workload Perses dashboards work on the **core** tier alone. Enable the **dashboard** tier only when those detailed dashboards are in use.
+
+Reference files for both tiers live in the Kiali repository under [`hack/istio/metric-rules/`](https://github.com/kiali/kiali/tree/master/hack/istio/metric-rules):
+
+| File | Description |
+| ---- | ----------- |
+| `recording-rules.yml` | Edge recording rules producing `workload:*` series |
+| `kiali-required-metrics.yml` | Canonical core metric list |
+| `federation-match-dashboards.yml` | Optional federation `match[]` selectors for Perses dashboards |
+| `prometheus-prod.yaml` | Example production federation scrape job (core tier) |
+
+#### Recording rules (edge Prometheus)
+
+Add rules like the following to the Prometheus instance that scrapes Istio traffic. Rules sum away scrape-level labels while preserving the workload/service labels Kiali uses in queries:
+
+```yaml
+groups:
+- name: istio.workload-aggregation
+  interval: 30s
+  rules:
+  - record: workload:istio_requests_total
+    expr: sum without (pod, instance, namespace, job, node) (istio_requests_total)
+  - record: workload:istio_request_duration_milliseconds_bucket
+    expr: sum without (pod, instance, namespace, job, node) (istio_request_duration_milliseconds_bucket)
+  # ... remaining traffic counters and histogram components — see recording-rules.yml
+```
+
+{{% alert color="warning" %}}
+Record **counter snapshots**, not `rate()`. Kiali applies `rate()` at query time with user-selected durations. Use `sum without (...)` rather than `sum by (...)` so required labels are not dropped accidentally.
+{{% /alert %}}
+
+How you install the rules depends on your platform—for example a `rule_files` entry in `prometheus.yml`, a ConfigMap volume mount, or a Prometheus Operator `PrometheusRule` CR in the namespace where edge Prometheus runs.
+
+#### Federation (production Prometheus)
+
+Add a federation scrape job to your **existing** long-retention Prometheus. Federate `workload:*` traffic metrics from the edge and relabel names before storage:
+
+```yaml
+- job_name: istio-mesh-federate
+  honor_labels: true
+  metrics_path: /federate
+  scrape_interval: 30s
+  params:
+    match[]:
+      - '{__name__=~"workload:istio_requests_total"}'
+      - '{__name__=~"workload:istio_request_bytes_(bucket|count|sum)"}'
+      - '{__name__=~"workload:istio_request_duration_milliseconds_(bucket|count|sum)"}'
+      # ... see prometheus-prod.yaml for the full core-tier list
+  metric_relabel_configs:
+  - source_labels: [__name__]
+    regex: 'workload:(.*)'
+    target_label: __name__
+    action: replace
+  static_configs:
+  - targets:
+    - '<edge-prometheus-host>:9090'
+```
+
+Also federate non-traffic metrics that Kiali needs but does not aggregate (for example `istio_build`, `pilot_xds`, `container_cpu_usage_seconds_total`) directly by name—see `kiali-required-metrics.yml` and `prometheus-prod.yaml`.
+
+To include Perses dashboard metrics, append the selectors from `federation-match-dashboards.yml` to `match[]`.
+
+Configure **network access**, **TLS**, and **authentication** between production and edge Prometheus according to your environment. Kiali authentication for the production URL is configured separately (see [Prometheus authentication configuration](#prometheus-authentication-configuration) below).
+
+#### Demo walkthrough (lab only)
+
+The Kiali repository provides a demo script that patches the Istio add-on Prometheus in `istio-system`, deploys a sample `prometheus-prod` federator, and optionally switches Kiali to use it. Use this to learn the pattern or validate in CI—not as a production deployment:
+
+```bash
+# From a clone of github.com/kiali/kiali, with Istio add-on Prometheus running:
+./hack/istio/metric-rules/install.sh
+
+# Optional: also federate Perses dashboard metrics
+./hack/istio/metric-rules/install.sh --with-dashboards
+
+# Optional: point Kiali at the demo production Prometheus
+./hack/istio/metric-rules/install.sh --switch-kiali
+```
+
+See [`hack/istio/metric-rules/README.md`](https://github.com/kiali/kiali/blob/master/hack/istio/metric-rules/README.md) for verification queries and teardown (`uninstall.sh`).
+
+#### Production checklist
+
+1. Identify **edge Prometheus**—the TSDB that scrapes Istio/Envoy (may be in a `monitoring` namespace, a remote cluster, or a managed service—not necessarily `istio-system`).
+2. Install **recording rules** on the edge; set **short retention** on raw mesh telemetry.
+3. Add a **federation scrape job** to your existing **production** Prometheus using the core-tier `match[]` list.
+4. Optionally extend `match[]` with **dashboard-tier** selectors if Perses Istio dashboards are enabled.
+5. Point **`external_services.prometheus.url`** at production Prometheus (and Perses at the same URL).
+6. **Validate** equivalence between edge aggregates and federated data (see below).
+7. Tune **scrape interval**, **rule evaluation interval**, and **retention** using the guidance in the following sections.
+
+For **multi-cluster** deployments, federation is typically per mesh cluster (edge → production for that cluster). Kiali already supports per-cluster Prometheus URLs in multicluster configuration.
+
+#### Scrape interval and minimum duration
+
+With federated aggregated metrics, the limiting factor for rate queries is no longer only Envoy scrape interval. Account for **recording rule evaluation interval** plus **federation scrape interval** when choosing minimum graph durations. Kiali filters duration options using `globalScrapeInterval × 2` from the Prometheus Kiali queries; when using federation, ensure production Prometheus reports a scrape interval that reflects the effective sampling of federated data (often the federation job interval).
+
+#### Validation
+
+Confirm that federated series match edge aggregates (on production Prometheus, after relabel):
+
+```promql
+# Edge Prometheus
+sum(rate(workload:istio_requests_total{destination_workload_namespace="bookinfo"}[5m]))
+
+# Production Prometheus
+sum(rate(istio_requests_total{destination_workload_namespace="bookinfo"}[5m]))
+```
+
+Compare series counts on the edge before federation:
+
+```promql
+count({__name__="istio_requests_total"})
+count({__name__="workload:istio_requests_total"})
+```
+
+The `workload:*` count should be substantially lower when workloads have multiple proxy replicas.
+
+
 ### Scrape Interval
 
 The Prometheus `globalScrapeInterval` is an important configuration option[^2]. The scrape interval can have a significant effect on metrics collection overhead as it takes effort to pull all of those configured metrics and update the relevant time-series. And although it doesn't affect time-series cardinality, it does affect storage for the data-points, as well as having impact when computing query results (the more data-points, the more processing and aggregation).

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -289,9 +289,9 @@ See [`hack/istio/metric-rules/README.md`](https://github.com/kiali/kiali/blob/ma
 
 #### Production checklist
 
-1. Identify **edge Prometheus**—the TSDB that scrapes Istio/Envoy (may be in a `monitoring` namespace, a remote cluster, or a managed service—not necessarily `istio-system`).
-2. Install **recording rules** on the edge; set **short retention** on raw mesh telemetry.
-3. Add a **federation scrape job** to your existing **production** Prometheus using the core-tier `match[]` list.
+1. Identify edge Prometheus—the TSDB that scrapes Istio/Envoy (may be in a `monitoring` namespace, a remote cluster, or a managed service—not necessarily `istio-system`).
+2. Install recording rules on the edge; set short retention on raw mesh telemetry.
+3. Add a federation scrape job to your production Prometheus using the core-tier `match[]` list.
 4. Optionally extend `match[]` with **dashboard-tier** selectors if Perses Istio dashboards are enabled.
 5. If Kiali self-monitoring is enabled, choose an option from [Kiali self-monitoring metrics](#kiali-self-monitoring-metrics): apply `kiali-recording-rules.yml` on the Kiali edge and federate `federation-match-kiali.yml` to production (Options 1–2), or scrape Kiali directly into production (Option 3).
 6. Point **`external_services.prometheus.url`** at production Prometheus (and Perses at the same URL).

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -297,7 +297,7 @@ See [`hack/istio/metric-rules/README.md`](https://github.com/kiali/kiali/blob/ma
 4. Optionally extend `match[]` with Istio dashboard-tier selectors if Istio dashboards are enabled.
 5. If Kiali self-monitoring is enabled, choose an option from [Kiali self-monitoring metrics](#kiali-self-monitoring-metrics): apply `kiali-recording-rules.yml` on the Kiali edge and federate `federation-match-kiali.yml` to production (Options 1–2), or scrape Kiali directly into production (Option 3).
 6. Point `external_services.prometheus.url` at production Prometheus (and the same URL for Perses/Grafana, if using).
-7. **Validate** equivalence between edge aggregates and federated data (see below).
+7. Validate equivalence between edge aggregates and federated data (see below).
 8. Tune intervals using [Interval tuning](#interval-tuning) below.
 
 For **multi-cluster** deployments, federation is typically per mesh cluster (edge → production for that cluster).
@@ -316,10 +316,14 @@ Several independent intervals affect freshness, CPU use, and the minimum time wi
 
 **Rules of thumb:**
 
-1. Recording rule interval ≥ edge scrape interval. Rules read raw series; evaluating more often than scrapes complete adds CPU without new data. A practical range is equal to the scrape interval, up to 2× the scrape interval ([Istio guidance](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)).
-2. **Federation interval ≥ recording rule interval.** The Production Prometheus should federate aggregates after the edge has evaluated them. **30s** is a common federation interval and matches the Kiali reference configuration.
-3. **Set `scrape_timeout` below `scrape_interval`** on the federation job (for example `25s` timeout with `30s` interval) so slow federation scrapes do not overlap.
-4. **Kiali minimum duration** depends on the **effective sampling** of the data it queries (production Prometheus), not the edge scrape interval. With federation, that is roughly **recording rule interval + federation scrape interval**. Kiali needs at least **two samples** in a rate window, so minimum graph duration should be **≥ 2× that effective interval** (see [Scrape Interval](#scrape-interval) below).
+1. Recording rule interval ≥ edge scrape interval.
+  -- Rules read raw series; evaluating more often than scrapes complete adds CPU without new data. A practical range is equal to the scrape interval, up to 2× the scrape interval ([Istio guidance](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)).
+2. Federation interval ≥ recording rule interval.
+  -- The Production Prometheus should federate aggregates after the edge has evaluated them. **30s** is a common federation interval and matches the Kiali reference configuration.
+3. Set `scrape_timeout` below `scrape_interval` on the federation job.
+  -- (for example `25s` timeout with `30s` interval) so slow federation scrapes do not overlap.
+4. Kiali minimum duration depends on the **effective sampling** of the data it queries (production Prometheus), not the edge scrape interval.
+  -- With federation, that is roughly **recording rule interval + federation scrape interval**. Kiali needs at least **two samples** in a rate window, so minimum graph duration should be **≥ 2× that effective interval** (see [Scrape Interval](#scrape-interval) below).
 
 **Recommended settings when edge scrape is 30s:**
 
@@ -374,8 +378,8 @@ Istio’s own examples sometimes use **5s** rule evaluation with **30s** federat
 
 Today Kiali reads `globalScrapeInterval` from the Prometheus URL in `external_services.prometheus.url` (production) and filters durations with **`≥ 2 × globalScrapeInterval`**. When using federation:
 
-- Ensure production Prometheus **`global.scrape_interval`** (or the value exposed in `/api/v1/status/config`) reflects the **federation job interval** if that is the coarsest sampling Kiali sees, **or**
-- Plan for a future **`metric_aggregation_interval`** setting (see the [metric rules KEP](https://github.com/kiali/kiali/blob/master/design/KEPS/metric-rules/proposal.md)) to set the minimum duration floor explicitly to **rule interval + federation interval**.
+- Ensure production Prometheus **`global.scrape_interval`** (or the value exposed in `/api/v1/status/config`) reflects the federation job interval if that is the coarsest sampling Kiali sees, **OR**
+- Plan for a future **`metric_aggregation_interval`** setting (see the [metric rules KEP](https://github.com/kiali/kiali/blob/master/design/KEPS/metric-rules/proposal.md)) to set the minimum duration floor explicitly to (rule interval + federation interval).
 
 Until `metric_aggregation_interval` is available, if production `global.scrape_interval` is `1m` but federation runs every `30s`, Kiali may offer durations that are shorter than ideal for federated traffic metrics. Operators can rely on slightly longer graph durations (for example `2m` or `5m`) for rate-based views when in doubt.
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -166,7 +166,7 @@ Federation configuration is split so operators only pull what they need:
 | Tier | Purpose | Required for |
 | ---- | ------- | ------------ |
 | **Core** | [Kiali required metrics]({{< ref "/docs/faq/general#requiredmetrics" >}}) | Traffic graph, health, lists, mesh overview |
-| **Dashboards** | Optional control-plane, perf, ztunnel, and WASM metrics | [Perses Istio dashboards](https://github.com/perses/community-mixins/tree/main/examples/dashboards/perses/istio) |
+| **Istio Dashboards** | Optional control-plane, perf, ztunnel, and WASM metrics | [Perses Istio dashboards](https://github.com/perses/community-mixins/tree/main/examples/dashboards/perses/istio) |
 | **Kiali self-monitoring** | Kiali operational metrics (`kiali_*`) | Kiali Internal Metrics dashboard, optional health-status alerting |
 &nbsp;
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -171,7 +171,6 @@ Federation configuration is split into tiers (metric groupings) so that the prod
 | **Istio Dashboards** | Optional control-plane, perf, ztunnel, and WASM metrics | [Perses Istio dashboards](https://github.com/perses/community-mixins/tree/main/examples/dashboards/perses/istio) |
 | **Kiali self-monitoring** | Kiali operational metrics (`kiali_*`) | Kiali Internal Metrics dashboard, optional health-status alerting |
 
-&nbsp;
 
 Some Perses dashboards work with the **Core** tier alone (Mesh, service, and workload dashboards). To ensure all of the Istio dashboards are supported, Enable the **Istio Dashboards** tier. Enable **Kiali self-monitoring** when the built-in Kiali metrics dashboard or `kiali_health_status` alerting is needed. Note that if you define your own Kiali Custom Dashboards, you will need to ensure any required metrics are also configured for the production Prometheus.
 
@@ -188,7 +187,6 @@ Reference files live in the Kiali repository under [`hack/istio/metric-rules/`](
 | `federation-match-kiali.yml` | Federation `match[]` selectors for `kiali:*` series |
 | `prometheus-kiali-edge.yaml` | Example dedicated Kiali edge Prometheus (Option 2) |
 
-&nbsp;
 
 #### Recording rules (edge Prometheus)
 
@@ -316,14 +314,14 @@ Several independent intervals affect freshness, CPU use, and the minimum time wi
 | **Metric retention** | Edge Prometheus | `storage.tsdb.retention.time` | How long raw and `workload:*` series are kept before expiry (short, e.g. 6h) |
 | **Metric retention** | Production Prometheus | `storage.tsdb.retention.time` | Long-term history Kiali and dashboards query (as desired) |
 
-**Rules of thumb**
+**Rules of thumb:**
 
 1. Recording rule interval ≥ edge scrape interval. Rules read raw series; evaluating more often than scrapes complete adds CPU without new data. A practical range is equal to the scrape interval, up to 2× the scrape interval ([Istio guidance](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)).
 2. **Federation interval ≥ recording rule interval.** The Production Prometheus should federate aggregates after the edge has evaluated them. **30s** is a common federation interval and matches the Kiali reference configuration.
 3. **Set `scrape_timeout` below `scrape_interval`** on the federation job (for example `25s` timeout with `30s` interval) so slow federation scrapes do not overlap.
 4. **Kiali minimum duration** depends on the **effective sampling** of the data it queries (production Prometheus), not the edge scrape interval. With federation, that is roughly **recording rule interval + federation scrape interval**. Kiali needs at least **two samples** in a rate window, so minimum graph duration should be **≥ 2× that effective interval** (see [Scrape Interval](#scrape-interval) below).
 
-**Recommended settings when edge scrape is 30s**
+**Recommended settings when edge scrape is 30s:**
 
 This is a common production default (for example kube-prometheus-stack). The Kiali reference bundle uses these values:
 
@@ -360,7 +358,7 @@ groups:
 
 Expected freshness: mesh traffic visible in Kiali on production Prometheus is typically on the order of **one to two minutes** behind live traffic (one scrape + one rule evaluation + one federation cycle, plus alignment jitter).
 
-**Other edge scrape intervals**
+**Other edge scrape intervals:**
 
 | Edge scrape | Recording rules | Federation | Effective sampling | Min duration (2×) |
 | ----------- | --------------- | ---------- | ------------------ | ----------------- |
@@ -372,7 +370,7 @@ For fresher aggregates at the cost of more edge CPU, use a recording rule interv
 
 Istio’s own examples sometimes use **5s** rule evaluation with **30s** federation for faster edge aggregation; that is reasonable when edge scrape is `15s` and you want sub-minute freshness. It increases rule-evaluation load and is optional—not required for Kiali correctness.
 
-**Kiali duration dropdown**
+**Kiali duration dropdown:**
 
 Today Kiali reads `globalScrapeInterval` from the Prometheus URL in `external_services.prometheus.url` (production) and filters durations with **`≥ 2 × globalScrapeInterval`**. When using federation:
 
@@ -385,7 +383,7 @@ Until `metric_aggregation_interval` is available, if production `global.scrape_i
 
 Kiali can export its own Prometheus metrics (`kiali_*`) for performance and optional health-status monitoring. These are **not** Istio mesh metrics—they are not produced on the edge by Envoy, not listed in `kiali-required-metrics.yml`, and not part of the Istio federation tiers.
 
-Because Kiali queries **production** Prometheus, `kiali_*` series must ultimately be available in that same TSDB. The [metric rules KEP](https://github.com/kiali/kiali/blob/master/design/KEPS/metric-rules/proposal.md#kiali-self-monitoring-metrics) describes **three deployment options**:
+Because Kiali queries production Prometheus, `kiali_*` series must ultimately be available in that same TSDB. The [metric rules KEP](https://github.com/kiali/kiali/blob/master/design/KEPS/metric-rules/proposal.md#kiali-self-monitoring-metrics) describes three deployment options:
 
 | Option | Kiali metrics scraped by | Before production |
 | ------ | ------------------------ | ----------------- |
@@ -393,14 +391,12 @@ Because Kiali queries **production** Prometheus, `kiali_*` series must ultimatel
 | **2. Dedicated Kiali edge** | Separate edge Prom for Kiali only | Recording rules + federation to prod |
 | **3. Direct to production** | Production Prom directly | Raw scrape; dedup required in queries for HA |
 
-&nbsp;
 
 | Config | Default | Purpose |
 | ------ | ------- | ------- |
 | `server.observability.metrics.enabled` | `true` | Operational metrics (API, graph, cache, validation, etc.) |
 | `server.observability.metrics.health_status.enabled` | `false` | `kiali_health_status` gauge per entity (opt-in; higher cardinality) |
 
-&nbsp;
 
 The metrics HTTP listener (port `server.observability.metrics.port`, default `9090`) starts when **either** flag is true.
 
@@ -455,7 +451,6 @@ The `metric_relabel_configs:` attribute should be added under each job name defi
 ```
 
 Applying this configuration should reduce the number of stored metrics by about 20%, as well as reducing the number of attributes stored on many remaining metrics.
-
 
 
 ### Metric Thinning with Disabled Features

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -111,74 +111,9 @@ Production environments should not be using the Istio Prometheus add-on, or carr
 
 This section is primarily for users where Prometheus is being used specifically for Kiali, and possible optimizations that can be made knowing that Kiali does not utilize all of the default Istio and Envoy telemetry.
 
-
-### Metric Thinning
-
 Istio and Envoy generate a large amount of telemetry for analysis and troubleshooting.  This can result in significant resources being required to ingest and store the telemetry, and to support queries into the data.  If you use the telemetry specifically to support Kiali, it is possible to drop unnecessary metrics and unnecessary labels on required metrics.  This [FAQ Entry]({{< ref "/docs/faq/general#requiredmetrics" >}}) displays the metrics and attributes required for Kiali to operate.
 
-To reduce the default telemetry to only what is needed by Kiali[^1] users can add the following snippet to their Prometheus configuration. Because things can change with different versions, it is recommended to ensure you use the correct version of this documentation based on your Kiali/Istio version.
-
-[^1]: Some non-essential telemetry remains in order to not over-complicate the configuration change.  The remaining telemetry is typically negligible.
-
-The `metric_relabel_configs:` attribute should be added under each job name defined to scrape Istio or Envoy metrics. Below we show it under the `kubernetes-pods` job, but you should adapt as needed. Be careful of indentation.
-
-```
-    - job_name: kubernetes-pods
-      metric_relabel_configs:
-      - action: drop
-        source_labels: [__name__]
-        regex: istio_agent_.*|istiod_.*|istio_build|citadel_.*|galley_.*|pilot_[^psx].*|envoy_cluster_[^u].*|envoy_cluster_update.*|envoy_listener_[^dh].*|envoy_server_[^mu].*|envoy_wasm_.*
-      - action: labeldrop
-        regex: chart|destination_app|destination_version|heritage|.*operator.*|istio.*|release|security_istio_io_.*|service_istio_io_.*|sidecar_istio_io_inject|source_app|source_version
-```
-
-Applying this configuration should reduce the number of stored metrics by about 20%, as well as reducing the number of attributes stored on many remaining metrics.
-
-
-
-### Metric Thinning with Crippling
-
-The section above drops metrics unused by Kiali. As such, making those configuration changes should not negatively impact Kiali behavior in any way. But some very heavy metrics remain. These metrics can also be dropped, but their removal will impact the behavior of Kiali.  This may be OK if you don't use the affected features of Kiali, or if you are willing to sacrifice the feature for the associated metric savings. In particular, these are "Histogram" metrics.  Istio is planning to make some improvements to help users better configure these metrics, but as of this writing they are still defined with fairly inefficient default "buckets", making the number of associated time-series quite large, and the overhead of maintaining and querying the metrics, intensive.  Each histogram actually is comprised of 3 stored metrics.  For example, a histogram named `xxx` would result in the following metrics stored into Prometheus:
-
-- `xxx_bucket`
-  - The most intensive metric, and is required to calculate percentile values.
-- `xxx_count`
-  - Required to calculate 'avg' values.
-- `xxx_sum`
-  - Required to calculate rates over time, and for 'avg' values.
-
-When considering whether to thin the Histogram metrics, one of the following three approaches is recommended:
-
-1. If the relevant Kiali reporting is needed, keep the histogram as-is.
-2. If the relevant Kiali reporting is not needed, or not worth the additional metric overhead, drop the entire histogram.
-3. If the metric chart percentiles are not required, drop only the xxx_bucket metric.  This removes the majority of the histogram overhead while keeping rate and average (non-percentile) values in Kiali.
-
-
-These are the relevant Histogram metrics:
-
-#### istio_request_bytes
-
-This metric is used to produce the `Request Size` chart on the metric tabs.  It also supports `Request Throughput` edge labels on the graph.
-
-- Appending `|istio_request_bytes_.*` to the `drop` regex above would drop all associated metrics and would prevent any request size/throughput reporting in Kiali.
-- Appending `|istio_request_bytes_bucket` to the `drop` regex above, would prevent any request size percentile reporting in the Kiali metric charts.
-
-#### istio_response_bytes
-
-This metric is used to produce the `Response Size` chart on the metric tabs.  And also supports `Response Throughput` edge labels on the graph
-
-- Appending `|istio_response_bytes_.*` to the `drop` regex above would drop all associated metrics and would prevent any response size/throughput reporting in Kiali.
-- Appending `|istio_response_bytes_bucket` to the `drop` regex above would prevent any response size percentile reporting in the Kiali metric charts.
-
-#### istio_request_duration_milliseconds
-
-This metric is used to produce the `Request Duration` chart on the metric tabs.  It also supports `Response Time` edge labels on the graph.
-
-- Appending `|istio_request_duration_milliseconds_.*` to the `drop` regex above would drop all associated metrics and would prevent any request duration/response time reporting in Kiali.
-- Appending `|istio_request_duration_milliseconds_bucket` to the `drop` regex above would prevent any request duration/response time percentile reporting in the Kiali metric charts or graph edge labels.
-
-
-### Recording Rules and Federation
+### Option 1: Recording Rules and Federation (Recommended)
 
 For production meshes at scale, [metric thinning](#metric-thinning) on a single Prometheus TSDB reduces storage somewhat but still retains per-proxy Istio series. A more efficient approach—aligned with [Istio Observability Best Practices](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)—is to:
 
@@ -344,6 +279,72 @@ count({__name__="workload:istio_requests_total"})
 ```
 
 The `workload:*` count should be substantially lower when workloads have multiple proxy replicas.
+
+
+### Option 2: Metric Thinning
+
+If the Federation option is not possible and you are limited to a single TSDB intance, this may be helpful.
+
+To reduce the default telemetry to only what is needed by Kiali[^1] users can add the following snippet to their Prometheus configuration. Because things can change with different versions, it is recommended to ensure you use the correct version of this documentation based on your Kiali/Istio version.
+
+[^1]: Some non-essential telemetry remains in order to not over-complicate the configuration change.  The remaining telemetry is typically negligible.
+
+The `metric_relabel_configs:` attribute should be added under each job name defined to scrape Istio or Envoy metrics. Below we show it under the `kubernetes-pods` job, but you should adapt as needed. Be careful of indentation.
+
+```
+    - job_name: kubernetes-pods
+      metric_relabel_configs:
+      - action: drop
+        source_labels: [__name__]
+        regex: istio_agent_.*|istiod_.*|istio_build|citadel_.*|galley_.*|pilot_[^psx].*|envoy_cluster_[^u].*|envoy_cluster_update.*|envoy_listener_[^dh].*|envoy_server_[^mu].*|envoy_wasm_.*
+      - action: labeldrop
+        regex: chart|destination_app|destination_version|heritage|.*operator.*|istio.*|release|security_istio_io_.*|service_istio_io_.*|sidecar_istio_io_inject|source_app|source_version
+```
+
+Applying this configuration should reduce the number of stored metrics by about 20%, as well as reducing the number of attributes stored on many remaining metrics.
+
+
+
+### Metric Thinning with Crippling
+
+The section above drops metrics unused by Kiali. As such, making those configuration changes should not negatively impact Kiali behavior in any way. But some very heavy metrics remain. These metrics can also be dropped, but their removal will impact the behavior of Kiali.  This may be OK if you don't use the affected features of Kiali, or if you are willing to sacrifice the feature for the associated metric savings. In particular, these are "Histogram" metrics.  Istio is planning to make some improvements to help users better configure these metrics, but as of this writing they are still defined with fairly inefficient default "buckets", making the number of associated time-series quite large, and the overhead of maintaining and querying the metrics, intensive.  Each histogram actually is comprised of 3 stored metrics.  For example, a histogram named `xxx` would result in the following metrics stored into Prometheus:
+
+- `xxx_bucket`
+  - The most intensive metric, and is required to calculate percentile values.
+- `xxx_count`
+  - Required to calculate 'avg' values.
+- `xxx_sum`
+  - Required to calculate rates over time, and for 'avg' values.
+
+When considering whether to thin the Histogram metrics, one of the following three approaches is recommended:
+
+1. If the relevant Kiali reporting is needed, keep the histogram as-is.
+2. If the relevant Kiali reporting is not needed, or not worth the additional metric overhead, drop the entire histogram.
+3. If the metric chart percentiles are not required, drop only the xxx_bucket metric.  This removes the majority of the histogram overhead while keeping rate and average (non-percentile) values in Kiali.
+
+
+These are the relevant Histogram metrics:
+
+#### istio_request_bytes
+
+This metric is used to produce the `Request Size` chart on the metric tabs.  It also supports `Request Throughput` edge labels on the graph.
+
+- Appending `|istio_request_bytes_.*` to the `drop` regex above would drop all associated metrics and would prevent any request size/throughput reporting in Kiali.
+- Appending `|istio_request_bytes_bucket` to the `drop` regex above, would prevent any request size percentile reporting in the Kiali metric charts.
+
+#### istio_response_bytes
+
+This metric is used to produce the `Response Size` chart on the metric tabs.  And also supports `Response Throughput` edge labels on the graph
+
+- Appending `|istio_response_bytes_.*` to the `drop` regex above would drop all associated metrics and would prevent any response size/throughput reporting in Kiali.
+- Appending `|istio_response_bytes_bucket` to the `drop` regex above would prevent any response size percentile reporting in the Kiali metric charts.
+
+#### istio_request_duration_milliseconds
+
+This metric is used to produce the `Request Duration` chart on the metric tabs.  It also supports `Response Time` edge labels on the graph.
+
+- Appending `|istio_request_duration_milliseconds_.*` to the `drop` regex above would drop all associated metrics and would prevent any request duration/response time reporting in Kiali.
+- Appending `|istio_request_duration_milliseconds_bucket` to the `drop` regex above would prevent any request duration/response time percentile reporting in the Kiali metric charts or graph edge labels.
 
 
 ### Scrape Interval

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -117,7 +117,7 @@ Istio and Envoy generate a large amount of telemetry for analysis and troublesho
 
 For production meshes at scale, [metric thinning](#option-2-metric-thinning) on a single Prometheus TSDB reduces storage somewhat but still retains per-proxy Istio series. A more efficient approach—aligned with [Istio Observability Best Practices](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)—is to:
 
-1. **Aggregate at the edge** using Prometheus recording rules that "sum away" per-proxy labels (`pod`, `instance`, etc.) into `workload:*` series. "Sum away" is a recording rule term that means that several time-series will be aggregated into one, by combining those with like values for specified fields. The resulting value is the sum of the individual time-series values. Because Kiali presents information at the workload level, not the pod level, aggregation offers a significant reduction in time-series cardinality.
+1. **Aggregate at the edge** using Prometheus recording rules that "sum away" per-proxy labels (`pod`, `instance`, etc.) into `workload:*` series. "Sum away" is a recording rule term that means that several time-series will be aggregated into one, by combining those with like values for specified fields. The resulting value is the sum of the individual time-series values.
 2. **Federate** only those aggregates (plus a small set of control-plane metrics) into your long-retention production Prometheus.
 3. **Relabel** `workload:istio_requests_total` back to `istio_requests_total` on the production instance so Kiali queries standard metric names.
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -210,7 +210,7 @@ How you install the rules depends on your platform—for example a `rule_files` 
 
 #### Federation (production Prometheus)
 
-Add a federation scrape job to your **existing** long-retention Prometheus. Federate `workload:*` traffic metrics from the edge and relabel names before storage:
+Add a federation scrape job to your existing long-retention Prometheus. Federate `workload:*` traffic metrics from the edge and relabel names before storage:
 
 ```yaml
 - job_name: istio-mesh-federate

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -315,7 +315,7 @@ Several independent intervals affect freshness, CPU use, and the minimum time wi
 **Rules of thumb**
 
 1. Recording rule interval ≥ edge scrape interval. Rules read raw series; evaluating more often than scrapes complete adds CPU without new data. A practical range is equal to the scrape interval, up to 2× the scrape interval ([Istio guidance](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)).
-2. **Federation interval ≥ recording rule interval.** Production should pull aggregates after the edge has evaluated them. **30s** is a common federation interval and matches the Kiali reference configuration.
+2. **Federation interval ≥ recording rule interval.** The Production Prometheus should federate aggregates after the edge has evaluated them. **30s** is a common federation interval and matches the Kiali reference configuration.
 3. **Set `scrape_timeout` below `scrape_interval`** on the federation job (for example `25s` timeout with `30s` interval) so slow federation scrapes do not overlap.
 4. **Kiali minimum duration** depends on the **effective sampling** of the data it queries (production Prometheus), not the edge scrape interval. With federation, that is roughly **recording rule interval + federation scrape interval**. Kiali needs at least **two samples** in a rate window, so minimum graph duration should be **≥ 2× that effective interval** (see [Scrape Interval](#scrape-interval) below).
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -314,7 +314,7 @@ Several independent intervals affect freshness, CPU use, and the minimum time wi
 
 **Rules of thumb**
 
-1. **Recording rule interval ≥ edge scrape interval.** Rules read raw series; evaluating more often than scrapes complete adds CPU without new data. A practical range is **equal to the scrape interval, up to 2× the scrape interval** ([Istio guidance](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)).
+1. Recording rule interval ≥ edge scrape interval. Rules read raw series; evaluating more often than scrapes complete adds CPU without new data. A practical range is equal to the scrape interval, up to 2× the scrape interval ([Istio guidance](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)).
 2. **Federation interval ≥ recording rule interval.** Production should pull aggregates after the edge has evaluated them. **30s** is a common federation interval and matches the Kiali reference configuration.
 3. **Set `scrape_timeout` below `scrape_interval`** on the federation job (for example `25s` timeout with `30s` interval) so slow federation scrapes do not overlap.
 4. **Kiali minimum duration** depends on the **effective sampling** of the data it queries (production Prometheus), not the edge scrape interval. With federation, that is roughly **recording rule interval + federation scrape interval**. Kiali needs at least **two samples** in a rate window, so minimum graph duration should be **≥ 2× that effective interval** (see [Scrape Interval](#scrape-interval) below).

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -119,8 +119,8 @@ For production meshes at scale, [metric thinning](#option-2-metric-thinning) on 
 
 1. **Aggregate** using a short-lived "edge" Prometheus. Scrape your raw metrics and then use recording rules that "sum away" per-proxy labels (`pod`, `instance`, etc.) into `workload:*` series.
     - "Sum away" means that several time-series will be aggregated into one, by combining those with like values for specified fields. The resulting value is the sum of the individual time-series values.
-2. **Federate** using a long-lived "production" Prometheus. Use Prometheus federation to pull the edge aggregates (plus required non-aggregated metrics) into your production Prometheus.
-    - Federating will relabel the `workload:*` aggregates back to standard metric names (e.g. `workload:istio_requests_total` back to `istio_requests_total`) on the production instance so Kiali queries standard metric names.
+2. **Federate** using a long-lived Federated Prometheus. Use Prometheus federation to pull the edge aggregates (plus required non-aggregated metrics) into Federated Prometheus.
+    - Federating will relabel the `workload:*` aggregates back to standard metric names (e.g. `workload:istio_requests_total` back to `istio_requests_total`) on Federated Prometheus so Kiali queries standard metric names.
 
 Kiali already aggregates traffic at workload/service granularity in its PromQL; it does not use per-pod Istio labels. Pre-aggregated counters and histograms are therefore compatible with the traffic graph, health monitoring, and metrics tabs.
 
@@ -128,7 +128,7 @@ Kiali already aggregates traffic at workload/service granularity in its PromQL; 
 #### Architecture
 
 ```
-  Edge Prometheus                         Production Prometheus
+  Edge Prometheus                         Federated Prometheus
   (scrapes Istio/Envoy)                   (long retention; Kiali queries here)
         │                                           ▲
         │  recording rules                          │  /federate
@@ -139,7 +139,9 @@ Kiali already aggregates traffic at workload/service granularity in its PromQL; 
 
 **Edge Prometheus** is whichever instance scrapes Istio mesh telemetry (often *not* the same as your platform monitoring stack). It evaluates recording rules and keeps a short retention (for example 6 hours) on raw and aggregated series.
 
-**Production Prometheus** is the TSDB Kiali should query. It federates selected series from the edge, relabels `workload:*` back to `istio_*`, and holds long retention. Configure Kiali accordingly:
+**Federated Prometheus** is the long-retention TSDB Kiali should query. It federates selected series from the edge, relabels `workload:*` back to `istio_*`, and holds long retention. Both instances are production components; only Federated Prometheus is Kiali's query target.
+
+Configure Kiali accordingly:
 
 {{% alert color="info" %}}
 The two Prometheus instances are often in different namespaces or clusters in real deployments. The Kiali repository includes a **demo lab harness** that co-locates both in `istio-system` for learning and CI—it is not a production installer.
@@ -149,21 +151,21 @@ The two Prometheus instances are often in different namespaces or clusters in re
 spec:
   external_services:
     prometheus:
-      # Production Prometheus URL — not the edge Istio scraper
-      url: "http://prometheus-prod.monitoring:9090/"
+      # Federated Prometheus URL — not the edge Istio scraper
+      url: "http://prometheus-federated.monitoring:9090/"
 ```
 
-If you use Istio [Perses (or Grafana) dashboards]({{< relref "./perses" >}}) with Kiali , configure them to point at the same production Prometheus URL.
+If you use Istio [Perses (or Grafana) dashboards]({{< relref "./perses" >}}) with Kiali , configure them to point at the same Federated Prometheus URL.
 
 {{% alert color="warning" %}}
-**Production assumption:** In this pattern, `external_services.prometheus.url` **always** targets production Prometheus—the long-retention TSDB that holds federated mesh metrics. The edge exists only to collect raw telemetry, evaluate recording rules, and federate upstream; it is not Kiali's database.
+**Query target:** In this pattern, `external_services.prometheus.url` **always** targets Federated Prometheus—the long-retention TSDB that holds federated mesh metrics. Edge Prometheus exists only to collect raw telemetry, evaluate recording rules, and federate upstream; it is not Kiali's database.
 
-`kiali_*` self-monitoring metrics must also end up in that production TSDB, but may reach it via edge aggregation and federation or via direct scrape—see [Kiali self-monitoring metrics](#kiali-self-monitoring-metrics).
+`kiali_*` self-monitoring metrics must also end up in that Federated Prometheus TSDB, but may reach it via edge aggregation and federation or via direct scrape—see [Kiali self-monitoring metrics](#kiali-self-monitoring-metrics).
 {{% /alert %}}
 
 #### Metric tiers
 
-Federation configuration is split into tiers (metric groupings) so that the production Prometheus pulls only needed metrics:
+Federation configuration is split into tiers (metric groupings) so that Federated Prometheus pulls only needed metrics:
 
 | Tier | Purpose | Required for |
 | ---- | ------- | ------------ |
@@ -172,7 +174,7 @@ Federation configuration is split into tiers (metric groupings) so that the prod
 | **Kiali self-monitoring** | Kiali operational metrics (`kiali_*`) | Kiali Internal Metrics dashboard, optional health-status alerting |
 
 
-Some Perses dashboards work with the **Core** tier alone (Mesh, service, and workload dashboards). To ensure all of the Istio dashboards are supported, Enable the **Istio Dashboards** tier. Enable **Kiali self-monitoring** when the built-in Kiali metrics dashboard or `kiali_health_status` alerting is needed. Note that if you define your own Kiali Custom Dashboards, you will need to ensure any required metrics are also configured for the production Prometheus.
+Some Perses dashboards work with the **Core** tier alone (Mesh, service, and workload dashboards). To ensure all of the Istio dashboards are supported, Enable the **Istio Dashboards** tier. Enable **Kiali self-monitoring** when the built-in Kiali metrics dashboard or `kiali_health_status` alerting is needed. Note that if you define your own Kiali Custom Dashboards, you will need to ensure any required metrics are also configured for the federated Prometheus.
 
 #### Production reference files
 
@@ -181,7 +183,7 @@ For **production** deployments, merge the YAML below from [`hack/istio/metric-ru
 | File | Integrate into | Purpose |
 | ---- | -------------- | ------- |
 | `core-recording-rules.yml` | Edge Prometheus (scrapes Istio/Envoy) | Recording rules producing `workload:*` series |
-| `core-federation-match.yml` | Production Prometheus federation job | Core-tier `match[]` selectors |
+| `core-federation-match.yml` | Federated Prometheus federation job | Core-tier `match[]` selectors |
 | `core-metrics.yml` | (reference) | Canonical core Istio metric list |
 | `istio-dashboard-federation-match.yml` | Production federation job (optional) | Perses dashboard `match[]` selectors |
 | `istio-dashboard-metrics.yml` | (reference) | Optional Istio dashboard metric list |
@@ -189,16 +191,16 @@ For **production** deployments, merge the YAML below from [`hack/istio/metric-ru
 | `kiali-metrics-federation-match.yml` | Production federation job (optional) | Federation selectors for `kiali:*` series |
 | `kiali-metrics.yml` | (reference) | Canonical Kiali self-monitoring metric list |
 
-The [recording rules](#recording-rules-edge-prometheus), [federation](#federation-production-prometheus), and [production checklist](#production-checklist) sections below describe how to apply these files. Optional tiers (Istio dashboards, Kiali self-monitoring) are added only when those features are enabled.
+The [recording rules](#recording-rules-edge-prometheus), [federation](#federation-federated-prometheus), and [production checklist](#integration-checklist) sections below describe how to apply these files. Optional tiers (Istio dashboards, Kiali self-monitoring) are added only when those features are enabled.
 
 #### Demo lab files (not for production)
 
-The `demo/` subdirectory under the same path contains scripts and sample Kubernetes deployments for learning and CI. They patch the Istio add-on Prometheus in `istio-system` and deploy sample `prometheus-prod` / `prometheus-kiali-edge` instances. **Do not use `demo/` in production clusters**—use the reference files above with your own Prometheus instead.
+The `demo/` subdirectory under the same path contains scripts and sample Kubernetes deployments for learning and CI. They patch the Istio add-on Prometheus in `istio-system` and deploy sample `prometheus-federated` / `prometheus-kiali-edge` instances. **Do not use `demo/` in production clusters**—use the reference files above with your own Prometheus instead.
 
 | File | Purpose |
 | ---- | ------- |
 | `demo/install.sh` / `demo/uninstall.sh` | Demo lab deploy and teardown |
-| `demo/prometheus-prod.yaml` | Sample production federator deployment |
+| `demo/prometheus-federated.yaml` | Sample Federated Prometheus deployment deployment |
 | `demo/prometheus-kiali-edge.yaml` | Sample dedicated Kiali edge Prometheus |
 | `demo/render-*.py`, `demo/merge-recording-rules.py` | Render demo manifests from the production reference YAML |
 
@@ -227,9 +229,9 @@ The recording rules do not apply `rate()`. Kiali applies `rate()` at query time 
 
 How you install the rules depends on your platform—for example a `rule_files` entry in `prometheus.yml`, a ConfigMap volume mount, or a Prometheus Operator `PrometheusRule` CR in the namespace where edge Prometheus runs.
 
-#### Federation (production Prometheus)
+#### Federation (federated Prometheus)
 
-Add a federation scrape job to your **existing** long-retention production Prometheus. Use `core-federation-match.yml` for the complete core-tier `match[]` list. Federate `workload:*` traffic metrics from the edge and relabel names before storage:
+Add a federation scrape job to your **existing** long-retention federated Prometheus. Use `core-federation-match.yml` for the complete core-tier `match[]` list. Federate `workload:*` traffic metrics from the edge and relabel names before storage:
 
 ```yaml
 - job_name: istio-mesh-federate
@@ -256,7 +258,7 @@ Also federate non-traffic metrics that Kiali needs but does not aggregate (for e
 
 To include Istio dashboard metrics, append the selectors from `istio-dashboard-federation-match.yml` to `match[]`.
 
-Configure network access, TLS, and authentication between production and edge Prometheus according to your environment. Kiali authentication for the production URL is configured separately (see [Prometheus authentication configuration](#prometheus-authentication-configuration) below).
+Configure network access, TLS, and authentication between Federated and Edge Prometheus according to your environment. Kiali authentication for the Federated Prometheus URL is configured separately (see [Prometheus authentication configuration](#prometheus-authentication-configuration) below).
 
 #### Demo walkthrough (lab only)
 
@@ -275,7 +277,7 @@ The `demo/install.sh` script is a **learning and CI harness only**. It does not 
 # Optional: federate Kiali self-monitoring (dedicated Kiali edge Prometheus)
 ./hack/istio/metric-rules/demo/install.sh --with-kiali-metrics --kiali-edge dedicated
 
-# Optional: point Kiali at the demo production Prometheus
+# Optional: point Kiali at the demo federated Prometheus
 ./hack/istio/metric-rules/demo/install.sh --switch-kiali
 
 # Combine flags as needed, for example:
@@ -288,8 +290,8 @@ After install, port-forward and verify:
 # Istio edge Prometheus (recording rules)
 kubectl port-forward -n istio-system svc/prometheus 9091:9090
 
-# Demo production Prometheus (federated data; point Kiali here)
-kubectl port-forward -n istio-system svc/prometheus-prod 9092:9090
+# Demo federated Prometheus (federated data; point Kiali here)
+kubectl port-forward -n istio-system svc/prometheus-federated 9092:9090
 
 # Dedicated Kiali edge (only with --kiali-edge dedicated)
 kubectl port-forward -n istio-system svc/prometheus-kiali-edge 9093:9090
@@ -302,24 +304,24 @@ curl -s 'http://localhost:9092/api/v1/query?query=count(istio_requests_total)'
 curl -s 'http://localhost:9092/api/v1/query?query=count({__name__=~"kiali_.*"})'
 ```
 
-The **Kiali Internal Metrics** dashboard only works when Kiali queries production Prometheus (`--switch-kiali` or `external_services.prometheus.url` → `prometheus-prod`).
+The **Kiali Internal Metrics** dashboard only works when Kiali queries federated Prometheus (`--switch-kiali` or `external_services.prometheus.url` → `prometheus-federated`).
 
 See [`hack/istio/metric-rules/README.md`](https://github.com/kiali/kiali/blob/master/hack/istio/metric-rules/README.md) for teardown (`demo/uninstall.sh`).
 
-#### Production checklist
+#### Integration checklist
 
 Use this checklist when integrating the [production reference files](#production-reference-files) into your own Prometheus stack (not the `demo/` installer):
 
 1. Identify edge Prometheus—the TSDB that scrapes Istio/Envoy (may be in a `monitoring` namespace, a remote cluster, or a managed service—not necessarily `istio-system`).
 2. Merge `core-recording-rules.yml` onto the edge; set short retention on raw mesh telemetry.
-3. Add a federation scrape job to production Prometheus using `core-federation-match.yml`.
+3. Add a federation scrape job to federated Prometheus using `core-federation-match.yml`.
 4. Optionally extend `match[]` with Istio dashboard-tier selectors if Istio dashboards are enabled.
-5. If Kiali self-monitoring is enabled, choose an option from [Kiali self-monitoring metrics](#kiali-self-monitoring-metrics): apply `kiali-metrics-recording-rules.yml` on the Kiali edge and federate `kiali-metrics-federation-match.yml` to production (Options 1–2), or scrape Kiali directly into production (Option 3).
-6. Point `external_services.prometheus.url` at production Prometheus (and the same URL for Perses/Grafana, if using).
+5. If Kiali self-monitoring is enabled, choose an option from [Kiali self-monitoring metrics](#kiali-self-monitoring-metrics): apply `kiali-metrics-recording-rules.yml` on the Kiali edge and federate `kiali-metrics-federation-match.yml` to Federated Prometheus (Options 1–2), or scrape Kiali directly into Federated Prometheus (Option 3).
+6. Point `external_services.prometheus.url` at federated Prometheus (and the same URL for Perses/Grafana, if using).
 7. Validate equivalence between edge aggregates and federated data (see below).
 8. Tune intervals using [Interval tuning](#interval-tuning) below.
 
-For **multi-cluster** deployments, federation is typically per mesh cluster (edge → production for that cluster).
+For **multi-cluster** deployments, federation is typically per mesh cluster (edge → federated for that cluster).
 
 #### Interval tuning
 
@@ -329,19 +331,19 @@ Several independent intervals affect freshness, CPU use, and the minimum time wi
 | ------- | ---------------- | ---- | ---- |
 | **Metric Scrape interval** | Edge Prometheus | `global.scrape_interval` (or per-job override on Istio/Envoy targets) | How often raw `istio_*` metrics are scraped |
 | **Recording rule interval** | Edge Prometheus | `interval` on the rule group in `core-recording-rules.yml` | How often `workload:*` aggregates are recomputed |
-| **Federation interval** | Production Prometheus | `scrape_interval` on the production federation job | How often Prometheus pulls `workload:*` (and other federated series) from the edge |
+| **Federation interval** | Federated Prometheus | `scrape_interval` on the federated Prometheus federation job | How often Prometheus pulls `workload:*` (and other federated series) from the edge |
 | **Metric retention** | Edge Prometheus | `storage.tsdb.retention.time` | How long raw and `workload:*` series are kept before expiry (short, e.g. 6h) |
-| **Metric retention** | Production Prometheus | `storage.tsdb.retention.time` | Long-term history Kiali and dashboards query (as desired) |
+| **Metric retention** | Federated Prometheus | `storage.tsdb.retention.time` | Long-term history Kiali and dashboards query (as desired) |
 
 **Rules of thumb:**
 
 1. Recording rule interval ≥ edge scrape interval.
   -- Rules read raw series; evaluating more often than scrapes complete adds CPU without new data. A practical range is equal to the scrape interval, up to 2× the scrape interval ([Istio guidance](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)).
 2. Federation interval ≥ recording rule interval.
-  -- The Production Prometheus should federate aggregates after the edge has evaluated them. **30s** is a common federation interval and matches the Kiali reference configuration.
+  -- The Federated Prometheus should federate aggregates after the edge has evaluated them. **30s** is a common federation interval and matches the Kiali reference configuration.
 3. Set `scrape_timeout` below `scrape_interval` on the federation job.
   -- (for example `25s` timeout with `30s` interval) so slow federation scrapes do not overlap.
-4. Kiali minimum duration depends on the **effective sampling** of the data it queries (production Prometheus), not the edge scrape interval.
+4. Kiali minimum duration depends on the **effective sampling** of the data it queries (federated Prometheus), not the edge scrape interval.
   -- With federation, that is roughly **recording rule interval + federation scrape interval**. Kiali needs at least **two samples** in a rate window, so minimum graph duration should be **≥ 2× that effective interval** (see [Scrape Interval](#scrape-interval) below).
 
 **Recommended settings when edge scrape is 30s:**
@@ -352,13 +354,13 @@ This is a common production default (for example kube-prometheus-stack). The Kia
 | ------- | ----------------- | ----- |
 | Edge `scrape_interval` | `30s` | Your stated baseline |
 | Recording rule `interval` | `30s` | Matches scrape; good balance of freshness and CPU |
-| Federation `scrape_interval` | `30s` | Istio-recommended; used in `demo/prometheus-prod.yaml` |
+| Federation `scrape_interval` | `30s` | Istio-recommended; used in `demo/prometheus-federated.yaml` |
 | Federation `scrape_timeout` | `25s` | Slightly less than scrape interval |
 | Edge retention | `6h` | Enough for troubleshooting; raw series expire after federation |
 | Effective sampling (Kiali) | `~60s` | Rule interval + federation interval |
 | Practical minimum Kiali duration | `≥ 2m` (`120s`) | `2 × 60s`; Kiali may round up in the duration dropdown |
 
-Example edge rule group header and production federation job:
+Example edge rule group header and federated Prometheus federation job:
 
 ```yaml
 # Edge Prometheus — recording rules
@@ -371,7 +373,7 @@ groups:
 ```
 
 ```yaml
-# Production Prometheus — federation job
+# Federated Prometheus — federation job
 - job_name: istio-mesh-federate
   scrape_interval: 30s
   scrape_timeout: 25s
@@ -379,7 +381,7 @@ groups:
   # ... match[] and relabel configs
 ```
 
-Expected freshness: mesh traffic visible in Kiali on production Prometheus is typically on the order of **one to two minutes** behind live traffic (one scrape + one rule evaluation + one federation cycle, plus alignment jitter).
+Expected freshness: mesh traffic visible in Kiali on federated Prometheus is typically on the order of **one to two minutes** behind live traffic (one scrape + one rule evaluation + one federation cycle, plus alignment jitter).
 
 **Other edge scrape intervals:**
 
@@ -397,7 +399,7 @@ Istio’s own examples sometimes use **5s** rule evaluation with **30s** federat
 
 Today Kiali reads `globalScrapeInterval` from the Prometheus URL in `external_services.prometheus.url` (production) and filters durations with **`≥ 2 × globalScrapeInterval`**. When using federation:
 
-- Ensure production Prometheus **`global.scrape_interval`** (or the value exposed in `/api/v1/status/config`) reflects the federation job interval if that is the coarsest sampling Kiali sees, **OR**
+- Ensure federated Prometheus **`global.scrape_interval`** (or the value exposed in `/api/v1/status/config`) reflects the federation job interval if that is the coarsest sampling Kiali sees, **OR**
 - Plan for a future **`metric_aggregation_interval`** setting (see the [metric rules KEP](https://github.com/kiali/kiali/blob/master/design/KEPS/metric-rules/proposal.md)) to set the minimum duration floor explicitly to (rule interval + federation interval).
 
 Until `metric_aggregation_interval` is available, if production `global.scrape_interval` is `1m` but federation runs every `30s`, Kiali may offer durations that are shorter than ideal for federated traffic metrics. Operators can rely on slightly longer graph durations (for example `2m` or `5m`) for rate-based views when in doubt.
@@ -406,13 +408,13 @@ Until `metric_aggregation_interval` is available, if production `global.scrape_i
 
 Kiali can export its own Prometheus metrics (`kiali_*`) for performance and optional health-status monitoring. These are **not** Istio mesh metrics—they are not produced on the edge by Envoy, not listed in `core-metrics.yml`, and not part of the Istio federation tiers.
 
-Because Kiali queries production Prometheus, `kiali_*` series must ultimately be available in that same TSDB. The [metric rules KEP](https://github.com/kiali/kiali/blob/master/design/KEPS/metric-rules/proposal.md#kiali-self-monitoring-metrics) describes three deployment options:
+Because Kiali queries federated Prometheus, `kiali_*` series must ultimately be available in that same TSDB. The [metric rules KEP](https://github.com/kiali/kiali/blob/master/design/KEPS/metric-rules/proposal.md#kiali-self-monitoring-metrics) describes three deployment options:
 
 | Option | Kiali metrics scraped by | Before production |
 | ------ | ------------------------ | ----------------- |
 | **1. Shared Istio edge** | Same edge Prom as Istio/Envoy | Recording rules + federation (parallel to `workload:*`) |
 | **2. Dedicated Kiali edge** | Separate edge Prom for Kiali only | Recording rules + federation to prod |
-| **3. Direct to production** | Production Prom directly | Raw scrape; dedup required in queries for HA |
+| **3. Direct to Federated** | Federated Prom directly | Raw scrape; dedup required in queries for HA |
 
 
 | Config | Default | Purpose |
@@ -425,7 +427,7 @@ The metrics HTTP listener (port `server.observability.metrics.port`, default `90
 
 **`kiali_health_status` and HA:** Multiple Kiali replicas export the **same** gauge values for the same entities (duplicate series, not partition-of-work). With Options 1 or 2, use `max without (pod, instance, …)` in recording rules to deduplicate—not `sum`. With Option 3, apply the same dedup in alert/dashboard queries (for example `max by (cluster, namespace, health_type, name) (kiali_health_status)`), because raw scrape retains per-replica copies.
 
-The built-in **Kiali Internal Metrics** custom dashboard queries `external_services.prometheus.url`; it only works when production Prometheus holds the `kiali_*` series (via federation or direct scrape).
+The built-in **Kiali Internal Metrics** custom dashboard queries `external_services.prometheus.url`; it only works when federated Prometheus holds the `kiali_*` series (via federation or direct scrape).
 
 Reference files for Options 1–2: `kiali-metrics-recording-rules.yml`, `kiali-metrics-federation-match.yml`, and (for Option 2) `demo/prometheus-kiali-edge.yaml`. Try them in the [demo walkthrough](#demo-walkthrough-lab-only) with `--with-kiali-metrics` and optionally `--kiali-edge dedicated`.
 
@@ -433,13 +435,13 @@ For `kiali_health_status` alerting on OpenShift, see the [OSSM health status ale
 
 #### Validation
 
-Confirm that federated series match edge aggregates (on production Prometheus, after relabel):
+Confirm that federated series match edge aggregates (on federated Prometheus, after relabel):
 
 ```promql
 # Edge Prometheus
 sum(rate(workload:istio_requests_total{destination_workload_namespace="bookinfo"}[5m]))
 
-# Production Prometheus
+# Federated Prometheus
 sum(rate(istio_requests_total{destination_workload_namespace="bookinfo"}[5m]))
 ```
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -174,23 +174,40 @@ Federation configuration is split into tiers (metric groupings) so that the prod
 
 Some Perses dashboards work with the **Core** tier alone (Mesh, service, and workload dashboards). To ensure all of the Istio dashboards are supported, Enable the **Istio Dashboards** tier. Enable **Kiali self-monitoring** when the built-in Kiali metrics dashboard or `kiali_health_status` alerting is needed. Note that if you define your own Kiali Custom Dashboards, you will need to ensure any required metrics are also configured for the production Prometheus.
 
-Reference files live in the Kiali repository under [`hack/istio/metric-rules/`](https://github.com/kiali/kiali/tree/master/hack/istio/metric-rules):
+#### Production reference files
 
-| File | Description |
-| ---- | ----------- |
-| `recording-rules.yml` | Edge recording rules producing `workload:*` series |
-| `kiali-required-metrics.yml` | Canonical core Istio metric list |
-| `federation-match-dashboards.yml` | Optional federation `match[]` selectors for Perses dashboards |
-| `prometheus-prod.yaml` | Example production federation scrape job (core tier) |
-| `kiali-recording-rules.yml` | Edge recording rules for Kiali metrics (`kiali:*` series) |
-| `kiali-export-metrics.yml` | Canonical Kiali self-monitoring metric list |
-| `federation-match-kiali.yml` | Federation `match[]` selectors for `kiali:*` series |
-| `prometheus-kiali-edge.yaml` | Example dedicated Kiali edge Prometheus (Option 2) |
+For **production** deployments, merge the YAML below from [`hack/istio/metric-rules/`](https://github.com/kiali/kiali/tree/master/hack/istio/metric-rules) into **your existing** Prometheus configuration. These files are reference snippets—not a Kiali installer and not full deployments. Integrate them the same way you manage other Prometheus rules and scrape jobs (`rule_files`, ConfigMap volume mounts, `PrometheusRule` CRs, Helm values, etc.).
+
+| File | Integrate into | Purpose |
+| ---- | -------------- | ------- |
+| `core-recording-rules.yml` | Edge Prometheus (scrapes Istio/Envoy) | Recording rules producing `workload:*` series |
+| `core-federation-match.yml` | Production Prometheus federation job | Core-tier `match[]` selectors |
+| `core-metrics.yml` | (reference) | Canonical core Istio metric list |
+| `istio-dashboard-federation-match.yml` | Production federation job (optional) | Perses dashboard `match[]` selectors |
+| `istio-dashboard-metrics.yml` | (reference) | Optional Istio dashboard metric list |
+| `kiali-metrics-recording-rules.yml` | Kiali edge Prometheus (optional) | Recording rules for `kiali:*` series |
+| `kiali-metrics-federation-match.yml` | Production federation job (optional) | Federation selectors for `kiali:*` series |
+| `kiali-metrics.yml` | (reference) | Canonical Kiali self-monitoring metric list |
+
+The [recording rules](#recording-rules-edge-prometheus), [federation](#federation-production-prometheus), and [production checklist](#production-checklist) sections below describe how to apply these files. Optional tiers (Istio dashboards, Kiali self-monitoring) are added only when those features are enabled.
+
+#### Demo lab files (not for production)
+
+The `demo/` subdirectory under the same path contains scripts and sample Kubernetes deployments for learning and CI. They patch the Istio add-on Prometheus in `istio-system` and deploy sample `prometheus-prod` / `prometheus-kiali-edge` instances. **Do not use `demo/` in production clusters**—use the reference files above with your own Prometheus instead.
+
+| File | Purpose |
+| ---- | ------- |
+| `demo/install.sh` / `demo/uninstall.sh` | Demo lab deploy and teardown |
+| `demo/prometheus-prod.yaml` | Sample production federator deployment |
+| `demo/prometheus-kiali-edge.yaml` | Sample dedicated Kiali edge Prometheus |
+| `demo/render-*.py`, `demo/merge-recording-rules.py` | Render demo manifests from the production reference YAML |
+
+See [Demo walkthrough](#demo-walkthrough-lab-only) below to try the pattern locally.
 
 
 #### Recording rules (edge Prometheus)
 
-Add recording rules like the following to the Prometheus instance that scrapes Istio traffic. The rules aggregate on scrape-level labels while preserving the workload/service labels Kiali uses in queries:
+Apply `core-recording-rules.yml` on the Prometheus instance that scrapes Istio traffic (or merge the groups into your existing rule set). The rules aggregate on scrape-level labels while preserving the workload/service labels Kiali uses in queries:
 
 ```yaml
 groups:
@@ -201,7 +218,7 @@ groups:
     expr: sum without (pod, instance, namespace, job, node) (istio_requests_total)
   - record: workload:istio_request_duration_milliseconds_bucket
     expr: sum without (pod, instance, namespace, job, node) (istio_request_duration_milliseconds_bucket)
-  # ... remaining traffic counters and histogram components — see recording-rules.yml
+  # ... remaining traffic counters and histogram components — see core-recording-rules.yml
 ```
 
 {{% alert color="warning" %}}
@@ -212,7 +229,7 @@ How you install the rules depends on your platform—for example a `rule_files` 
 
 #### Federation (production Prometheus)
 
-Add a federation scrape job to your existing long-retention Prometheus. Federate `workload:*` traffic metrics from the edge and relabel names before storage:
+Add a federation scrape job to your **existing** long-retention production Prometheus. Use `core-federation-match.yml` for the complete core-tier `match[]` list. Federate `workload:*` traffic metrics from the edge and relabel names before storage:
 
 ```yaml
 - job_name: istio-mesh-federate
@@ -224,7 +241,7 @@ Add a federation scrape job to your existing long-retention Prometheus. Federate
       - '{__name__=~"workload:istio_requests_total"}'
       - '{__name__=~"workload:istio_request_bytes_(bucket|count|sum)"}'
       - '{__name__=~"workload:istio_request_duration_milliseconds_(bucket|count|sum)"}'
-      # ... see prometheus-prod.yaml for the full core-tier list
+      # ... see core-federation-match.yml for the full core-tier list
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: 'workload:(.*)'
@@ -235,34 +252,34 @@ Add a federation scrape job to your existing long-retention Prometheus. Federate
     - '<edge-prometheus-host>:9090'
 ```
 
-Also federate non-traffic metrics that Kiali needs but does not aggregate (for example `istio_build`, `pilot_xds`, `container_cpu_usage_seconds_total`) directly by name—see `kiali-required-metrics.yml` and `prometheus-prod.yaml`.
+Also federate non-traffic metrics that Kiali needs but does not aggregate (for example `istio_build`, `pilot_xds`, `container_cpu_usage_seconds_total`) directly by name—see `core-metrics.yml` and `core-federation-match.yml`.
 
-To include Istio dashboard metrics, append the selectors from `federation-match-dashboards.yml` to `match[]`.
+To include Istio dashboard metrics, append the selectors from `istio-dashboard-federation-match.yml` to `match[]`.
 
 Configure network access, TLS, and authentication between production and edge Prometheus according to your environment. Kiali authentication for the production URL is configured separately (see [Prometheus authentication configuration](#prometheus-authentication-configuration) below).
 
 #### Demo walkthrough (lab only)
 
-The Kiali repository provides a demo script that patches the Istio add-on Prometheus in `istio-system`, deploys a sample `prometheus-prod` federator, and optionally switches Kiali to use it. Use this to learn the pattern or validate in CI—not as a production deployment:
+The `demo/install.sh` script is a **learning and CI harness only**. It does not replace the production integration above—it automates the same reference YAML against the Istio add-on Prometheus in `istio-system` so you can validate the pattern locally:
 
 ```bash
 # From a clone of github.com/kiali/kiali, with Istio add-on Prometheus running:
-./hack/istio/metric-rules/install.sh
+./hack/istio/metric-rules/demo/install.sh
 
 # Optional: also federate Perses dashboard metrics
-./hack/istio/metric-rules/install.sh --with-dashboards
+./hack/istio/metric-rules/demo/install.sh --with-dashboards
 
 # Optional: federate Kiali self-monitoring (shared Istio edge Prometheus)
-./hack/istio/metric-rules/install.sh --with-kiali-metrics
+./hack/istio/metric-rules/demo/install.sh --with-kiali-metrics
 
 # Optional: federate Kiali self-monitoring (dedicated Kiali edge Prometheus)
-./hack/istio/metric-rules/install.sh --with-kiali-metrics --kiali-edge dedicated
+./hack/istio/metric-rules/demo/install.sh --with-kiali-metrics --kiali-edge dedicated
 
 # Optional: point Kiali at the demo production Prometheus
-./hack/istio/metric-rules/install.sh --switch-kiali
+./hack/istio/metric-rules/demo/install.sh --switch-kiali
 
 # Combine flags as needed, for example:
-./hack/istio/metric-rules/install.sh --with-dashboards --with-kiali-metrics --switch-kiali
+./hack/istio/metric-rules/demo/install.sh --with-dashboards --with-kiali-metrics --switch-kiali
 ```
 
 After install, port-forward and verify:
@@ -287,15 +304,17 @@ curl -s 'http://localhost:9092/api/v1/query?query=count({__name__=~"kiali_.*"})'
 
 The **Kiali Internal Metrics** dashboard only works when Kiali queries production Prometheus (`--switch-kiali` or `external_services.prometheus.url` → `prometheus-prod`).
 
-See [`hack/istio/metric-rules/README.md`](https://github.com/kiali/kiali/blob/master/hack/istio/metric-rules/README.md) for teardown (`uninstall.sh`).
+See [`hack/istio/metric-rules/README.md`](https://github.com/kiali/kiali/blob/master/hack/istio/metric-rules/README.md) for teardown (`demo/uninstall.sh`).
 
 #### Production checklist
 
+Use this checklist when integrating the [production reference files](#production-reference-files) into your own Prometheus stack (not the `demo/` installer):
+
 1. Identify edge Prometheus—the TSDB that scrapes Istio/Envoy (may be in a `monitoring` namespace, a remote cluster, or a managed service—not necessarily `istio-system`).
-2. Install recording rules on the edge; set short retention on raw mesh telemetry.
-3. Add a federation scrape job to your production Prometheus using the core-tier `match[]` list.
+2. Merge `core-recording-rules.yml` onto the edge; set short retention on raw mesh telemetry.
+3. Add a federation scrape job to production Prometheus using `core-federation-match.yml`.
 4. Optionally extend `match[]` with Istio dashboard-tier selectors if Istio dashboards are enabled.
-5. If Kiali self-monitoring is enabled, choose an option from [Kiali self-monitoring metrics](#kiali-self-monitoring-metrics): apply `kiali-recording-rules.yml` on the Kiali edge and federate `federation-match-kiali.yml` to production (Options 1–2), or scrape Kiali directly into production (Option 3).
+5. If Kiali self-monitoring is enabled, choose an option from [Kiali self-monitoring metrics](#kiali-self-monitoring-metrics): apply `kiali-metrics-recording-rules.yml` on the Kiali edge and federate `kiali-metrics-federation-match.yml` to production (Options 1–2), or scrape Kiali directly into production (Option 3).
 6. Point `external_services.prometheus.url` at production Prometheus (and the same URL for Perses/Grafana, if using).
 7. Validate equivalence between edge aggregates and federated data (see below).
 8. Tune intervals using [Interval tuning](#interval-tuning) below.
@@ -309,7 +328,7 @@ Several independent intervals affect freshness, CPU use, and the minimum time wi
 | What is configured | Where configured | Setting | Role |
 | ------- | ---------------- | ---- | ---- |
 | **Metric Scrape interval** | Edge Prometheus | `global.scrape_interval` (or per-job override on Istio/Envoy targets) | How often raw `istio_*` metrics are scraped |
-| **Recording rule interval** | Edge Prometheus | `interval` on the rule group in `recording-rules.yml` | How often `workload:*` aggregates are recomputed |
+| **Recording rule interval** | Edge Prometheus | `interval` on the rule group in `core-recording-rules.yml` | How often `workload:*` aggregates are recomputed |
 | **Federation interval** | Production Prometheus | `scrape_interval` on the production federation job | How often Prometheus pulls `workload:*` (and other federated series) from the edge |
 | **Metric retention** | Edge Prometheus | `storage.tsdb.retention.time` | How long raw and `workload:*` series are kept before expiry (short, e.g. 6h) |
 | **Metric retention** | Production Prometheus | `storage.tsdb.retention.time` | Long-term history Kiali and dashboards query (as desired) |
@@ -333,7 +352,7 @@ This is a common production default (for example kube-prometheus-stack). The Kia
 | ------- | ----------------- | ----- |
 | Edge `scrape_interval` | `30s` | Your stated baseline |
 | Recording rule `interval` | `30s` | Matches scrape; good balance of freshness and CPU |
-| Federation `scrape_interval` | `30s` | Istio-recommended; used in `prometheus-prod.yaml` |
+| Federation `scrape_interval` | `30s` | Istio-recommended; used in `demo/prometheus-prod.yaml` |
 | Federation `scrape_timeout` | `25s` | Slightly less than scrape interval |
 | Edge retention | `6h` | Enough for troubleshooting; raw series expire after federation |
 | Effective sampling (Kiali) | `~60s` | Rule interval + federation interval |
@@ -385,7 +404,7 @@ Until `metric_aggregation_interval` is available, if production `global.scrape_i
 
 #### Kiali self-monitoring metrics
 
-Kiali can export its own Prometheus metrics (`kiali_*`) for performance and optional health-status monitoring. These are **not** Istio mesh metrics—they are not produced on the edge by Envoy, not listed in `kiali-required-metrics.yml`, and not part of the Istio federation tiers.
+Kiali can export its own Prometheus metrics (`kiali_*`) for performance and optional health-status monitoring. These are **not** Istio mesh metrics—they are not produced on the edge by Envoy, not listed in `core-metrics.yml`, and not part of the Istio federation tiers.
 
 Because Kiali queries production Prometheus, `kiali_*` series must ultimately be available in that same TSDB. The [metric rules KEP](https://github.com/kiali/kiali/blob/master/design/KEPS/metric-rules/proposal.md#kiali-self-monitoring-metrics) describes three deployment options:
 
@@ -408,7 +427,7 @@ The metrics HTTP listener (port `server.observability.metrics.port`, default `90
 
 The built-in **Kiali Internal Metrics** custom dashboard queries `external_services.prometheus.url`; it only works when production Prometheus holds the `kiali_*` series (via federation or direct scrape).
 
-Reference files for Options 1–2: `kiali-recording-rules.yml`, `federation-match-kiali.yml`, and (for Option 2) `prometheus-kiali-edge.yaml`. Try them in the [demo walkthrough](#demo-walkthrough-lab-only) with `--with-kiali-metrics` and optionally `--kiali-edge dedicated`.
+Reference files for Options 1–2: `kiali-metrics-recording-rules.yml`, `kiali-metrics-federation-match.yml`, and (for Option 2) `demo/prometheus-kiali-edge.yaml`. Try them in the [demo walkthrough](#demo-walkthrough-lab-only) with `--with-kiali-metrics` and optionally `--kiali-edge dedicated`.
 
 For `kiali_health_status` alerting on OpenShift, see the [OSSM health status alerts tutorial]({{< relref "../../Tutorials/ossm-multicluster/ossm-health-status-alerts" >}}).
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -316,8 +316,6 @@ Several independent intervals affect freshness, CPU use, and the minimum time wi
 | **Metric retention** | Edge Prometheus | `storage.tsdb.retention.time` | How long raw and `workload:*` series are kept before expiry (short, e.g. 6h) |
 | **Metric retention** | Production Prometheus | `storage.tsdb.retention.time` | Long-term history Kiali and dashboards query (as desired) |
 
-&nbsp;
-
 **Rules of thumb**
 
 1. Recording rule interval ≥ edge scrape interval. Rules read raw series; evaluating more often than scrapes complete adds CPU without new data. A practical range is equal to the scrape interval, up to 2× the scrape interval ([Istio guidance](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)).
@@ -325,7 +323,7 @@ Several independent intervals affect freshness, CPU use, and the minimum time wi
 3. **Set `scrape_timeout` below `scrape_interval`** on the federation job (for example `25s` timeout with `30s` interval) so slow federation scrapes do not overlap.
 4. **Kiali minimum duration** depends on the **effective sampling** of the data it queries (production Prometheus), not the edge scrape interval. With federation, that is roughly **recording rule interval + federation scrape interval**. Kiali needs at least **two samples** in a rate window, so minimum graph duration should be **≥ 2× that effective interval** (see [Scrape Interval](#scrape-interval) below).
 
-##### Recommended settings when edge scrape is 30s
+**Recommended settings when edge scrape is 30s**
 
 This is a common production default (for example kube-prometheus-stack). The Kiali reference bundle uses these values:
 
@@ -338,8 +336,6 @@ This is a common production default (for example kube-prometheus-stack). The Kia
 | Edge retention | `6h` | Enough for troubleshooting; raw series expire after federation |
 | Effective sampling (Kiali) | `~60s` | Rule interval + federation interval |
 | Practical minimum Kiali duration | `≥ 2m` (`120s`) | `2 × 60s`; Kiali may round up in the duration dropdown |
-
-&nbsp;
 
 Example edge rule group header and production federation job:
 
@@ -362,9 +358,9 @@ groups:
   # ... match[] and relabel configs
 ```
 
-**Expected freshness:** mesh traffic visible in Kiali on production Prometheus is typically on the order of **one to two minutes** behind live traffic (one scrape + one rule evaluation + one federation cycle, plus alignment jitter).
+Expected freshness: mesh traffic visible in Kiali on production Prometheus is typically on the order of **one to two minutes** behind live traffic (one scrape + one rule evaluation + one federation cycle, plus alignment jitter).
 
-##### Other edge scrape intervals
+**Other edge scrape intervals**
 
 | Edge scrape | Recording rules | Federation | Effective sampling | Min duration (2×) |
 | ----------- | --------------- | ---------- | ------------------ | ----------------- |
@@ -372,13 +368,11 @@ groups:
 | `30s` (recommended row above) | `30s` | `30s` | `60s` | `120s` |
 | `1m` | `1m` | `1m` | `2m` | `4m` |
 
-&nbsp;
-
-For **fresher** aggregates at the cost of more edge CPU, use a recording rule interval **equal to** the scrape interval (for example both `15s`). For **lower** edge CPU, use rule interval **2×** scrape (for example `30s` rules with `15s` scrape, or `60s` rules with `30s` scrape)—accepting additional lag before `workload:*` updates.
+For fresher aggregates at the cost of more edge CPU, use a recording rule interval **equal to** the scrape interval (for example both `15s`). For lower edge CPU, use rule interval **2×** scrape (for example `30s` rules with `15s` scrape, or `60s` rules with `30s` scrape)—accepting additional lag before `workload:*` updates.
 
 Istio’s own examples sometimes use **5s** rule evaluation with **30s** federation for faster edge aggregation; that is reasonable when edge scrape is `15s` and you want sub-minute freshness. It increases rule-evaluation load and is optional—not required for Kiali correctness.
 
-##### Kiali duration dropdown
+**Kiali duration dropdown**
 
 Today Kiali reads `globalScrapeInterval` from the Prometheus URL in `external_services.prometheus.url` (production) and filters durations with **`≥ 2 × globalScrapeInterval`**. When using federation:
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -117,9 +117,9 @@ Istio and Envoy generate a large amount of telemetry for analysis and troublesho
 
 For production meshes at scale, [metric thinning](#option-2-metric-thinning) on a single Prometheus TSDB reduces storage somewhat but still retains per-proxy Istio series. A more efficient approach—aligned with [Istio Observability Best Practices](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)—is to:
 
-1. **Aggregate** using a short-lived "edge" Prometheus. Scrape your raw metrics and then use recording rules that "sum away" per-proxy labels (`pod`, `instance`, etc.) into `workload:*` series.
+1. Aggregate using a short-lived "edge" Prometheus. Scrape your raw metrics and then use recording rules that "sum away" per-proxy labels (`pod`, `instance`, etc.) into `workload:*` series.
     - "Sum away" means that several time-series will be aggregated into one, by combining those with like values for specified fields. The resulting value is the sum of the individual time-series values.
-2. **Federate** using a long-lived Federated Prometheus. Use Prometheus federation to pull the edge aggregates (plus required non-aggregated metrics) into Federated Prometheus.
+2. Federate using a long-lived Federated Prometheus. Use Prometheus federation to pull the edge aggregates (plus required non-aggregated metrics) into Federated Prometheus.
     - Federating will relabel the `workload:*` aggregates back to standard metric names (e.g. `workload:istio_requests_total` back to `istio_requests_total`) on Federated Prometheus so Kiali queries standard metric names.
 
 Kiali already aggregates traffic at workload/service granularity in its PromQL; it does not use per-pod Istio labels. Pre-aggregated counters and histograms are therefore compatible with the traffic graph, health monitoring, and metrics tabs.
@@ -137,14 +137,14 @@ Kiali already aggregates traffic at workload/service granularity in its PromQL; 
         └───────────────────────────────────────────┘
 ```
 
-**Edge Prometheus** is whichever instance scrapes Istio mesh telemetry (often *not* the same as your platform monitoring stack). It evaluates recording rules and keeps a short retention (for example 6 hours) on raw and aggregated series.
+Edge Prometheus is whichever instance scrapes Istio mesh telemetry (often *not* the same as your platform monitoring stack). It evaluates recording rules and keeps a short retention (for example 6 hours) on raw and aggregated series.
 
-**Federated Prometheus** is the long-retention TSDB Kiali should query. It federates selected series from the edge, relabels `workload:*` back to `istio_*`, and holds long retention. Both instances are production components; only Federated Prometheus is Kiali's query target.
+Federated Prometheus is the long-retention TSDB Kiali should query. It federates selected series from the edge, relabels `workload:*` back to `istio_*`, and holds long retention. Both instances are production components; only Federated Prometheus is Kiali's query target.
 
 Configure Kiali accordingly:
 
 {{% alert color="info" %}}
-The two Prometheus instances are often in different namespaces or clusters in real deployments. The Kiali repository includes a **demo lab harness** that co-locates both in `istio-system` for learning and CI—it is not a production installer.
+The two Prometheus instances are often in different namespaces or clusters in real deployments. The Kiali repository includes a demo lab harness that co-locates both in `istio-system` for learning and CI—it is not a production installer.
 {{% /alert %}}
 
 ```yaml
@@ -155,10 +155,10 @@ spec:
       url: "http://prometheus-federated.monitoring:9090/"
 ```
 
-If you use Istio [Perses (or Grafana) dashboards]({{< relref "./perses" >}}) with Kiali , configure them to point at the same Federated Prometheus URL.
+If you use Istio [Perses (or Grafana) dashboards]({{< relref "./perses" >}}) with Kiali, configure them to point at the same Federated Prometheus URL.
 
 {{% alert color="warning" %}}
-**Query target:** In this pattern, `external_services.prometheus.url` **always** targets Federated Prometheus—the long-retention TSDB that holds federated mesh metrics. Edge Prometheus exists only to collect raw telemetry, evaluate recording rules, and federate upstream; it is not Kiali's database.
+Query target: In this pattern, `external_services.prometheus.url` always targets Federated Prometheus—the long-retention TSDB that holds federated mesh metrics. Edge Prometheus exists only to collect raw telemetry, evaluate recording rules, and federate upstream; it is not Kiali's database.
 
 `kiali_*` self-monitoring metrics must also end up in that Federated Prometheus TSDB, but may reach it via edge aggregation and federation or via direct scrape—see [Kiali self-monitoring metrics](#kiali-self-monitoring-metrics).
 {{% /alert %}}
@@ -174,11 +174,11 @@ Federation configuration is split into tiers (metric groupings) so that Federate
 | **Kiali self-monitoring** | Kiali operational metrics (`kiali_*`) | Kiali Internal Metrics dashboard, optional health-status alerting |
 
 
-Some Perses dashboards work with the **Core** tier alone (Mesh, service, and workload dashboards). To ensure all of the Istio dashboards are supported, Enable the **Istio Dashboards** tier. Enable **Kiali self-monitoring** when the built-in Kiali metrics dashboard or `kiali_health_status` alerting is needed. Note that if you define your own Kiali Custom Dashboards, you will need to ensure any required metrics are also configured for the federated Prometheus.
+Some Perses dashboards work with the Core tier alone (Mesh, service, and workload dashboards). To ensure all of the Istio dashboards are supported, enable the Istio Dashboards tier. Enable Kiali self-monitoring when the built-in Kiali metrics dashboard or `kiali_health_status` alerting is needed. Note that if you define your own Kiali Custom Dashboards, you will need to ensure any required metrics are also configured for the federated Prometheus.
 
 #### Production reference files
 
-For **production** deployments, merge the YAML below from [`hack/istio/metric-rules/`](https://github.com/kiali/kiali/tree/master/hack/istio/metric-rules) into **your existing** Prometheus configuration. These files are reference snippets—not a Kiali installer and not full deployments. Integrate them the same way you manage other Prometheus rules and scrape jobs (`rule_files`, ConfigMap volume mounts, `PrometheusRule` CRs, Helm values, etc.).
+For production deployments, merge the YAML below from [`hack/istio/metric-rules/`](https://github.com/kiali/kiali/tree/master/hack/istio/metric-rules) into your existing Prometheus configuration. These files are reference snippets—not a Kiali installer and not full deployments. Integrate them the same way you manage other Prometheus rules and scrape jobs (`rule_files`, ConfigMap volume mounts, `PrometheusRule` CRs, Helm values, etc.).
 
 | File | Integrate into | Purpose |
 | ---- | -------------- | ------- |
@@ -200,7 +200,7 @@ The `demo/` subdirectory under the same path contains scripts and sample Kuberne
 | File | Purpose |
 | ---- | ------- |
 | `demo/install.sh` / `demo/uninstall.sh` | Demo lab deploy and teardown |
-| `demo/prometheus-federated.yaml` | Sample Federated Prometheus deployment deployment |
+| `demo/prometheus-federated.yaml` | Sample Federated Prometheus deployment |
 | `demo/prometheus-kiali-edge.yaml` | Sample dedicated Kiali edge Prometheus |
 | `demo/render-*.py`, `demo/merge-recording-rules.py` | Render demo manifests from the production reference YAML |
 
@@ -217,9 +217,9 @@ groups:
   interval: 30s
   rules:
   - record: workload:istio_requests_total
-    expr: sum without (pod, instance, namespace, job, node) (istio_requests_total)
+    expr: sum without (pod, pod_template_hash, instance, namespace, job, node) (istio_requests_total)
   - record: workload:istio_request_duration_milliseconds_bucket
-    expr: sum without (pod, instance, namespace, job, node) (istio_request_duration_milliseconds_bucket)
+    expr: sum without (pod, pod_template_hash, instance, namespace, job, node) (istio_request_duration_milliseconds_bucket)
   # ... remaining traffic counters and histogram components — see core-recording-rules.yml
 ```
 
@@ -231,7 +231,7 @@ How you install the rules depends on your platform—for example a `rule_files` 
 
 #### Federation (federated Prometheus)
 
-Add a federation scrape job to your **existing** long-retention federated Prometheus. Use `core-federation-match.yml` for the complete core-tier `match[]` list. Federate `workload:*` traffic metrics from the edge and relabel names before storage:
+Add a federation scrape job to your existing long-retention federated Prometheus. Use `core-federation-match.yml` for the complete core-tier `match[]` list. Federate `workload:*` traffic metrics from the edge and relabel names before storage:
 
 ```yaml
 - job_name: istio-mesh-federate
@@ -254,6 +254,8 @@ Add a federation scrape job to your **existing** long-retention federated Promet
     - '<edge-prometheus-host>:9090'
 ```
 
+Set `honor_labels: true` on every federation scrape job. Without it, Prometheus renames conflicting labels from the federated edge with an `exported_` prefix (for example `destination_workload` becomes `exported_destination_workload`). Kiali queries assume standard Istio label names (`source_*`, `destination_*`, `reporter`, and so on); omitting `honor_labels` can break the traffic graph, health, and metrics tabs even when `match[]` and relabel rules are correct.
+
 Also federate non-traffic metrics that Kiali needs but does not aggregate (for example `istio_build`, `pilot_xds`, `container_cpu_usage_seconds_total`) directly by name—see `core-metrics.yml` and `core-federation-match.yml`.
 
 To include Istio dashboard metrics, append the selectors from `istio-dashboard-federation-match.yml` to `match[]`.
@@ -262,7 +264,7 @@ Configure network access, TLS, and authentication between Federated and Edge Pro
 
 #### Demo walkthrough (lab only)
 
-The `demo/install.sh` script is a **learning and CI harness only**. It does not replace the production integration above—it automates the same reference YAML against the Istio add-on Prometheus in `istio-system` so you can validate the pattern locally:
+The `demo/install.sh` script is a learning and CI harness only. It does not replace the production integration above—it automates the same reference YAML against the Istio add-on Prometheus in `istio-system` so you can validate the pattern locally:
 
 ```bash
 # From a clone of github.com/kiali/kiali, with Istio add-on Prometheus running:
@@ -304,9 +306,9 @@ curl -s 'http://localhost:9092/api/v1/query?query=count(istio_requests_total)'
 curl -s 'http://localhost:9092/api/v1/query?query=count({__name__=~"kiali_.*"})'
 ```
 
-The **Kiali Internal Metrics** dashboard only works when Kiali queries federated Prometheus (`--switch-kiali` or `external_services.prometheus.url` → `prometheus-federated`).
+The Kiali Internal Metrics dashboard only works when Kiali queries federated Prometheus (`--switch-kiali` or `external_services.prometheus.url` → `prometheus-federated`).
 
-See [`hack/istio/metric-rules/README.md`](https://github.com/kiali/kiali/blob/master/hack/istio/metric-rules/README.md) for teardown (`demo/uninstall.sh`).
+Run `demo/uninstall.sh` for teardown.
 
 #### Integration checklist
 
@@ -321,7 +323,7 @@ Use this checklist when integrating the [production reference files](#production
 7. Validate equivalence between edge aggregates and federated data (see below).
 8. Tune intervals using [Interval tuning](#interval-tuning) below.
 
-For **multi-cluster** deployments, federation is typically per mesh cluster (edge → federated for that cluster).
+For multi-cluster deployments, apply the same edge → federated pattern per mesh cluster: each cluster's Edge Prometheus scrapes local Istio/Envoy telemetry, evaluates recording rules, and federates into that cluster's Federated Prometheus (or into a shared central Federated Prometheus, if your organization consolidates metrics that way). Kiali already supports per-cluster Prometheus URLs in [multicluster configuration]({{< ref "/docs/configuration/multi-cluster" >}})—set each cluster's `external_services.prometheus.url` to the Federated Prometheus instance that holds that cluster's federated mesh metrics, not the local Edge scraper.
 
 #### Interval tuning
 
@@ -335,18 +337,18 @@ Several independent intervals affect freshness, CPU use, and the minimum time wi
 | **Metric retention** | Edge Prometheus | `storage.tsdb.retention.time` | How long raw and `workload:*` series are kept before expiry (short, e.g. 6h) |
 | **Metric retention** | Federated Prometheus | `storage.tsdb.retention.time` | Long-term history Kiali and dashboards query (as desired) |
 
-**Rules of thumb:**
+Rules of thumb:
 
 1. Recording rule interval ≥ edge scrape interval.
   -- Rules read raw series; evaluating more often than scrapes complete adds CPU without new data. A practical range is equal to the scrape interval, up to 2× the scrape interval ([Istio guidance](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)).
 2. Federation interval ≥ recording rule interval.
-  -- The Federated Prometheus should federate aggregates after the edge has evaluated them. **30s** is a common federation interval and matches the Kiali reference configuration.
+  -- The Federated Prometheus should federate aggregates after the edge has evaluated them. 30s is a common federation interval and matches the Kiali reference configuration.
 3. Set `scrape_timeout` below `scrape_interval` on the federation job.
   -- (for example `25s` timeout with `30s` interval) so slow federation scrapes do not overlap.
-4. Kiali minimum duration depends on the **effective sampling** of the data it queries (federated Prometheus), not the edge scrape interval.
-  -- With federation, that is roughly **recording rule interval + federation scrape interval**. Kiali needs at least **two samples** in a rate window, so minimum graph duration should be **≥ 2× that effective interval** (see [Scrape Interval](#scrape-interval) below).
+4. Kiali minimum duration depends on the effective sampling of the data it queries (federated Prometheus), not the edge scrape interval.
+  -- With federation, that is roughly recording rule interval + federation scrape interval. Kiali needs at least two samples in a rate window, so minimum graph duration should be ≥ 2× that effective interval (see [Scrape Interval](#scrape-interval) below).
 
-**Recommended settings when edge scrape is 30s:**
+Recommended settings when edge scrape is 30s:
 
 This is a common production default (for example kube-prometheus-stack). The Kiali reference bundle uses these values:
 
@@ -369,7 +371,7 @@ groups:
   interval: 30s          # match 30s scrape_interval
   rules:
   - record: workload:istio_requests_total
-    expr: sum without (pod, instance, namespace, job, node) (istio_requests_total)
+    expr: sum without (pod, pod_template_hash, instance, namespace, job, node) (istio_requests_total)
 ```
 
 ```yaml
@@ -381,9 +383,9 @@ groups:
   # ... match[] and relabel configs
 ```
 
-Expected freshness: mesh traffic visible in Kiali on federated Prometheus is typically on the order of **one to two minutes** behind live traffic (one scrape + one rule evaluation + one federation cycle, plus alignment jitter).
+Expected freshness: mesh traffic visible in Kiali on federated Prometheus is typically on the order of one to two minutes behind live traffic (one scrape + one rule evaluation + one federation cycle, plus alignment jitter).
 
-**Other edge scrape intervals:**
+Other edge scrape intervals:
 
 | Edge scrape | Recording rules | Federation | Effective sampling | Min duration (2×) |
 | ----------- | --------------- | ---------- | ------------------ | ----------------- |
@@ -391,22 +393,22 @@ Expected freshness: mesh traffic visible in Kiali on federated Prometheus is typ
 | `30s` (recommended row above) | `30s` | `30s` | `60s` | `120s` |
 | `1m` | `1m` | `1m` | `2m` | `4m` |
 
-For fresher aggregates at the cost of more edge CPU, use a recording rule interval **equal to** the scrape interval (for example both `15s`). For lower edge CPU, use rule interval **2×** scrape (for example `30s` rules with `15s` scrape, or `60s` rules with `30s` scrape)—accepting additional lag before `workload:*` updates.
+For fresher aggregates at the cost of more edge CPU, use a recording rule interval equal to the scrape interval (for example both `15s`). For lower edge CPU, use rule interval 2× scrape (for example `30s` rules with `15s` scrape, or `60s` rules with `30s` scrape)—accepting additional lag before `workload:*` updates.
 
-Istio’s own examples sometimes use **5s** rule evaluation with **30s** federation for faster edge aggregation; that is reasonable when edge scrape is `15s` and you want sub-minute freshness. It increases rule-evaluation load and is optional—not required for Kiali correctness.
+Istio’s own examples sometimes use 5s rule evaluation with 30s federation for faster edge aggregation; that is reasonable when edge scrape is `15s` and you want sub-minute freshness. It increases rule-evaluation load and is optional—not required for Kiali correctness.
 
-**Kiali duration dropdown:**
+Kiali duration dropdown:
 
-Today Kiali reads `globalScrapeInterval` from the Prometheus URL in `external_services.prometheus.url` (production) and filters durations with **`≥ 2 × globalScrapeInterval`**. When using federation:
+Today Kiali reads `globalScrapeInterval` from the Prometheus URL in `external_services.prometheus.url` (production) and filters durations with `≥ 2 × globalScrapeInterval`. When using federation:
 
-- Ensure federated Prometheus **`global.scrape_interval`** (or the value exposed in `/api/v1/status/config`) reflects the federation job interval if that is the coarsest sampling Kiali sees, **OR**
-- Plan for a future **`metric_aggregation_interval`** setting (see the [metric rules KEP](https://github.com/kiali/kiali/blob/master/design/KEPS/metric-rules/proposal.md)) to set the minimum duration floor explicitly to (rule interval + federation interval).
+- Ensure federated Prometheus `global.scrape_interval` (or the value exposed in `/api/v1/status/config`) reflects the federation job interval if that is the coarsest sampling Kiali sees, OR
+- Plan for a future `metric_aggregation_interval` setting (see the [metric rules KEP](https://github.com/kiali/kiali/blob/master/design/KEPS/metric-rules/proposal.md)) to set the minimum duration floor explicitly to (rule interval + federation interval).
 
 Until `metric_aggregation_interval` is available, if production `global.scrape_interval` is `1m` but federation runs every `30s`, Kiali may offer durations that are shorter than ideal for federated traffic metrics. Operators can rely on slightly longer graph durations (for example `2m` or `5m`) for rate-based views when in doubt.
 
 #### Kiali self-monitoring metrics
 
-Kiali can export its own Prometheus metrics (`kiali_*`) for performance and optional health-status monitoring. These are **not** Istio mesh metrics—they are not produced on the edge by Envoy, not listed in `core-metrics.yml`, and not part of the Istio federation tiers.
+Kiali can export its own Prometheus metrics (`kiali_*`) for performance and optional health-status monitoring. These are not Istio mesh metrics—they are not produced on the edge by Envoy, not listed in `core-metrics.yml`, and not part of the Istio federation tiers.
 
 Because Kiali queries federated Prometheus, `kiali_*` series must ultimately be available in that same TSDB. The [metric rules KEP](https://github.com/kiali/kiali/blob/master/design/KEPS/metric-rules/proposal.md#kiali-self-monitoring-metrics) describes three deployment options:
 
@@ -423,11 +425,11 @@ Because Kiali queries federated Prometheus, `kiali_*` series must ultimately be 
 | `server.observability.metrics.health_status.enabled` | `false` | `kiali_health_status` gauge per entity (opt-in; higher cardinality) |
 
 
-The metrics HTTP listener (port `server.observability.metrics.port`, default `9090`) starts when **either** flag is true.
+The metrics HTTP listener (port `server.observability.metrics.port`, default `9090`) starts when either flag is true.
 
-**`kiali_health_status` and HA:** Multiple Kiali replicas export the **same** gauge values for the same entities (duplicate series, not partition-of-work). With Options 1 or 2, use `max without (pod, instance, …)` in recording rules to deduplicate—not `sum`. With Option 3, apply the same dedup in alert/dashboard queries (for example `max by (cluster, namespace, health_type, name) (kiali_health_status)`), because raw scrape retains per-replica copies.
+`kiali_health_status` and HA: Multiple Kiali replicas export the same gauge values for the same entities (duplicate series, not partition-of-work). With Options 1 or 2, use `max without (pod, instance, …)` in recording rules to deduplicate—not `sum`. With Option 3, apply the same dedup in alert/dashboard queries (for example `max by (cluster, namespace, health_type, name) (kiali_health_status)`), because raw scrape retains per-replica copies.
 
-The built-in **Kiali Internal Metrics** custom dashboard queries `external_services.prometheus.url`; it only works when federated Prometheus holds the `kiali_*` series (via federation or direct scrape).
+The built-in Kiali Internal Metrics custom dashboard queries `external_services.prometheus.url`; it only works when federated Prometheus holds the `kiali_*` series (via federation or direct scrape).
 
 Reference files for Options 1–2: `kiali-metrics-recording-rules.yml`, `kiali-metrics-federation-match.yml`, and (for Option 2) `demo/prometheus-kiali-edge.yaml`. Try them in the [demo walkthrough](#demo-walkthrough-lab-only) with `--with-kiali-metrics` and optionally `--kiali-edge dedicated`.
 
@@ -457,7 +459,7 @@ The `workload:*` count should be substantially lower when workloads have been as
 
 ### Option 2: Metric Thinning
 
-If the Federation option is not possible and you are limited to a single TSDB intance, this may be helpful.
+If the Federation option is not possible and you are limited to a single TSDB instance, this may be helpful.
 
 To reduce the default telemetry to only what is needed by Kiali[^1] users can add the following snippet to their Prometheus configuration. Because things can change with different versions, it is recommended to ensure you use the correct version of this documentation based on your Kiali/Istio version.
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -117,15 +117,13 @@ Istio and Envoy generate a large amount of telemetry for analysis and troublesho
 
 For production meshes at scale, [metric thinning](#option-2-metric-thinning) on a single Prometheus TSDB reduces storage somewhat but still retains per-proxy Istio series. A more efficient approach—aligned with [Istio Observability Best Practices](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)—is to:
 
-1. **Aggregate at the edge** using Prometheus recording rules that "sum away" per-proxy labels (`pod`, `instance`, etc.) into `workload:*` series. "Sum away" is a recording rule term that means that several time-series will be aggregated into one, by combining those with like values for specified fields. The resulting value is the sum of the individual time-series values.
-2. **Federate** only those aggregates (plus a small set of control-plane metrics) into your long-retention production Prometheus.
-3. **Relabel** `workload:istio_requests_total` back to `istio_requests_total` on the production instance so Kiali queries standard metric names.
+1. **Aggregate** using a short-lived "edge" Prometheus. Scrape your raw metrics and then use recording rules that "sum away" per-proxy labels (`pod`, `instance`, etc.) into `workload:*` series.
+    - "Sum away" means that several time-series will be aggregated into one, by combining those with like values for specified fields. The resulting value is the sum of the individual time-series values.
+2. **Federate** using a long-lived "production" Prometheus. Use Prometheus federation to pull the edge aggregates (plus required non-aggregated metrics) into your production Prometheus.
+    - Federating will relabel the `workload:*` aggregates back to standard metric names (e.g. `workload:istio_requests_total` back to `istio_requests_total`) on the production instance so Kiali queries standard metric names.
 
 Kiali already aggregates traffic at workload/service granularity in its PromQL; it does not use per-pod Istio labels. Pre-aggregated counters and histograms are therefore compatible with the traffic graph, health monitoring, and metrics tabs.
 
-{{% alert color="info" %}}
-This pattern uses **two Prometheus roles** (edge and production). They are often in different namespaces or clusters in real deployments. The Kiali repository includes a **demo lab harness** that co-locates both in `istio-system` for learning and CI—it is not a production installer.
-{{% /alert %}}
 
 #### Architecture
 
@@ -139,9 +137,13 @@ This pattern uses **two Prometheus roles** (edge and production). They are often
         └───────────────────────────────────────────┘
 ```
 
-**Edge Prometheus** is whichever instance scrapes Istio mesh telemetry (often *not* the same as your platform monitoring stack). It evaluates recording rules and keeps a **short retention** (for example 6 hours) on raw and aggregated series.
+**Edge Prometheus** is whichever instance scrapes Istio mesh telemetry (often *not* the same as your platform monitoring stack). It evaluates recording rules and keeps a short retention (for example 6 hours) on raw and aggregated series.
 
-**Production Prometheus** is the TSDB Kiali should query. It federates selected series from the edge, relabels `workload:*` back to `istio_*`, and holds **long retention**. Configure Kiali accordingly:
+**Production Prometheus** is the TSDB Kiali should query. It federates selected series from the edge, relabels `workload:*` back to `istio_*`, and holds long retention. Configure Kiali accordingly:
+
+{{% alert color="info" %}}
+The two Prometheus instances are often in different namespaces or clusters in real deployments. The Kiali repository includes a **demo lab harness** that co-locates both in `istio-system` for learning and CI—it is not a production installer.
+{{% /alert %}}
 
 ```yaml
 spec:
@@ -154,7 +156,7 @@ spec:
 If you use Istio [Perses (or Grafana) dashboards]({{< relref "./perses" >}}) with Kiali , configure them to point at the same production Prometheus URL.
 
 {{% alert color="warning" %}}
-**Production assumption:** In this pattern, `external_services.prometheus.url` **always** targets production Prometheus—the long-retention TSDB that holds federated mesh metrics. Kiali must **not** query the edge Istio scraper in production. The edge exists only to collect raw telemetry, evaluate recording rules, and federate upstream; it is not Kiali's database.
+**Production assumption:** In this pattern, `external_services.prometheus.url` **always** targets production Prometheus—the long-retention TSDB that holds federated mesh metrics. The edge exists only to collect raw telemetry, evaluate recording rules, and federate upstream; it is not Kiali's database.
 
 `kiali_*` self-monitoring metrics must also end up in that production TSDB, but may reach it via edge aggregation and federation or via direct scrape—see [Kiali self-monitoring metrics](#kiali-self-monitoring-metrics).
 {{% /alert %}}
@@ -168,9 +170,10 @@ Federation configuration is split into tiers (metric groupings) so that the prod
 | **Core** | [Kiali required metrics]({{< ref "/docs/faq/general#requiredmetrics" >}}) | Traffic graph, health, lists, mesh overview |
 | **Istio Dashboards** | Optional control-plane, perf, ztunnel, and WASM metrics | [Perses Istio dashboards](https://github.com/perses/community-mixins/tree/main/examples/dashboards/perses/istio) |
 | **Kiali self-monitoring** | Kiali operational metrics (`kiali_*`) | Kiali Internal Metrics dashboard, optional health-status alerting |
+
 &nbsp;
 
-Some Perses dashboards work with the **core** tier alone (Mesh, service, and workload dashboards). To ensure all of the Istio dashboards are supported, Enable the **Istio Dashboards** tier. Enable **Kiali self-monitoring** when the built-in Kiali metrics dashboard or `kiali_health_status` alerting is needed. Note that if you define your own **Kiali  Custom Dashboards**, you will need to ensure any required metrics are also configured for the production Prometheus.
+Some Perses dashboards work with the **Core** tier alone (Mesh, service, and workload dashboards). To ensure all of the Istio dashboards are supported, Enable the **Istio Dashboards** tier. Enable **Kiali self-monitoring** when the built-in Kiali metrics dashboard or `kiali_health_status` alerting is needed. Note that if you define your own Kiali Custom Dashboards, you will need to ensure any required metrics are also configured for the production Prometheus.
 
 Reference files live in the Kiali repository under [`hack/istio/metric-rules/`](https://github.com/kiali/kiali/tree/master/hack/istio/metric-rules):
 
@@ -184,6 +187,7 @@ Reference files live in the Kiali repository under [`hack/istio/metric-rules/`](
 | `kiali-export-metrics.yml` | Canonical Kiali self-monitoring metric list |
 | `federation-match-kiali.yml` | Federation `match[]` selectors for `kiali:*` series |
 | `prometheus-kiali-edge.yaml` | Example dedicated Kiali edge Prometheus (Option 2) |
+
 &nbsp;
 
 #### Recording rules (edge Prometheus)
@@ -235,9 +239,9 @@ Add a federation scrape job to your existing long-retention Prometheus. Federate
 
 Also federate non-traffic metrics that Kiali needs but does not aggregate (for example `istio_build`, `pilot_xds`, `container_cpu_usage_seconds_total`) directly by name—see `kiali-required-metrics.yml` and `prometheus-prod.yaml`.
 
-To include Perses dashboard metrics, append the selectors from `federation-match-dashboards.yml` to `match[]`.
+To include Istio dashboard metrics, append the selectors from `federation-match-dashboards.yml` to `match[]`.
 
-Configure **network access**, **TLS**, and **authentication** between production and edge Prometheus according to your environment. Kiali authentication for the production URL is configured separately (see [Prometheus authentication configuration](#prometheus-authentication-configuration) below).
+Configure network access, TLS, and authentication between production and edge Prometheus according to your environment. Kiali authentication for the production URL is configured separately (see [Prometheus authentication configuration](#prometheus-authentication-configuration) below).
 
 #### Demo walkthrough (lab only)
 
@@ -294,23 +298,25 @@ See [`hack/istio/metric-rules/README.md`](https://github.com/kiali/kiali/blob/ma
 3. Add a federation scrape job to your production Prometheus using the core-tier `match[]` list.
 4. Optionally extend `match[]` with Istio dashboard-tier selectors if Istio dashboards are enabled.
 5. If Kiali self-monitoring is enabled, choose an option from [Kiali self-monitoring metrics](#kiali-self-monitoring-metrics): apply `kiali-recording-rules.yml` on the Kiali edge and federate `federation-match-kiali.yml` to production (Options 1–2), or scrape Kiali directly into production (Option 3).
-6. Point **`external_services.prometheus.url`** at production Prometheus (and Perses at the same URL).
+6. Point `external_services.prometheus.url` at production Prometheus (and the same URL for Perses/Grafana, if using).
 7. **Validate** equivalence between edge aggregates and federated data (see below).
 8. Tune intervals using [Interval tuning](#interval-tuning) below.
 
-For **multi-cluster** deployments, federation is typically per mesh cluster (edge → production for that cluster). Kiali already supports per-cluster Prometheus URLs in multicluster configuration.
+For **multi-cluster** deployments, federation is typically per mesh cluster (edge → production for that cluster).
 
 #### Interval tuning
 
 Several independent intervals affect freshness, CPU use, and the minimum time windows Kiali can use for `rate()` queries. Set them together—not in isolation.
 
-| Setting | Where configured | Role |
-| ------- | ---------------- | ---- |
-| **Edge scrape interval** | Edge Prometheus `global.scrape_interval` (or per-job override on Istio/Envoy targets) | How often raw `istio_*` counters are collected from proxies |
-| **Recording rule interval** | `interval` on the rule group in `recording-rules.yml` | How often `workload:*` aggregates are recomputed on the edge |
-| **Federation scrape interval** | `scrape_interval` on the production federation job | How often production Prometheus pulls `workload:*` (and other federated series) from the edge |
-| **Edge retention** | Edge Prometheus `storage.tsdb.retention.time` | How long raw and `workload:*` series are kept before expiry (short, e.g. 6h) |
-| **Production retention** | Production Prometheus retention | Long-term history Kiali and dashboards query |
+| What is configured | Where configured | Setting | Role |
+| ------- | ---------------- | ---- | ---- |
+| **Metric Scrape interval** | Edge Prometheus | `global.scrape_interval` (or per-job override on Istio/Envoy targets) | How often raw `istio_*` metrics are scraped |
+| **Recording rule interval** | Edge Prometheus | `interval` on the rule group in `recording-rules.yml` | How often `workload:*` aggregates are recomputed |
+| **Federation interval** | Production Prometheus | `scrape_interval` on the production federation job | How often Prometheus pulls `workload:*` (and other federated series) from the edge |
+| **Metric retention** | Edge Prometheus | `storage.tsdb.retention.time` | How long raw and `workload:*` series are kept before expiry (short, e.g. 6h) |
+| **Metric retention** | Production Prometheus | `storage.tsdb.retention.time` | Long-term history Kiali and dashboards query (as desired) |
+
+&nbsp;
 
 **Rules of thumb**
 
@@ -332,6 +338,8 @@ This is a common production default (for example kube-prometheus-stack). The Kia
 | Edge retention | `6h` | Enough for troubleshooting; raw series expire after federation |
 | Effective sampling (Kiali) | `~60s` | Rule interval + federation interval |
 | Practical minimum Kiali duration | `≥ 2m` (`120s`) | `2 × 60s`; Kiali may round up in the duration dropdown |
+
+&nbsp;
 
 Example edge rule group header and production federation job:
 
@@ -364,6 +372,8 @@ groups:
 | `30s` (recommended row above) | `30s` | `30s` | `60s` | `120s` |
 | `1m` | `1m` | `1m` | `2m` | `4m` |
 
+&nbsp;
+
 For **fresher** aggregates at the cost of more edge CPU, use a recording rule interval **equal to** the scrape interval (for example both `15s`). For **lower** edge CPU, use rule interval **2×** scrape (for example `30s` rules with `15s` scrape, or `60s` rules with `30s` scrape)—accepting additional lag before `workload:*` updates.
 
 Istio’s own examples sometimes use **5s** rule evaluation with **30s** federation for faster edge aggregation; that is reasonable when edge scrape is `15s` and you want sub-minute freshness. It increases rule-evaluation load and is optional—not required for Kiali correctness.
@@ -389,10 +399,14 @@ Because Kiali queries **production** Prometheus, `kiali_*` series must ultimatel
 | **2. Dedicated Kiali edge** | Separate edge Prom for Kiali only | Recording rules + federation to prod |
 | **3. Direct to production** | Production Prom directly | Raw scrape; dedup required in queries for HA |
 
+&nbsp;
+
 | Config | Default | Purpose |
 | ------ | ------- | ------- |
 | `server.observability.metrics.enabled` | `true` | Operational metrics (API, graph, cache, validation, etc.) |
 | `server.observability.metrics.health_status.enabled` | `false` | `kiali_health_status` gauge per entity (opt-in; higher cardinality) |
+
+&nbsp;
 
 The metrics HTTP listener (port `server.observability.metrics.port`, default `9090`) starts when **either** flag is true.
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -170,7 +170,7 @@ Federation configuration is split into tiers (metric groupings) so that the prod
 | **Kiali self-monitoring** | Kiali operational metrics (`kiali_*`) | Kiali Internal Metrics dashboard, optional health-status alerting |
 &nbsp;
 
-Mesh, service, and workload Perses dashboards work on the **core** tier alone. Enable the **Dashboards** tier only when using those detailed dashboards. Enable **Kiali self-monitoring** when the built-in Kiali metrics dashboard or `kiali_health_status` alerting is needed.
+Some Perses dashboards work with the **core** tier alone (Mesh, service, and workload dashboards). To ensure all of the Istio dashboards are supported, Enable the **Istio Dashboards** tier. Enable **Kiali self-monitoring** when the built-in Kiali metrics dashboard or `kiali_health_status` alerting is needed. Note that if you define your own **Kiali  Custom Dashboards**, you will need to ensure any required metrics are also configured for the production Prometheus.
 
 Reference files live in the Kiali repository under [`hack/istio/metric-rules/`](https://github.com/kiali/kiali/tree/master/hack/istio/metric-rules):
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -203,7 +203,7 @@ groups:
 ```
 
 {{% alert color="warning" %}}
-Record **counter snapshots**, not `rate()`. Kiali applies `rate()` at query time with user-selected durations. Use `sum without (...)` rather than `sum by (...)` so required labels are not dropped accidentally.
+The recording rules do not apply `rate()`. Kiali applies `rate()` at query time with user-selected durations. Use `sum without (...)` rather than `sum by (...)` so required labels are not dropped accidentally.
 {{% /alert %}}
 
 How you install the rules depends on your platform—for example a `rule_files` entry in `prometheus.yml`, a ConfigMap volume mount, or a Prometheus Operator `PrometheusRule` CR in the namespace where edge Prometheus runs.

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -117,7 +117,7 @@ Istio and Envoy generate a large amount of telemetry for analysis and troublesho
 
 For production meshes at scale, [metric thinning](#option-2-metric-thinning) on a single Prometheus TSDB reduces storage somewhat but still retains per-proxy Istio series. A more efficient approach—aligned with [Istio Observability Best Practices](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)—is to:
 
-1. **Aggregate at the edge** using Prometheus recording rules that sum away per-proxy labels (`pod`, `instance`, etc.) into `workload:*` series.
+1. **Aggregate at the edge** using Prometheus recording rules that "sum away" per-proxy labels (`pod`, `instance`, etc.) into `workload:*` series. "Sum away" is a recording rule term that means that several time-series will be aggregated into one, by combining those with like values for specified fields. The resulting value is the sum of the individual time-series values. Because Kiali presents information at the workload level, not the pod level, aggregation offers a significant reduction in time-series cardinality.
 2. **Federate** only those aggregates (plus a small set of control-plane metrics) into your long-retention production Prometheus.
 3. **Relabel** `workload:istio_requests_total` back to `istio_requests_total` on the production instance so Kiali queries standard metric names.
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -339,28 +339,25 @@ Several independent intervals affect freshness, CPU use, and the minimum time wi
 
 Rules of thumb:
 
-1. Recording rule interval ≥ edge scrape interval.
-  -- Rules read raw series; evaluating more often than scrapes complete adds CPU without new data. A practical range is equal to the scrape interval, up to 2× the scrape interval ([Istio guidance](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics)).
-2. Federation interval ≥ recording rule interval.
-  -- The Federated Prometheus should federate aggregates after the edge has evaluated them. 30s is a common federation interval and matches the Kiali reference configuration.
-3. Set `scrape_timeout` below `scrape_interval` on the federation job.
+1. Set all three intervals equal: edge scrape = recording rule = federation scrape.
+  -- The recommended default is 30s/30s/30s. This is straightforward, efficient, and correct for Kiali. Evaluating rules faster than the scrape interval wastes CPU (re-sums unchanged data). Evaluating slower means `workload:*` updates lag behind available raw data. Federation at the same rate ensures each federation scrape captures a freshly evaluated aggregate.
+2. Set `scrape_timeout` below `scrape_interval` on the federation job.
   -- (for example `25s` timeout with `30s` interval) so slow federation scrapes do not overlap.
-4. Kiali minimum duration depends on the effective sampling of the data it queries (federated Prometheus), not the edge scrape interval.
-  -- With federation, that is roughly recording rule interval + federation scrape interval. Kiali needs at least two samples in a rate window, so minimum graph duration should be ≥ 2× that effective interval (see [Scrape Interval](#scrape-interval) below).
+3. Kiali minimum duration depends on the federation scrape interval alone.
+  -- Each federation scrape produces one data point in the federated TSDB. Prometheus `rate()` requires at least two data points in the range window, so the minimum useful Kiali duration is `2 × federation_scrape_interval`. With 30s federation, that is 60s (1m) — matching Kiali's smallest offered duration.
 
-Recommended settings when edge scrape is 30s:
+Recommended settings — 30s/30s/30s:
 
 This is a common production default (for example kube-prometheus-stack). The Kiali reference bundle uses these values:
 
 | Setting | Recommended value | Notes |
 | ------- | ----------------- | ----- |
-| Edge `scrape_interval` | `30s` | Your stated baseline |
-| Recording rule `interval` | `30s` | Matches scrape; good balance of freshness and CPU |
-| Federation `scrape_interval` | `30s` | Istio-recommended; used in `demo/prometheus-federated.yaml` |
+| Edge `scrape_interval` | `30s` | Common production baseline |
+| Recording rule `interval` | `30s` | Matches scrape; one eval per scrape cycle |
+| Federation `scrape_interval` | `30s` | Determines Kiali's sampling rate |
 | Federation `scrape_timeout` | `25s` | Slightly less than scrape interval |
 | Edge retention | `6h` | Enough for troubleshooting; raw series expire after federation |
-| Effective sampling (Kiali) | `~60s` | Rule interval + federation interval |
-| Practical minimum Kiali duration | `≥ 2m` (`120s`) | `2 × 60s`; Kiali may round up in the duration dropdown |
+| Minimum Kiali duration | `1m` (`60s`) | `2 × 30s` federation; Kiali's smallest dropdown value |
 
 Example edge rule group header and federated Prometheus federation job:
 
@@ -383,28 +380,23 @@ groups:
   # ... match[] and relabel configs
 ```
 
-Expected freshness: mesh traffic visible in Kiali on federated Prometheus is typically on the order of one to two minutes behind live traffic (one scrape + one rule evaluation + one federation cycle, plus alignment jitter).
+Expected freshness: with 30s/30s/30s, the three intervals run on independent, unsynchronized clocks. Worst-case staleness of the most recent data point is ~90s (three consecutive 30s waits); average staleness is ~45s. This staleness applies to each counter snapshot. Rate accuracy between consecutive federation data points is unaffected — `rate()` computes the slope between correctly ordered samples regardless of their absolute delay from live traffic.
 
-Other edge scrape intervals:
+When to use different intervals:
 
-| Edge scrape | Recording rules | Federation | Effective sampling | Min duration (2×) |
-| ----------- | --------------- | ---------- | ------------------ | ----------------- |
-| `15s` (Istio add-on demo) | `15s`–`30s` | `30s` | `45s`–`60s` | `90s`–`120s` |
-| `30s` (recommended row above) | `30s` | `30s` | `60s` | `120s` |
-| `1m` | `1m` | `1m` | `2m` | `4m` |
+| Edge scrape | Recording rules | Federation | Min Kiali duration | When to use |
+| ----------- | --------------- | ---------- | ------------------ | ----------- |
+| `15s` | `15s` | `30s` | `60s` (1m) | Edge also serves alerting or direct queries needing fine granularity. Doubles scrape load vs 30s; no Kiali benefit via federation. |
+| `30s` (recommended) | `30s` | `30s` | `60s` (1m) | Default. Efficient, straightforward. |
+| `1m` | `1m` | `1m` | `2m` | Very large clusters where reducing scrape load outweighs freshness. |
 
-For fresher aggregates at the cost of more edge CPU, use a recording rule interval equal to the scrape interval (for example both `15s`). For lower edge CPU, use rule interval 2× scrape (for example `30s` rules with `15s` scrape, or `60s` rules with `30s` scrape)—accepting additional lag before `workload:*` updates.
-
-Istio’s own examples sometimes use 5s rule evaluation with 30s federation for faster edge aggregation; that is reasonable when edge scrape is `15s` and you want sub-minute freshness. It increases rule-evaluation load and is optional—not required for Kiali correctness.
+Istio's own examples use `interval: 5s` for recording rules with a 15s scrape. That configuration was designed for their quick-start addon where the same Prometheus serves direct queries; faster rule eval keeps `workload:*` fresh for local consumers. In a federation architecture where no one queries the edge directly, this benefit disappears and the extra CPU is wasted.
 
 Kiali duration dropdown:
 
-Today Kiali reads `globalScrapeInterval` from the Prometheus URL in `external_services.prometheus.url` (production) and filters durations with `≥ 2 × globalScrapeInterval`. When using federation:
+Kiali reads `globalScrapeInterval` from the Prometheus at `external_services.prometheus.url` and filters durations to `>= 2 x globalScrapeInterval`. With federation, Kiali queries the federated Prometheus. If the federated Prometheus `global.scrape_interval` is set to `30s` (matching the federation job interval), Kiali auto-detects the correct minimum duration of 60s (1m) and no additional configuration is needed.
 
-- Ensure federated Prometheus `global.scrape_interval` (or the value exposed in `/api/v1/status/config`) reflects the federation job interval if that is the coarsest sampling Kiali sees, OR
-- Plan for a future `metric_aggregation_interval` setting (see the [metric rules KEP](https://github.com/kiali/kiali/blob/master/design/KEPS/metric-rules/proposal.md)) to set the minimum duration floor explicitly to (rule interval + federation interval).
-
-Until `metric_aggregation_interval` is available, if production `global.scrape_interval` is `1m` but federation runs every `30s`, Kiali may offer durations that are shorter than ideal for federated traffic metrics. Operators can rely on slightly longer graph durations (for example `2m` or `5m`) for rate-based views when in doubt.
+If the federated Prometheus `global.scrape_interval` differs from the federation job interval (for example `global.scrape_interval: 15s` but the federation job runs every `30s`), Kiali may offer durations shorter than the federation sampling supports. Ensure the federated Prometheus `global.scrape_interval` matches or exceeds the federation job's `scrape_interval`.
 
 #### Kiali self-monitoring metrics
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -153,6 +153,12 @@ spec:
 
 If you use [Kiali Perses dashboards]({{< relref "./perses" >}}), point Perses at the same production Prometheus URL.
 
+{{% alert color="warning" %}}
+**Production assumption:** In this pattern, `external_services.prometheus.url` **always** targets production Prometheus—the long-retention TSDB that holds federated mesh metrics. Kiali must **not** query the edge Istio scraper in production. The edge exists only to collect raw telemetry, evaluate recording rules, and federate upstream; it is not Kiali's database.
+
+`kiali_*` self-monitoring metrics must also end up in that production TSDB, but may reach it via edge aggregation and federation or via direct scrape—see [Kiali self-monitoring metrics](#kiali-self-monitoring-metrics).
+{{% /alert %}}
+
 #### Metric tiers
 
 Federation configuration is split so operators only pull what they need:
@@ -161,18 +167,23 @@ Federation configuration is split so operators only pull what they need:
 | ---- | ------- | ------------ |
 | **Core** | [Kiali required metrics]({{< ref "/docs/faq/general#requiredmetrics" >}}) | Traffic graph, health, lists, mesh overview |
 | **Dashboards** | Optional control-plane, perf, ztunnel, and WASM metrics | [Perses Istio dashboards](https://github.com/perses/community-mixins/tree/main/examples/dashboards/perses/istio) |
+| **Kiali self-monitoring** | Kiali operational metrics (`kiali_*`) | Kiali Internal Metrics dashboard, optional health-status alerting |
 &nbsp;
 
-Mesh, service, and workload Perses dashboards work on the **core** tier alone. Enable the **Dashboards** tier only when using those detailed dashboards.
+Mesh, service, and workload Perses dashboards work on the **core** tier alone. Enable the **Dashboards** tier only when using those detailed dashboards. Enable **Kiali self-monitoring** when the built-in Kiali metrics dashboard or `kiali_health_status` alerting is needed.
 
-Reference files for both tiers live in the Kiali repository under [`hack/istio/metric-rules/`](https://github.com/kiali/kiali/tree/master/hack/istio/metric-rules):
+Reference files live in the Kiali repository under [`hack/istio/metric-rules/`](https://github.com/kiali/kiali/tree/master/hack/istio/metric-rules):
 
 | File | Description |
 | ---- | ----------- |
 | `recording-rules.yml` | Edge recording rules producing `workload:*` series |
-| `kiali-required-metrics.yml` | Canonical core metric list |
+| `kiali-required-metrics.yml` | Canonical core Istio metric list |
 | `federation-match-dashboards.yml` | Optional federation `match[]` selectors for Perses dashboards |
 | `prometheus-prod.yaml` | Example production federation scrape job (core tier) |
+| `kiali-recording-rules.yml` | Edge recording rules for Kiali metrics (`kiali:*` series) |
+| `kiali-export-metrics.yml` | Canonical Kiali self-monitoring metric list |
+| `federation-match-kiali.yml` | Federation `match[]` selectors for `kiali:*` series |
+| `prometheus-kiali-edge.yaml` | Example dedicated Kiali edge Prometheus (Option 2) |
 &nbsp;
 
 #### Recording rules (edge Prometheus)
@@ -239,11 +250,42 @@ The Kiali repository provides a demo script that patches the Istio add-on Promet
 # Optional: also federate Perses dashboard metrics
 ./hack/istio/metric-rules/install.sh --with-dashboards
 
+# Optional: federate Kiali self-monitoring (shared Istio edge Prometheus)
+./hack/istio/metric-rules/install.sh --with-kiali-metrics
+
+# Optional: federate Kiali self-monitoring (dedicated Kiali edge Prometheus)
+./hack/istio/metric-rules/install.sh --with-kiali-metrics --kiali-edge dedicated
+
 # Optional: point Kiali at the demo production Prometheus
 ./hack/istio/metric-rules/install.sh --switch-kiali
+
+# Combine flags as needed, for example:
+./hack/istio/metric-rules/install.sh --with-dashboards --with-kiali-metrics --switch-kiali
 ```
 
-See [`hack/istio/metric-rules/README.md`](https://github.com/kiali/kiali/blob/master/hack/istio/metric-rules/README.md) for verification queries and teardown (`uninstall.sh`).
+After install, port-forward and verify:
+
+```bash
+# Istio edge Prometheus (recording rules)
+kubectl port-forward -n istio-system svc/prometheus 9091:9090
+
+# Demo production Prometheus (federated data; point Kiali here)
+kubectl port-forward -n istio-system svc/prometheus-prod 9092:9090
+
+# Dedicated Kiali edge (only with --kiali-edge dedicated)
+kubectl port-forward -n istio-system svc/prometheus-kiali-edge 9093:9090
+
+# Edge: workload:* aggregates
+curl -s 'http://localhost:9091/api/v1/query?query=count(workload:istio_requests_total)'
+
+# Production: istio_* and kiali_* (no workload: or kiali: prefix)
+curl -s 'http://localhost:9092/api/v1/query?query=count(istio_requests_total)'
+curl -s 'http://localhost:9092/api/v1/query?query=count({__name__=~"kiali_.*"})'
+```
+
+The **Kiali Internal Metrics** dashboard only works when Kiali queries production Prometheus (`--switch-kiali` or `external_services.prometheus.url` → `prometheus-prod`).
+
+See [`hack/istio/metric-rules/README.md`](https://github.com/kiali/kiali/blob/master/hack/istio/metric-rules/README.md) for teardown (`uninstall.sh`).
 
 #### Production checklist
 
@@ -251,9 +293,10 @@ See [`hack/istio/metric-rules/README.md`](https://github.com/kiali/kiali/blob/ma
 2. Install **recording rules** on the edge; set **short retention** on raw mesh telemetry.
 3. Add a **federation scrape job** to your existing **production** Prometheus using the core-tier `match[]` list.
 4. Optionally extend `match[]` with **dashboard-tier** selectors if Perses Istio dashboards are enabled.
-5. Point **`external_services.prometheus.url`** at production Prometheus (and Perses at the same URL).
-6. **Validate** equivalence between edge aggregates and federated data (see below).
-7. Tune intervals using [Interval tuning](#interval-tuning) below.
+5. If Kiali self-monitoring is enabled, choose an option from [Kiali self-monitoring metrics](#kiali-self-monitoring-metrics): apply `kiali-recording-rules.yml` on the Kiali edge and federate `federation-match-kiali.yml` to production (Options 1–2), or scrape Kiali directly into production (Option 3).
+6. Point **`external_services.prometheus.url`** at production Prometheus (and Perses at the same URL).
+7. **Validate** equivalence between edge aggregates and federated data (see below).
+8. Tune intervals using [Interval tuning](#interval-tuning) below.
 
 For **multi-cluster** deployments, federation is typically per mesh cluster (edge → production for that cluster). Kiali already supports per-cluster Prometheus URLs in multicluster configuration.
 
@@ -333,6 +376,33 @@ Today Kiali reads `globalScrapeInterval` from the Prometheus URL in `external_se
 - Plan for a future **`metric_aggregation_interval`** setting (see the [metric rules KEP](https://github.com/kiali/kiali/blob/master/design/KEPS/metric-rules/proposal.md)) to set the minimum duration floor explicitly to **rule interval + federation interval**.
 
 Until `metric_aggregation_interval` is available, if production `global.scrape_interval` is `1m` but federation runs every `30s`, Kiali may offer durations that are shorter than ideal for federated traffic metrics. Operators can rely on slightly longer graph durations (for example `2m` or `5m`) for rate-based views when in doubt.
+
+#### Kiali self-monitoring metrics
+
+Kiali can export its own Prometheus metrics (`kiali_*`) for performance and optional health-status monitoring. These are **not** Istio mesh metrics—they are not produced on the edge by Envoy, not listed in `kiali-required-metrics.yml`, and not part of the Istio federation tiers.
+
+Because Kiali queries **production** Prometheus, `kiali_*` series must ultimately be available in that same TSDB. The [metric rules KEP](https://github.com/kiali/kiali/blob/master/design/KEPS/metric-rules/proposal.md#kiali-self-monitoring-metrics) describes **three deployment options**:
+
+| Option | Kiali metrics scraped by | Before production |
+| ------ | ------------------------ | ----------------- |
+| **1. Shared Istio edge** | Same edge Prom as Istio/Envoy | Recording rules + federation (parallel to `workload:*`) |
+| **2. Dedicated Kiali edge** | Separate edge Prom for Kiali only | Recording rules + federation to prod |
+| **3. Direct to production** | Production Prom directly | Raw scrape; dedup required in queries for HA |
+
+| Config | Default | Purpose |
+| ------ | ------- | ------- |
+| `server.observability.metrics.enabled` | `true` | Operational metrics (API, graph, cache, validation, etc.) |
+| `server.observability.metrics.health_status.enabled` | `false` | `kiali_health_status` gauge per entity (opt-in; higher cardinality) |
+
+The metrics HTTP listener (port `server.observability.metrics.port`, default `9090`) starts when **either** flag is true.
+
+**`kiali_health_status` and HA:** Multiple Kiali replicas export the **same** gauge values for the same entities (duplicate series, not partition-of-work). With Options 1 or 2, use `max without (pod, instance, …)` in recording rules to deduplicate—not `sum`. With Option 3, apply the same dedup in alert/dashboard queries (for example `max by (cluster, namespace, health_type, name) (kiali_health_status)`), because raw scrape retains per-replica copies.
+
+The built-in **Kiali Internal Metrics** custom dashboard queries `external_services.prometheus.url`; it only works when production Prometheus holds the `kiali_*` series (via federation or direct scrape).
+
+Reference files for Options 1–2: `kiali-recording-rules.yml`, `federation-match-kiali.yml`, and (for Option 2) `prometheus-kiali-edge.yaml`. Try them in the [demo walkthrough](#demo-walkthrough-lab-only) with `--with-kiali-metrics` and optionally `--kiali-edge dedicated`.
+
+For `kiali_health_status` alerting on OpenShift, see the [OSSM health status alerts tutorial]({{< relref "../../Tutorials/ossm-multicluster/ossm-health-status-alerts" >}}).
 
 #### Validation
 

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -188,7 +188,7 @@ Reference files live in the Kiali repository under [`hack/istio/metric-rules/`](
 
 #### Recording rules (edge Prometheus)
 
-Add rules like the following to the Prometheus instance that scrapes Istio traffic. Rules sum away scrape-level labels while preserving the workload/service labels Kiali uses in queries:
+Add recording rules like the following to the Prometheus instance that scrapes Istio traffic. The rules aggregate on scrape-level labels while preserving the workload/service labels Kiali uses in queries:
 
 ```yaml
 groups:

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -161,7 +161,7 @@ If you use Istio [Perses (or Grafana) dashboards]({{< relref "./perses" >}}) wit
 
 #### Metric tiers
 
-Federation configuration is split so operators only pull what they need:
+Federation configuration is split into tiers (metric groupings) so that the production Prometheus pulls only needed metrics:
 
 | Tier | Purpose | Required for |
 | ---- | ------- | ------------ |

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -151,7 +151,7 @@ spec:
       url: "http://prometheus-prod.monitoring:9090/"
 ```
 
-If you use [Kiali Perses dashboards]({{< relref "./perses" >}}), point Perses at the same production Prometheus URL.
+If you use Istio [Perses (or Grafana) dashboards]({{< relref "./perses" >}}) with Kiali , configure them to point at the same production Prometheus URL.
 
 {{% alert color="warning" %}}
 **Production assumption:** In this pattern, `external_services.prometheus.url` **always** targets production Prometheus—the long-retention TSDB that holds federated mesh metrics. Kiali must **not** query the edge Istio scraper in production. The edge exists only to collect raw telemetry, evaluate recording rules, and federate upstream; it is not Kiali's database.

--- a/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
+++ b/content/en/docs/Configuration/p8s-jaeger-grafana/prometheus.md
@@ -292,7 +292,7 @@ See [`hack/istio/metric-rules/README.md`](https://github.com/kiali/kiali/blob/ma
 1. Identify edge Prometheus—the TSDB that scrapes Istio/Envoy (may be in a `monitoring` namespace, a remote cluster, or a managed service—not necessarily `istio-system`).
 2. Install recording rules on the edge; set short retention on raw mesh telemetry.
 3. Add a federation scrape job to your production Prometheus using the core-tier `match[]` list.
-4. Optionally extend `match[]` with **dashboard-tier** selectors if Perses Istio dashboards are enabled.
+4. Optionally extend `match[]` with Istio dashboard-tier selectors if Istio dashboards are enabled.
 5. If Kiali self-monitoring is enabled, choose an option from [Kiali self-monitoring metrics](#kiali-self-monitoring-metrics): apply `kiali-recording-rules.yml` on the Kiali edge and federate `federation-match-kiali.yml` to production (Options 1–2), or scrape Kiali directly into production (Option 3).
 6. Point **`external_services.prometheus.url`** at production Prometheus (and Perses at the same URL).
 7. **Validate** equivalence between edge aggregates and federated data (see below).


### PR DESCRIPTION
Closes https://github.com/kiali/kiali/issues/6342
Depends-on: https://github.com/kiali/kiali/pull/10260

## Summary

- Adds a **[Recording Rules and Federation](https://deploy-preview-1008--kiali.netlify.app/docs/configuration/p8s-jaeger-grafana/prometheus/#option-1-recording-rules-and-federation-recommended)** section under [Prometheus Tuning](https://kiali.io/docs/configuration/p8s-jaeger-grafana/prometheus/#prometheus-tuning)
- Documents **production integration**: operators merge reference YAML from `hack/istio/metric-rules/` (`core-recording-rules.yml`, `core-federation-match.yml`, and optional dashboard/Kiali tiers) into their **existing** edge and production Prometheus configuration (`rule_files`, ConfigMap mounts, `PrometheusRule` CRs, Helm values, etc.)
- Separates **production reference files** (repo root under `metric-rules/`) from **`demo/`** scripts and sample deployments (lab/CI only—not for production clusters)
- Includes a production operator checklist and a demo walkthrough (`demo/install.sh`) to validate the pattern locally

Companion implementation/reference PR: kiali/kiali (`issue_6342`)

## Test plan

- [ ] Review doc structure and production vs demo guidance
- [ ] Verify Hugo links (Perses page, FAQ required metrics anchor, production-reference-files anchor)
- [ ] Preview on Netlify deploy

Made with [Cursor](https://cursor.com)