### PR TITLE
Fix build update endpoint

### DIFF
--- a/content/en/docs/Architecture/terminology/concepts.md
+++ b/content/en/docs/Architecture/terminology/concepts.md
@@ -18,7 +18,7 @@ For more information see the [Istio Envoy Documentation](https://istio.io/docs/o
 
 ### Envoy Health
 
-A health check performed by Envoy proxies, for inbound and outbound traffic: see membership_healthy and membership_total from [Envoy documentation](https://www.envoyproxy.io/docs/envoy/v1.7.1/configuration/cluster_manager/cluster_stats#general).
+A health check performed by Envoy proxies, for inbound and outbound traffic: see membership_healthy and membership_total from [Envoy documentation](https://www.envoyproxy.io/docs/envoy/v1.7.1/configuration/cluster_manager/cluster_stats.html#general).
 
 ### Istio object/configuration Type
 


### PR DESCRIPTION
Update link from 

https://www.envoyproxy.io/docs/envoy/v1.7.1/configuration/cluster_manager/cluster_stats#general 

to 

https://www.envoyproxy.io/docs/envoy/v1.7.1/configuration/cluster_manager/cluster_stats.html#general


```bash
For the Links > External check, the following failures were found:

* At ./public/docs/_print/index.html:31179:

  External link https://www.envoyproxy.io/docs/envoy/v1.7.1/configuration/cluster_manager/cluster_stats#general failed (status code 404)

* At ./public/docs/architecture/_print/index.html:340:

  External link https://www.envoyproxy.io/docs/envoy/v1.7.1/configuration/cluster_manager/cluster_stats#general failed (status code 404)

* At ./public/docs/architecture/terminology/_print/index.html:191:

  External link https://www.envoyproxy.io/docs/envoy/v1.7.1/configuration/cluster_manager/cluster_stats#general failed (status code 404)

* At ./public/docs/architecture/terminology/concepts/index.html:733:

  External link https://www.envoyproxy.io/docs/envoy/v1.7.1/configuration/cluster_manager/cluster_stats#general failed (status code 404)
```